### PR TITLE
xmltok: support comment markup in xml

### DIFF
--- a/xmltok/test.xml
+++ b/xmltok/test.xml
@@ -9,5 +9,6 @@
   baz
   
 </u:GetConnectionTypeInfo>
+<!-- Comments, you won't see me after tokenize. -->
 </s:Body>
 </s:Envelope>

--- a/xmltok/xmltok.py
+++ b/xmltok/xmltok.py
@@ -95,6 +95,14 @@ class XMLTokenizer:
                     yield from self.lex_attrs_till()
                     self.expect("?")
                     self.expect(">")
+                elif self.match("!"):
+                    self.expect("-")
+                    self.expect("-")
+                    last3 = ''
+                    while True:
+                        last3 = last3[-2:] + self.getch()
+                        if last3 == "-->":
+                            break
                 else:
                     tag = self.getnsident()
                     yield (START_TAG, tag)


### PR DESCRIPTION
basic support for comment which begin with `<!--` and end with `-->`