### PR TITLE
_libc.py: add libc.dylib (osx dynamic library) to list passed to ffi.open()

### DIFF
--- a/_libc/_libc.py
+++ b/_libc/_libc.py
@@ -4,7 +4,7 @@ import sys
 
 _h = None
 
-names = ('libc.so', 'libc.so.0', 'libc.so.6')
+names = ('libc.so', 'libc.so.0', 'libc.so.6', 'libc.dylib')
 
 def get():
     global _h

--- a/re-pcre/re.py
+++ b/re-pcre/re.py
@@ -1,8 +1,19 @@
 import ffi
 import array
 
+# pcre = ffi.open("libpcre.so.3")
 
-pcre = ffi.open("libpcre.so.3")
+def ffi_open(names):
+    err = None
+    for n in names:
+        try:
+            mod = ffi.open(n)
+            return mod
+        except OSError as e:
+            err = e
+    raise err
+
+pcre = ffi_open(('libpcre.so.3', 'libpcre.dylib', 'libpcre.0.dylib'))
 
 #       pcre *pcre_compile(const char *pattern, int options,
 #            const char **errptr, int *erroffset,

--- a/sqlite3/sqlite3.py
+++ b/sqlite3/sqlite3.py
@@ -1,7 +1,18 @@
 import ffi
 
+# sq3 = ffi.open("libsqlite3.so.0")
 
-sq3 = ffi.open("libsqlite3.so.0")
+def ffi_open(names):
+    err = None
+    for n in names:
+        try:
+            mod = ffi.open(n)
+            return mod
+        except OSError as e:
+            err = e
+    raise err
+
+sq3 = ffi_open(('libsqlite3.so.0', 'libsqlite3.dylib', 'libsqlite3.0.dylib'))
 
 sqlite3_open = sq3.func("i", "sqlite3_open", "sp")
 #int sqlite3_close(sqlite3*);


### PR DESCRIPTION
I also grep'd through micropython-lib for other instances of ```ffi.open()``` and found 3 instances:
```
./_libc/_libc.py:            _h = ffi.open(n)
./re-pcre/re.py:pcre = ffi.open("libpcre.so.3")
./sqlite3/sqlite3.py:sq3 = ffi.open("libsqlite3.so.0")
```
My mac (OSX 10.7.5) has these libraries available in /usr/lib:
```
/usr/lib/libpcre.0.dylib
/usr/lib/libpcre.dylib
/usr/lib/libpcreposix.0.dylib
/usr/lib/libpcreposix.dylib
/usr/lib/libsqlite3.0.dylib
/usr/lib/libsqlite3.dylib
```
If you would like I could patch ```re.py``` and ```sqlite3.py``` so ffi can also open these libraries. Of course these files would also need a list iterating mechanism like that used in ```_libc.py``` or ```micropython/tests/unix/ffi_float.py```
I also don't know if I should include all of the *.dylib options or just one of each.