### PR TITLE
Add sendto method to socket class

### DIFF
--- a/socket/socket.py
+++ b/socket/socket.py
@@ -53,3 +53,6 @@ class socket(_socket.socket):
 
     def sendall(self, *args):
         return self.send(*args)
+
+    def sendto(self, data, addr):
+        return super().sendto(data, _resolve_addr(addr))


### PR DESCRIPTION
Most UDP servers probably need `sendto` and automatically converting `addr` if needed like `bind` and `connect` do is convenient.