### PR TITLE
logging: log to sys.stderr instead of sys.stdout

### DIFF
--- a/logging/logging.py
+++ b/logging/logging.py
@@ -4,6 +4,8 @@
 # Basic, useful module, by CPython impl depends on module "string" which
 # uses metaclasses.
 
+import sys
+
 CRITICAL = 50
 ERROR    = 40
 WARNING  = 30
@@ -32,7 +34,7 @@ class Logger:
 
     def log(self, level, msg, *args):
         if level >= (self.level or _level):
-            print(("%s:%s:" + msg) % ((self._level_str(level), self.name) + args))
+            print(("%s:%s:" + msg) % ((self._level_str(level), self.name) + args), file=sys.stderr)
 
     def debug(self, msg, *args):
         self.log(DEBUG, msg, *args)


### PR DESCRIPTION
I am not sure if this will fly and how it affects non-unix ports but if we have to pick logging to stdout or stderr I would pick stderr.