### PR TITLE
unittest: make unittest.main() work

### DIFF
--- a/unittest/metadata.txt
+++ b/unittest/metadata.txt
@@ -1,4 +1,4 @@
 srctype = micropython-lib
 type = module
-version = 0.0.7
+version = 0.0.8
 author = Paul Sokolovsky

--- a/unittest/setup.py
+++ b/unittest/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-unittest',
-      version='0.0.7',
+      version='0.0.8',
       description='unittest module for MicroPython',
       long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
       url='https://github.com/micropython/micropython/issues/405',

--- a/unittest/test_unittest.py
+++ b/unittest/test_unittest.py
@@ -1,0 +1,20 @@
+import unittest
+
+class TestStringMethods(unittest.TestCase):
+
+  def test_upper(self):
+      self.assertEqual('foo'.upper(), 'FOO')
+
+  def test_isupper(self):
+      self.assertTrue('FOO'.isupper())
+      self.assertFalse('Foo'.isupper())
+
+  def test_split(self):
+      s = 'hello world'
+      self.assertEqual(s.split(), ['hello', 'world'])
+      # check that s.split fails when the separator is not a string
+      with self.assertRaises(TypeError):
+          s.split(2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unittest/test_unittest.py
+++ b/unittest/test_unittest.py
@@ -1,20 +1,64 @@
 import unittest
 
-class TestStringMethods(unittest.TestCase):
+class TestUnittestAssertions(unittest.TestCase):
 
-  def test_upper(self):
-      self.assertEqual('foo'.upper(), 'FOO')
+    def testFail(self):
+        with self.assertRaises(AssertionError):
+            self.fail('failure')
 
-  def test_isupper(self):
-      self.assertTrue('FOO'.isupper())
-      self.assertFalse('Foo'.isupper())
+    def testEqual(self):
+        self.assertEqual(0,0)
+        self.assertEqual([0,1,2], [0,1,2])
+        with self.assertRaises(AssertionError):
+            self.assertEqual(0,None)
+        with self.assertRaises(AssertionError):
+            self.assertEqual([0,1,2], [1,2,3])
 
-  def test_split(self):
-      s = 'hello world'
-      self.assertEqual(s.split(), ['hello', 'world'])
-      # check that s.split fails when the separator is not a string
-      with self.assertRaises(TypeError):
-          s.split(2)
+    def testNotEqual(self):
+        self.assertNotEqual([0,1,2], [0,2,1])
+        with self.assertRaises(AssertionError):
+            self.assertNotEqual(0,0)
+        with self.assertRaises(AssertionError):
+            self.assertNotEqual([0,1,2], [0,1,2])
+
+    def testIs(self):
+        self.assertIs(None, None)
+        with self.assertRaises(AssertionError):
+            self.assertIs([1,2,3], [1,2,3])
+
+    def testIsNot(self):
+        self.assertIsNot([1,2,3], [1,2,3])
+        with self.assertRaises(AssertionError):
+            self.assertIsNot(None, None)
+
+    def testTrue(self):
+        self.assertTrue(True)
+        with self.assertRaises(AssertionError):
+            self.assertTrue(False)
+
+    def testFalse(self):
+        self.assertFalse(False)
+        with self.assertRaises(AssertionError):
+            self.assertFalse(True)
+
+    def testIn(self):
+        self.assertIn('t', 'cat')
+        with self.assertRaises(AssertionError):
+            self.assertIn('x', 'cat')
+
+    def testIsInstance(self):
+        self.assertIsInstance('cat', str)
+        with self.assertRaises(AssertionError):
+            self.assertIsInstance(7, str)
+
+    def testRaises(self):
+        with self.assertRaises(ZeroDivisionError):
+            1/0
+            pass
+
+    @unittest.skip('test of skipping')
+    def testSkip(self):
+        self.assertFail('this should be skipped')
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/unittest.py
+++ b/unittest/unittest.py
@@ -12,7 +12,7 @@ class AssertRaisesContext:
 
     def __exit__(self, exc_type, exc_value, tb):
         if exc_type is None:
-            assert False, "%r not raised" % exc
+            assert False, "%r not raised" % self.expected
         if issubclass(exc_type, self.expected):
             return True
         return False
@@ -28,15 +28,34 @@ class TestCase:
             msg = "%r vs (expected) %r" % (x, y)
         assert x == y, msg
 
+    def assertNotEqual(self, x, y, msg=''):
+        if not msg:
+            msg = "%r not expected to be equal %r" % (x, y)
+        assert x != y, msg
+
     def assertIs(self, x, y, msg=''):
         if not msg:
             msg = "%r is not %r" % (x, y)
         assert x is y, msg
 
+    def assertIsNot(self, x, y, msg=''):
+        if not msg:
+            msg = "%r is %r" % (x, y)
+        assert x is not y, msg
+
     def assertTrue(self, x, msg=''):
+        if not msg:
+            msg = "Expected %r to be True" % x
         assert x, msg
 
+    def assertFalse(self, x, msg=''):
+        if not msg:
+            msg = "Expected %r to be False" % x
+        assert not x, msg
+
     def assertIn(self, x, y, msg=''):
+        if not msg:
+            msg = "Expected %r to be in %r" % (x, y)
         assert x in y, msg
 
     def assertIsInstance(self, x, y, msg=''):
@@ -53,9 +72,6 @@ class TestCase:
             if isinstance(e, exc):
                 return
             raise
-
-    def assertFalse(self, x, msg=''):
-        assert not x, msg
 
 
 def skip(msg):

--- a/unittest/unittest.py
+++ b/unittest/unittest.py
@@ -116,8 +116,19 @@ def run_class(c, test_result):
 
 
 def main(module="__main__"):
+    def test_cases(m):
+        for tn in dir(m):
+            c = getattr(m, tn)
+            if isinstance(c, object) and isinstance(c, type) and issubclass(c, TestCase):
+                yield c
+
     m = __import__(module)
-    for tn in dir(m):
-        c = getattr(m, tn)
-        if isinstance(c, object) and issubclass(c, TestCase):
-            run_class(c)
+    suite = TestSuite()
+    for c in test_cases(m):
+        suite.addTest(c)
+    runner = TestRunner()
+    result = runner.run(suite)
+    msg = "Ran %d tests" % result.testsRun
+    if result.skippedNum > 0:
+        msg += " (%d skipped)" % result.skippedNum
+    print(msg)


### PR DESCRIPTION
Enables standalone test scripts to use the [common idiom](https://docs.python.org/3.4/library/unittest.html#basic-example) in unit test scripts:
```python
if __name__ == '__main__':
    unittest.main()
```
