### PR TITLE
argparse: reproduce CPython's behaviour more closely

### DIFF
--- a/argparse/argparse.py
+++ b/argparse/argparse.py
@@ -126,7 +126,8 @@ class ArgumentParser:
 
         # print full information
         print()
-        print(self.description)
+        if self.description:
+            print(self.description)
         if self.pos:
             print("\npositional args:")
             for pos in self.pos:

--- a/argparse/argparse.py
+++ b/argparse/argparse.py
@@ -98,6 +98,8 @@ class ArgumentParser:
             dest = kwargs.get("dest")
             if dest is None:
                 dest = args[0]
+            if not args:
+                args = [dest]
         list.append(
             _Arg(args, dest, action, kwargs.get("nargs", None),
                 const, default, kwargs.get("help", "")))

--- a/argparse/test_argparse.py
+++ b/argparse/test_argparse.py
@@ -3,7 +3,7 @@ import argparse
 parser = argparse.ArgumentParser(description="command line program")
 parser.add_argument("a")
 parser.add_argument("b")
-parser.add_argument("c")
+parser.add_argument(dest="c")
 args = parser.parse_args(["1", "2", "3"])
 assert args.a == "1" and args.b == "2" and args.c == "3"
 

--- a/argparse/test_argparse.py
+++ b/argparse/test_argparse.py
@@ -18,6 +18,19 @@ args = parser.parse_args(["-b", "456"])
 assert args.a == False and args.b == "456"
 
 parser = argparse.ArgumentParser()
+parser.add_argument("-a", "--a-opt", action="store_true")
+parser.add_argument("-b", "--b-opt", default=123)
+parser.add_argument("--c-opt", default="test")
+args = parser.parse_args([])
+assert args.a_opt == False and args.b_opt == 123 and args.c_opt == "test"
+args = parser.parse_args(["--a-opt"])
+assert args.a_opt == True and args.b_opt == 123 and args.c_opt == "test"
+args = parser.parse_args(["--b-opt", "456"])
+assert args.a_opt == False and args.b_opt == "456" and args.c_opt == "test"
+args = parser.parse_args(["--c-opt", "override"])
+assert args.a_opt == False and args.b_opt == 123 and args.c_opt == "override"
+
+parser = argparse.ArgumentParser()
 parser.add_argument("files", nargs="+")
 args = parser.parse_args(["a"])
 assert args.files == ["a"]


### PR DESCRIPTION
Make argparse compile with CPython.
Make test work with CPython.
Make description a kwarg for ArgumentParser().
Make add_argument() accept multiple option names (i.e. long and short options).