### PR TITLE
os: avoid str/bytes comparison warnings for "listdir"

### DIFF
--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -134,7 +134,8 @@ def listdir(path="."):
     res = []
     for dirent in ilistdir(path):
         fname = dirent[0]
-        if fname not in (b".", b"..", ".", ".."):
+        # fname can be str or bytes - try to avoid expensive decoding
+        if len(fname) > 2 or (fsencode(fname) not in (b".", b"..")):
             if is_str:
                 fname = fsdecode(fname)
             res.append(fname)

--- a/os/test_dirs.py
+++ b/os/test_dirs.py
@@ -7,6 +7,10 @@ print(l)
 assert "test_dirs.py" in l
 assert "os" in l
 
+# return bytes if a bytes path is given
+l = os.listdir(b".")
+assert b"test_dirs.py" in l
+
 for t in os.walk("."):
     print(t)
 


### PR DESCRIPTION
Closes: #114

The "listdir" function caused the following warning for every single
directory item:
  Warning: Comparison between bytes and str