### PR TITLE
Draft implementation of xmltok module

### DIFF
--- a/xmltok/test.xml
+++ b/xmltok/test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<s:Envelope
+  xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
+  s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body>
+<u:GetConnectionTypeInfo
+  xmlns:u="urn:schemas-upnp-org:service:WANIPConnection:1">
+  foo bar
+  baz
+  
+</u:GetConnectionTypeInfo>
+</s:Body>
+</s:Envelope>

--- a/xmltok/test_xmltok.py
+++ b/xmltok/test_xmltok.py
@@ -1,0 +1,21 @@
+import xmltok
+
+expected = [
+('PI', 'xml'),
+('ATTR', ('', 'version'), '1.0'),
+('START_TAG', ('s', 'Envelope')),
+('ATTR', ('xmlns', 's'), 'http://schemas.xmlsoap.org/soap/envelope/'),
+('ATTR', ('s', 'encodingStyle'), 'http://schemas.xmlsoap.org/soap/encoding/'),
+('START_TAG', ('s', 'Body')),
+('START_TAG', ('u', 'GetConnectionTypeInfo')),
+('ATTR', ('xmlns', 'u'), 'urn:schemas-upnp-org:service:WANIPConnection:1'),
+('TEXT', 'foo bar\n  baz\n  \n'),
+('END_TAG', ('u', 'GetConnectionTypeInfo')),
+('END_TAG', ('s', 'Body')),
+('END_TAG', ('s', 'Envelope')),
+]
+
+ex = iter(expected)
+for i in xmltok.tokenize(open("test.xml")):
+    #print(i)
+    assert i == next(ex)

--- a/xmltok/xmltok.py
+++ b/xmltok/xmltok.py
@@ -2,12 +2,12 @@ import string
 
 TEXT = "TEXT"
 START_TAG = "START_TAG"
-START_TAG_DONE = "START_TAG_DONE"
+#START_TAG_DONE = "START_TAG_DONE"
 END_TAG = "END_TAG"
 PI = "PI"
-PI_DONE = "PI_DONE"
+#PI_DONE = "PI_DONE"
 ATTR = "ATTR"
-ATTR_VAL = "ATTR_VAL"
+#ATTR_VAL = "ATTR_VAL"
 
 class XMLSyntaxError(Exception):
     pass

--- a/xmltok/xmltok.py
+++ b/xmltok/xmltok.py
@@ -1,5 +1,3 @@
-import string
-
 TEXT = "TEXT"
 START_TAG = "START_TAG"
 #START_TAG_DONE = "START_TAG_DONE"
@@ -46,7 +44,10 @@ class XMLTokenizer:
     def getident(self):
         self.skip_ws()
         ident = ""
-        while self.curch() in (string.ascii_letters + string.digits):
+        while True:
+            c = self.curch()
+            if not(c.isalpha() or c.isdigit() or c in "_-."):
+                break
             ident += self.getch()
         return ident
 

--- a/xmltok/xmltok.py
+++ b/xmltok/xmltok.py
@@ -50,6 +50,15 @@ class XMLTokenizer:
             ident += self.getch()
         return ident
 
+    def getnsident(self):
+        ns = ""
+        ident = self.getident()
+        if self.curch() == ":":
+            self.nextch()
+            ns = ident
+            ident = self.getident()
+        return (ns, ident)
+
     def match(self, c):
         self.skip_ws()
         if self.curch() == c:
@@ -63,7 +72,7 @@ class XMLTokenizer:
 
     def lex_attrs_till(self):
         while self.isident():
-            attr = self.getident()
+            attr = self.getnsident()
             yield (ATTR, attr)
             self.expect("=")
             self.expect('"')
@@ -77,7 +86,7 @@ class XMLTokenizer:
         while not self.eof():
             if self.match("<"):
                 if self.match("/"):
-                    yield (END_TAG, self.getident())
+                    yield (END_TAG, self.getnsident())
                     self.expect(">")
                 elif self.match("?"):
                     yield (PI, self.getident())
@@ -85,7 +94,7 @@ class XMLTokenizer:
                     self.expect("?")
                     self.expect(">")
                 else:
-                    tag = self.getident()
+                    tag = self.getnsident()
                     yield (START_TAG, tag)
                     yield from self.lex_attrs_till()
                     if self.match("/"):

--- a/xmltok/xmltok.py
+++ b/xmltok/xmltok.py
@@ -73,14 +73,15 @@ class XMLTokenizer:
     def lex_attrs_till(self):
         while self.isident():
             attr = self.getnsident()
-            yield (ATTR, attr)
+            #yield (ATTR, attr)
             self.expect("=")
             self.expect('"')
             val = ""
             while self.curch() != '"':
                 val += self.getch()
-            yield (ATTR_VAL, val)
+            #yield (ATTR_VAL, val)
             self.expect('"')
+            yield (ATTR, attr, val)
 
     def tokenize(self):
         while not self.eof():

--- a/xmltok/xmltok.py
+++ b/xmltok/xmltok.py
@@ -115,7 +115,15 @@ def gfind(gen, pred):
 
 def text_of(gen, tag):
     # Return text content of a leaf tag
-    gfind(gen, lambda i: i == (START_TAG, tag))
+    def match_tag(t):
+        if t[0] != START_TAG:
+            return False
+        if isinstance(tag, ()):
+            return t[1] == tag
+        return t[1][1] == tag
+
+    gfind(gen, match_tag)
+    # Assumes no attributes
     t, val = next(gen)
     assert t == TEXT
     return val

--- a/xmltok/xmltok.py
+++ b/xmltok/xmltok.py
@@ -1,0 +1,115 @@
+import string
+
+TEXT = "TEXT"
+START_TAG = "START_TAG"
+START_TAG_DONE = "START_TAG_DONE"
+END_TAG = "END_TAG"
+PI = "PI"
+PI_DONE = "PI_DONE"
+ATTR = "ATTR"
+ATTR_VAL = "ATTR_VAL"
+
+class XMLSyntaxError(Exception):
+    pass
+
+class XMLTokenizer:
+
+    def __init__(self, f):
+        self.f = f
+        self.nextch()
+
+    def curch(self):
+        return self.c
+
+    def getch(self):
+        c = self.c
+        self.nextch()
+        return c
+
+    def eof(self):
+        return self.c == ""
+
+    def nextch(self):
+        self.c = self.f.read(1)
+        if not self.c:
+            raise StopIteration
+        return self.c
+
+    def skip_ws(self):
+        while self.curch().isspace():
+            self.nextch()
+
+    def isident(self):
+        self.skip_ws()
+        return self.curch().isalpha()
+
+    def getident(self):
+        self.skip_ws()
+        ident = ""
+        while self.curch() in (string.ascii_letters + string.digits):
+            ident += self.getch()
+        return ident
+
+    def match(self, c):
+        self.skip_ws()
+        if self.curch() == c:
+            self.nextch()
+            return True
+        return False
+
+    def expect(self, c):
+        if not self.match(c):
+            raise XMLSyntaxError
+
+    def lex_attrs_till(self):
+        while self.isident():
+            attr = self.getident()
+            yield (ATTR, attr)
+            self.expect("=")
+            self.expect('"')
+            val = ""
+            while self.curch() != '"':
+                val += self.getch()
+            yield (ATTR_VAL, val)
+            self.expect('"')
+
+    def tokenize(self):
+        while not self.eof():
+            if self.match("<"):
+                if self.match("/"):
+                    yield (END_TAG, self.getident())
+                    self.expect(">")
+                elif self.match("?"):
+                    yield (PI, self.getident())
+                    yield from self.lex_attrs_till()
+                    self.expect("?")
+                    self.expect(">")
+                else:
+                    tag = self.getident()
+                    yield (START_TAG, tag)
+                    yield from self.lex_attrs_till()
+                    if self.match("/"):
+                        yield (END_TAG, tag)
+                    self.expect(">")
+            else:
+                text = ""
+                while self.curch() != "<":
+                    text += self.getch()
+                if text:
+                    yield (TEXT, text)
+
+
+def gfind(gen, pred):
+    for i in gen:
+        if pred(i):
+            return i
+
+def text_of(gen, tag):
+    # Return text content of a leaf tag
+    gfind(gen, lambda i: i == (START_TAG, tag))
+    t, val = next(gen)
+    assert t == TEXT
+    return val
+
+def tokenize(file):
+    return XMLTokenizer(file).tokenize()


### PR DESCRIPTION
Per https://github.com/micropython/micropython-lib/issues/37 .

One thing to decide whether attribute lists should be explicitly terminated or not. As you can see, I initially wanted to have terminators, and tokens for them were added, but skipped implementing them. With terminators, parsing will be slightly easier, but of course there's more garbage to collect. The reason I didn't implement them is because I thought that for many useful algos (see e.g. gfind() helper), you'd need to consume "next" token anyway. Then token stream would be represented by pair of (head, tail), where head is a token (or maybe None) and tail is generator.

That's all speculative though - I played with parsing UPNP responses a bit, but switched away from it.
