### PR TITLE
umqtt.simple: Do the DNS resolution every time you connect

### DIFF
--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -13,7 +13,6 @@ class MQTTClient:
             port = 8883 if ssl else 1883
         self.client_id = client_id
         self.sock = None
-        self.addr = socket.getaddrinfo(server, port)[0][-1]
         self.ssl = ssl
         self.ssl_params = ssl_params
         self.pid = 0
@@ -53,7 +52,8 @@ class MQTTClient:
 
     def connect(self, clean_session=True):
         self.sock = socket.socket()
-        self.sock.connect(self.addr)
+        addr = socket.getaddrinfo(server, port)[0][-1]
+        self.sock.connect(addr)
         if self.ssl:
             import ussl
             self.sock = ussl.wrap_socket(self.sock, **self.ssl_params)


### PR DESCRIPTION
Do the DNS resolucion everytime you connect.

This is specially relevant for client "umqtt.robust" because you could not have network access when instantiate the object, so subsequent connections tries (after network is available) will fail because the "cached" address is wrong.

Resolving DNS in each connection is not a problem because reconnections should be sporadic and your DNS server (typically your local router) most probably cached the DNS reply anyway.