### PR TITLE
Remaining changes to support upip low-heap operation

### DIFF
--- a/make_metadata.py
+++ b/make_metadata.py
@@ -9,7 +9,7 @@ import glob
 TEMPLATE = """\
 import sys
 # Remove current dir from sys.path, otherwise setuptools will peek up our
-# module instead of system.
+# module instead of system's.
 sys.path.pop(0)
 from setuptools import setup
 sys.path.append("..")

--- a/make_metadata.py
+++ b/make_metadata.py
@@ -12,7 +12,8 @@ import sys
 # module instead of system.
 sys.path.pop(0)
 from setuptools import setup
-
+sys.path.append("..")
+import optimize_upip
 
 setup(name='micropython-%(dist_name)s',
       version='%(version)s',
@@ -24,6 +25,7 @@ setup(name='micropython-%(dist_name)s',
       maintainer=%(maintainer)r,
       maintainer_email='micro-python@googlegroups.com',
       license=%(license)r,
+      cmdclass={'optimize_upip': optimize_upip.OptimizeUpip},
       %(_what_)s=[%(modules)s]%(_inst_req_)s)
 """
 

--- a/optimize_upip.py
+++ b/optimize_upip.py
@@ -1,0 +1,106 @@
+#
+# This script optimizes a Python source distribution tarball as produced by
+# "python3 setup.py sdist" command for MicroPython's native package manager,
+# upip. Optimization includes:
+#  * Removing metadata files not used by upip (this includes setup.py)
+#  * Recompressing gzip archive with 4K dictionary size so it can be
+#    installed even on low-heap targets.
+#
+import sys
+import os
+import zlib
+from subprocess import Popen, PIPE
+import glob
+import tarfile
+import re
+import io
+
+
+def gzip_4k(inf, fname):
+    comp = zlib.compressobj(level=9, wbits=16 + 12)
+    with open(fname + ".out", "wb") as outf:
+        while 1:
+            data = inf.read(1024)
+            if not data:
+                break
+            outf.write(comp.compress(data))
+        outf.write(comp.flush())
+    os.rename(fname, fname + ".org")
+    os.rename(fname + ".out", fname)
+
+
+def recompress(fname):
+    with Popen(["gzip", "-d", "-c", fname], stdout=PIPE).stdout as inf:
+        gzip_4k(inf, fname)
+
+def find_latest(dir):
+    res = []
+    for fname in glob.glob(dir + "/*.gz"):
+        st = os.stat(fname)
+        res.append((st.st_mtime, fname))
+    res.sort()
+    latest = res[-1][1]
+    return latest
+
+
+def recompress_latest(dir):
+    latest = find_latest(dir)
+    print(latest)
+    recompress(latest)
+
+
+EXCLUDE = [r".+/setup.py"]
+INCLUDE = [r".+\.py", r".+\.egg-info/(PKG-INFO|requires\.txt)"]
+
+
+outbuf = io.BytesIO()
+
+def filter_tar(name):
+    fin = tarfile.open(name, "r:gz")
+    fout = tarfile.open(fileobj=outbuf, mode="w")
+    for info in fin:
+#        print(info)
+        include = None
+        for p in EXCLUDE:
+            if re.match(p, info.name):
+                include = False
+                break
+        if include is None:
+            for p in INCLUDE:
+                if re.match(p, info.name):
+                    include = True
+                    print("Including:", info.name)
+        if not include:
+            continue
+        farch = fin.extractfile(info)
+        fout.addfile(info, farch)
+    fout.close()
+    fin.close()
+
+
+
+from setuptools import Command
+
+class OptimizeUpip(Command):
+
+    user_options = []
+
+    def run(self):
+        latest = find_latest("dist")
+        filter_tar(latest)
+        outbuf.seek(0)
+        gzip_4k(outbuf, latest)
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+
+# For testing only
+if __name__ == "__main__":
+#    recompress_latest(sys.argv[1])
+    filter_tar(sys.argv[1])
+    outbuf.seek(0)
+    gzip_4k(outbuf, sys.argv[1])

--- a/pystone_lowmem/metadata.txt
+++ b/pystone_lowmem/metadata.txt
@@ -1,3 +1,3 @@
 srctype = cpython
 type = module
-version = 3.4.2-2
+version = 3.4.2-3

--- a/pystone_lowmem/setup.py
+++ b/pystone_lowmem/setup.py
@@ -1,12 +1,13 @@
 import sys
 # Remove current dir from sys.path, otherwise setuptools will peek up our
-# module instead of system.
+# module instead of system's.
 sys.path.pop(0)
 from setuptools import setup
-
+sys.path.append("..")
+import optimize_upip
 
 setup(name='micropython-pystone_lowmem',
-      version='3.4.2-2',
+      version='3.4.2-3',
       description='CPython pystone_lowmem module ported to MicroPython',
       long_description='This is a module ported from CPython standard library to be compatible with\nMicroPython interpreter. Usually, this means applying small patches for\nfeatures not supported (yet, or at all) in MicroPython. Sometimes, heavier\nchanges are required. Note that CPython modules are written with availability\nof vast resources in mind, and may not work for MicroPython ports with\nlimited heap. If you are affected by such a case, please help reimplement\nthe module from scratch.',
       url='https://github.com/micropython/micropython/issues/405',
@@ -15,4 +16,5 @@ setup(name='micropython-pystone_lowmem',
       maintainer='MicroPython Developers',
       maintainer_email='micro-python@googlegroups.com',
       license='Python',
+      cmdclass={'optimize_upip': optimize_upip.OptimizeUpip},
       py_modules=['pystone_lowmem'])

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -1,9 +1,11 @@
 import sys
+import gc
 import uos as os
 import uerrno as errno
 import ujson as json
 import uzlib
 import upip_utarfile as tarfile
+gc.collect()
 
 
 debug = False
@@ -148,6 +150,8 @@ def install_pkg(pkg_spec, install_path):
 
     latest_ver = data["info"]["version"]
     packages = data["releases"][latest_ver]
+    del data
+    gc.collect()
     assert len(packages) == 1
     package_url = packages[0]["url"]
     print("Installing %s %s from %s" % (pkg_spec, latest_ver, package_url))
@@ -157,6 +161,9 @@ def install_pkg(pkg_spec, install_path):
     f3 = tarfile.TarFile(fileobj=f2)
     meta = install_tar(f3, install_path)
     f1.close()
+    del f3
+    del f2
+    gc.collect()
     return meta
 
 def install(to_install, install_path=None):

--- a/upip/upip_utarfile.py
+++ b/upip/upip_utarfile.py
@@ -39,7 +39,13 @@ class FileSection:
         return sz
 
     def skip(self):
-        self.f.read(self.content_len + self.align)
+        sz = self.content_len + self.align
+        if sz:
+            buf = bytearray(16)
+            while sz:
+                s = min(sz, 16)
+                self.f.readinto(buf, s)
+                sz -= s
 
 class TarInfo:
 


### PR DESCRIPTION


These are remaining changes to make upip be runnable on esp8266. @dpgeorge, if you have any comments, please share them, otherwise I plan to merge this soon and proceed with re-uploading 4K-optimized packages to PyPI. Note that micropython-pystone_lowmem already uploaded in 4K version for testing.
