### PR TITLE
socket: Add socket.error

### DIFF
--- a/socket/metadata.txt
+++ b/socket/metadata.txt
@@ -1,4 +1,4 @@
 srctype = micropython-lib
 type = module
-version = 0.3.2
+version = 0.3.3
 author = Paul Sokolovsky

--- a/socket/setup.py
+++ b/socket/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-socket',
-      version='0.3.2',
+      version='0.3.3',
       description='socket module for MicroPython',
       long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
       url='https://github.com/micropython/micropython/issues/405',

--- a/socket/socket.py
+++ b/socket/socket.py
@@ -7,6 +7,8 @@ IPPROTO_IP = 0
 IP_ADD_MEMBERSHIP = 35
 IP_DROP_MEMBERSHIP = 36
 
+error = OSError
+
 def _resolve_addr(addr):
     if isinstance(addr, (bytes, bytearray)):
         return addr


### PR DESCRIPTION
CPython raises socker.error (or classes derived from it) as exceptions on errors.
This change fixes code that tries to catch socket errors such as:

```
try:
  socket...
except socker.error as e:
  ...
```

usocket uses OSError. So we assign that to socket.error