### PR TITLE
Fix os.walk

### DIFF
--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -143,12 +143,15 @@ def walk(top, topdown=True, onerror=None, followlinks=False):
     files = []
     dirs = []
     try:
-        for dirent in listdir(top):
-            if stat_.S_ISDIR(stat(top + sep + dirent)[0]):
-                if dirent != b"." and dirent != b"..":
-                    dirs.append(fsdecode(dirent))
+        for dirent in ilistdir(top):
+            mode = dirent[2] << 12
+            fname = fsdecode(dirent[0])
+            if fname in (".", ".."):
+                continue
+            if stat_.S_ISDIR(mode):
+                    dirs.append(fname)
             else:
-                files.append(fsdecode(dirent))
+                files.append(fname)
     except OSError as err:
         if onerror is not None:
             onerror(err)

--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -139,21 +139,25 @@ def listdir(path="."):
             res.append(fname)
     return res
 
-def walk(top, topdown=True):
+def walk(top, topdown=True, onerror=None, followlinks=False):
     files = []
     dirs = []
-    for dirent in ilistdir_ex(top):
-        mode = dirent[3] << 12
-        fname = dirent[4].split(b'\0', 1)[0]
-        if stat_.S_ISDIR(mode):
-            if fname != b"." and fname != b"..":
-                dirs.append(fsdecode(fname))
-        else:
-            files.append(fsdecode(fname))
+    try:
+        for dirent in listdir(top):
+            if stat_.S_ISDIR(stat(top + sep + dirent)[0]):
+                if dirent != b"." and dirent != b"..":
+                    dirs.append(fsdecode(dirent))
+            else:
+                files.append(fsdecode(dirent))
+    except OSError as err:
+        if onerror is not None:
+            onerror(err)
+        return
     if topdown:
         yield top, dirs, files
     for d in dirs:
-        yield from walk(top + "/" + d, topdown)
+        if not stat_.S_ISLNK(stat(top + sep + d)[0]) or followlinks:
+            yield from walk(top + sep + d, topdown, onerror, followlinks)
     if not topdown:
         yield top, dirs, files
 


### PR DESCRIPTION
I tried running walkdir (https://github.com/ncoghlan/walkdir) using micropython and noticed that os.walk is currently broken. I fixed the current function and added the ``followlinks`` and ``onerror`` arguments support. I didn't added tests for this yet. I will try to implement ``tempfile.mkdtemp`` on a different PR and then I will add the tests.