### PR TITLE
uasyncio.core.py: Only import logging for debug

### DIFF
--- a/uasyncio.core/uasyncio/core.py
+++ b/uasyncio.core/uasyncio/core.py
@@ -3,12 +3,12 @@ try:
 except ImportError:
     import time
 import utimeq
-import logging
-
 
 DEBUG = 0
 
-log = logging.getLogger("asyncio")
+if __debug__ and DEBUG:
+    import logging
+    log = logging.getLogger("asyncio")
 
 type_gen = type((lambda: (yield))())
 


### PR DESCRIPTION
As long as DEBUG is set to False, there is no need to import logging. Logging itself requires to be installed, thus it is an unneccary dependency for the normal user case.