### PR TITLE
urllib.parse : parse.py requires collections.defaultdict class. 

### DIFF
--- a/urllib.parse/metadata.txt
+++ b/urllib.parse/metadata.txt
@@ -1,4 +1,4 @@
 srctype = cpython
 type = package
-version = 0.5
-depends = re-pcre, collections
+version = 0.5.1
+depends = re-pcre, collections, collections.defaultdict

--- a/urllib.parse/setup.py
+++ b/urllib.parse/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-urllib.parse',
-      version='0.5',
+      version='0.5.1',
       description='CPython urllib.parse module ported to MicroPython',
       long_description='This is a module ported from CPython standard library to be compatible with\nMicroPython interpreter. Usually, this means applying small patches for\nfeatures not supported (yet, or at all) in MicroPython. Sometimes, heavier\nchanges are required. Note that CPython modules are written with availability\nof vast resources in mind, and may not work for MicroPython ports with\nlimited heap. If you are affected by such a case, please help reimplement\nthe module from scratch.',
       url='https://github.com/micropython/micropython/issues/405',
@@ -16,4 +16,4 @@ setup(name='micropython-urllib.parse',
       maintainer_email='micro-python@googlegroups.com',
       license='Python',
       packages=['urllib'],
-      install_requires=['micropython-re-pcre', 'micropython-collections'])
+      install_requires=['micropython-re-pcre', 'micropython-collections', 'micropython-collections.defaultdict'])


### PR DESCRIPTION
The defaultdict class is available in the collections.defaultdict module, which was not listed in the dependencies.