### PR TITLE
os: Import os.path

### DIFF
--- a/os/metadata.txt
+++ b/os/metadata.txt
@@ -1,5 +1,5 @@
 srctype = micropython-lib
 type = package
-version = 0.3
+version = 0.4
 author = Paul Sokolovsky
-depends = ffilib, errno, stat
+depends = ffilib, errno, stat, os.path

--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -8,6 +8,7 @@ try:
     from _os import *
 except:
     pass
+import os.path as path
 
 
 libc = ffilib.libc()

--- a/os/setup.py
+++ b/os/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-os',
-      version='0.3',
+      version='0.4',
       description='os module for MicroPython',
       long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
       url='https://github.com/micropython/micropython/issues/405',
@@ -16,4 +16,4 @@ setup(name='micropython-os',
       maintainer_email='micro-python@googlegroups.com',
       license='MIT',
       packages=['os'],
-      install_requires=['micropython-ffilib', 'micropython-errno', 'micropython-stat'])
+      install_requires=['micropython-ffilib', 'micropython-errno', 'micropython-stat', 'micropython-os.path'])


### PR DESCRIPTION
On CPython os.path does not need to be imported explicitly.
This fixes the following issue:

```
>>> import os
>>> os.path.exists("")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  AttributeError: 'module' object has no attribute 'path'
````