### PR TITLE
Makefile: Don't add _install_tmp to itself on make install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ install:
 	else \
 	    for d in $$(find -maxdepth 1 -type d ! -name ".*"); do \
 	        echo $$d; \
+	        [ "$$d" = "./_install_tmp" ] && continue; \
 	        (cd $$d; sh -c $(CMD)); \
 	    done \
 	fi

--- a/os/metadata.txt
+++ b/os/metadata.txt
@@ -1,5 +1,5 @@
 srctype = micropython-lib
 type = package
-version = 0.4.2
+version = 0.4.3
 author = Paul Sokolovsky
 depends = ffilib, errno, stat

--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -87,6 +87,7 @@ def rename(old, new):
 def unlink(name):
     e = unlink_(name)
     check_error(e)
+remove = unlink
 
 def rmdir(name):
     e = rmdir_(name)

--- a/os/setup.py
+++ b/os/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 
 setup(name='micropython-os',
-      version='0.4.2',
+      version='0.4.3',
       description='os module for MicroPython',
       long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
       url='https://github.com/micropython/micropython/issues/405',


### PR DESCRIPTION
When OpenWrt builder uses make install, some conditions cause make install to
include _install_tmp as a submodule and causes cp to error with
cp: _install_tmp/<file>.py is the same file as <full-path>/<file>.py