### PR TITLE
OSX seems to return errno.EISDIR when mkdir() on an existing directory

### DIFF
--- a/upip/metadata.txt
+++ b/upip/metadata.txt
@@ -1,6 +1,6 @@
 srctype = micropython-lib
 type = module
-version = 0.6.1
+version = 0.6.2
 author = Paul Sokolovsky
 extra_modules = upip_errno, upip_gzip, upip_utarfile
 desc = Simple package manager for MicroPython.

--- a/upip/setup.py
+++ b/upip/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-upip',
-      version='0.6.1',
+      version='0.6.2',
       description='Simple package manager for MicroPython.',
       long_description='Simple package manager for MicroPython, targetting to be self-hosted (but not yet there). Compatible only with packages without custom setup.py code.',
       url='https://github.com/micropython/micropython/issues/405',

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -47,6 +47,7 @@ def op_split(path):
 def op_basename(path):
     return op_split(path)[1]
 
+
 def _makedirs(name, mode=0o777):
     ret = False
     s = ""
@@ -56,7 +57,7 @@ def _makedirs(name, mode=0o777):
             os.mkdir(s)
             ret = True
         except OSError as e:
-            if e.args[0] != errno.EEXIST:
+            if e.args[0] != errno.EEXIST and e.args[0] != errno.EISDIR:
                 raise
             ret = False
     return ret


### PR DESCRIPTION
Fixes issue #1624 in micropython project