### PR TITLE
upip: Initialize socket with protocol family as gotten from resolver.…

### DIFF
--- a/upip/upip.py
+++ b/upip/upip.py
@@ -120,7 +120,7 @@ try:
         #print("Address infos:", ai)
         addr = ai[0][4]
 
-        s = usocket.socket()
+        s = usocket.socket(ai[0][0])
         #print("Connect address:", addr)
         s.connect(addr)
 


### PR DESCRIPTION
Fixes issue #2296 (tracked in micropython repo).