### PR TITLE
os.path: Add sep

### DIFF
--- a/os.path/metadata.txt
+++ b/os.path/metadata.txt
@@ -1,4 +1,4 @@
 srctype = micropython-lib
 type = package
-version = 0.1.1
+version = 0.1.2
 author = Paul Sokolovsky

--- a/os.path/os/path.py
+++ b/os.path/os/path.py
@@ -1,6 +1,8 @@
 import os
 
 
+sep = "/"
+
 def normcase(s):
     return s
 

--- a/os.path/setup.py
+++ b/os.path/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-os.path',
-      version='0.1.1',
+      version='0.1.2',
       description='os.path module for MicroPython',
       long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
       url='https://github.com/micropython/micropython/issues/405',


### PR DESCRIPTION
My application uses this to transform paths to an os-indepentent form and back (basically string.replace(os.path.sep, "/")).
We only support unix compatible '/'