### PR TITLE
fix typo in inspect.isclass()

### DIFF
--- a/inspect/inspect.py
+++ b/inspect/inspect.py
@@ -27,7 +27,7 @@ def ismethod(obj):
     return isinstance(obj, type(_Instance.meth))
 
 def isclass(obj):
-    return isinstance(object, type)
+    return isinstance(obj, type)
 
 def ismodule(obj):
     return isinstance(obj, type(sys))


### PR DESCRIPTION
Corrects argument passing to the <code>isinstance</code> test.
Should this include a bump of <code>version</code> in the associated<code>metadata.txt</code>?