### PR TITLE
email.utils: fix urllib.parse dependency

### DIFF
--- a/email.utils/setup.py
+++ b/email.utils/setup.py
@@ -16,4 +16,4 @@ setup(name='micropython-email.utils',
       maintainer_email='micro-python@googlegroups.com',
       license='Python',
       packages=['email'],
-      install_requires=['micropython-os', 'micropython-re-pcre', 'micropython-base64', 'micropython-random', 'micropython-datetime', 'micropython-urlib.parse', 'micropython-warnings', 'micropython-quopri', 'micropython-email.charset'])
+      install_requires=['micropython-os', 'micropython-re-pcre', 'micropython-base64', 'micropython-random', 'micropython-datetime', 'micropython-urllib.parse', 'micropython-warnings', 'micropython-quopri', 'micropython-email.charset'])


### PR DESCRIPTION
Fixes a typo in the `email.utils` dependencies. `setup.py` refers to `micropython-urlib.parse` instead of `micropython-urllib.parse` (notice the 2nd L). [Link to correct dependency.](https://pypi.python.org/pypi/micropython-urllib.parse)