### PR TITLE
__future__: Add dummies for all available feature descriptions

### DIFF
--- a/__future__/__future__.py
+++ b/__future__/__future__.py
@@ -1,1 +1,7 @@
+nested_scopes = True
+generators = True
+division = True
+absolute_import = True
+with_statement = True
 print_function = True
+unicode_literals = True

--- a/__future__/metadata.txt
+++ b/__future__/metadata.txt
@@ -1,4 +1,4 @@
 srctype=dummy
 type=module
-version=0.0.1
+version=0.0.2
 dist_name=future

--- a/__future__/setup.py
+++ b/__future__/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-future',
-      version='0.0.1',
+      version='0.0.2',
       description='Dummy __future__ module for MicroPython',
       long_description='This is a dummy implementation of a module for MicroPython standard library.\nIt contains zero or very little functionality, and primarily intended to\navoid import errors (using idea that even if an application imports a\nmodule, it may be not using it onevery code path, so may work at least\npartially). It is expected that more complete implementation of the module\nwill be provided later. Please help with the development if you are\ninterested in this module.',
       url='https://github.com/micropython/micropython/issues/405',


### PR DESCRIPTION
This will make statements such as
from __future__ import division
not fail.