### PR TITLE
Add support of `len` to `collections.deque`

### DIFF
--- a/collections.deque/collections/deque.py
+++ b/collections.deque/collections/deque.py
@@ -23,3 +23,6 @@ class deque:
 
     def __len__(self):
         return len(self.q)
+
+    def __bool__(self):
+        return len(self) > 0


### PR DESCRIPTION
Currently `collections.deque` in micropython doesn't support `len`:

``` python
>>> from collections.deque import deque
>>> q = deque()
>>> len(q)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: object of type 'deque' has no len()
```

But cpython supports:

``` python
In [1]: from collections import deque
In [2]: q = deque()
In [3]: len(q)
Out[3]: 0
```

So I've added it to micropython `collections.deque`.
