### PR TITLE
unittest: Add `assertFalse` to `TestCase`

### DIFF
--- a/unittest/unittest.py
+++ b/unittest/unittest.py
@@ -35,6 +35,9 @@ class TestCase:
                 return
             raise
 
+    def assertFalse(self, x, msg=''):
+        assert not x, msg
+
 
 def skip(msg):
     def _decor(fun):


### PR DESCRIPTION
In cpython `TestCase` has an `assertFalse` method, so I think it should be here.
