### PR TITLE
ffilib: Initial version of wrapper for ffi module.

### DIFF
--- a/ffilib/ffilib.py
+++ b/ffilib/ffilib.py
@@ -1,3 +1,4 @@
+import sys
 import ffi
 
 _cache = {}
@@ -7,22 +8,18 @@ def open(name, maxver=10, extra=()):
         return _cache[name]
     except KeyError:
         pass
+    def libs():
+        if sys.platform == "linux":
+            yield '%s.so' % name
+            for i in range(maxver, -1, -1):
+                yield '%s.so.%u' % (name, i)
+        else:
+            for ext in ('dylib', 'dll'):
+                yield '%s.%s' % (name, ext)
+        for n in extra:
+            yield n
     err = None
-    for n in ("%s.so" % name, "%s.dylib" % name):
-        try:
-            l = ffi.open(n)
-            _cache[name] = l
-            return l
-        except OSError as e:
-            err = e
-    for i in range(maxver):
-        try:
-            l = ffi.open("%s.so.%u" % (name, i))
-            _cache[name] = l
-            return l
-        except OSError as e:
-            err = e
-    for n in extra:
+    for n in libs():
         try:
             l = ffi.open(n)
             _cache[name] = l

--- a/ffilib/ffilib.py
+++ b/ffilib/ffilib.py
@@ -1,0 +1,32 @@
+import ffi
+
+_cache = {}
+
+def open(name, maxver=10, extra=()):
+    try:
+        return _cache[name]
+    except KeyError:
+        pass
+    err = None
+    for n in ("%s.so" % name, "%s.dylib" % name):
+        try:
+            l = ffi.open(n)
+            _cache[name] = l
+            return l
+        except OSError as e:
+            err = e
+    for i in range(maxver):
+        try:
+            l = ffi.open("%s.so.%u" % (name, i))
+            _cache[name] = l
+            return l
+        except OSError as e:
+            err = e
+    for n in extra:
+        try:
+            l = ffi.open(n)
+            _cache[name] = l
+            return l
+        except OSError as e:
+            err = e
+    raise err

--- a/ffilib/metadata.txt
+++ b/ffilib/metadata.txt
@@ -1,0 +1,7 @@
+dist_name = ffilib
+srctype = micropython-lib
+type = module
+version = 0.1.0
+author = Damien George
+desc = MicroPython FFI helper module
+long_desc = MicroPython FFI helper module to easily interface with underlying shared libraries

--- a/ffilib/setup.py
+++ b/ffilib/setup.py
@@ -1,0 +1,18 @@
+import sys
+# Remove current dir from sys.path, otherwise setuptools will peek up our
+# module instead of system.
+sys.path.pop(0)
+from setuptools import setup
+
+
+setup(name='micropython-libc',
+      version='0.1.0',
+      description='MicroPython FFI helper module',
+      long_description='MicroPython FFI helper module to easily interface with underlying shared libraries',
+      url='https://github.com/micropython/micropython/issues/405',
+      author='Damien George',
+      author_email='micro-python@googlegroups.com',
+      maintainer='MicroPython Developers',
+      maintainer_email='micro-python@googlegroups.com',
+      license='MIT',
+      py_modules=['ffilib'])

--- a/ffilib/setup.py
+++ b/ffilib/setup.py
@@ -5,7 +5,7 @@ sys.path.pop(0)
 from setuptools import setup
 
 
-setup(name='micropython-libc',
+setup(name='micropython-ffilib',
       version='0.1.0',
       description='MicroPython FFI helper module',
       long_description='MicroPython FFI helper module to easily interface with underlying shared libraries',


### PR DESCRIPTION
This library allows to search for an module to load with ffi.  See issue #25 for background.

There is a bit of code duplication here but I couldn't find a way to reduce it.

I think I'd rather just allow a list of libs to be passed in and searched.  It's much simpler.