### PR TITLE
umqtt.simple: do not close the socket in ping()

### DIFF
--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -58,7 +58,6 @@ class MQTTClient:
 
     def ping(self):
         self.sock.write(b"\xc0\0")
-        self.sock.close()
 
     def publish(self, topic, msg, retain=False, qos=0):
         pkt = bytearray(b"\x30\0\0\0")


### PR DESCRIPTION
IMHO there is no need to close the socket in `ping()` and it  break the MQTT connection.