### PR TITLE
urequests: A Location-header with a 2XX status is not a redirect

### DIFF
--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -85,7 +85,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
         if l.startswith(b"Transfer-Encoding:"):
             if b"chunked" in l:
                 raise ValueError("Unsupported " + l)
-        elif l.startswith(b"Location:"):
+        elif l.startswith(b"Location:") and not 200 <= status <= 299:
             raise NotImplementedError("Redirects not yet supported")
 
     resp = Response(s)


### PR DESCRIPTION
When using the POST method you get the Location of the new
object in a Location header but it's not a redirect.
For details see for example RFC2616 10.2.2 and 10.2.3