### PR TITLE
umqtt.simple: let subscribe() process meassages

### DIFF
--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -104,12 +104,15 @@ class MQTTClient:
         self.sock.write(pkt)
         self._send_str(topic)
         self.sock.write(qos.to_bytes(1))
-        resp = self.sock.read(5)
-        #print(resp)
-        assert resp[0] == 0x90
-        assert resp[2] == pkt[2] and resp[3] == pkt[3]
-        if resp[4] == 0x80:
-            raise MQTTException(resp[4])
+        while 1:
+            op = self.wait_msg()
+            if op == 0x90:
+                resp = self.sock.read(4)
+                #print(resp)
+                assert resp[1] == pkt[2] and resp[2] == pkt[3]
+                if resp[3] == 0x80:
+                    raise MQTTException(resp[3])
+                return
 
     # Wait for a single incoming MQTT message and process it.
     # Subscribed messages are delivered to a callback previously


### PR DESCRIPTION
Utilising retained messages and multiple subscribes, a message could
arrive before the SUBACK packet.  Therefore, `wait_msg()` must be called
in `subscribe()`.

This propose should close #85 .