### PR TITLE
umqtt.robust: Resubscribe to topics after doing reconnect.

### DIFF
--- a/umqtt.robust/umqtt/robust.py
+++ b/umqtt.robust/umqtt/robust.py
@@ -6,6 +6,10 @@ class MQTTClient(simple.MQTTClient):
     DELAY = 2
     DEBUG = False
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.subscriptions = []
+
     def delay(self, i):
         utime.sleep(self.DELAY)
 
@@ -20,7 +24,12 @@ class MQTTClient(simple.MQTTClient):
         i = 0
         while 1:
             try:
-                return super().connect(False)
+                ret = super().connect(False)
+                for topic, qos in self.subscriptions:
+                    if self.DEBUG:
+                        print("mqtt resubscribe: %r" % topic)
+                    super().subscribe(topic, qos)
+                return ret
             except OSError as e:
                 self.log(True, e)
                 i += 1
@@ -30,6 +39,16 @@ class MQTTClient(simple.MQTTClient):
         while 1:
             try:
                 return super().publish(topic, msg, retain, qos)
+            except OSError as e:
+                self.log(False, e)
+            self.reconnect()
+
+    def subscribe(self, topic, qos=0):
+        while 1:
+            try:
+                ret = super().subscribe(topic, qos)
+                self.subscriptions.append((topic, qos))
+                return ret
             except OSError as e:
                 self.log(False, e)
             self.reconnect()

--- a/umqtt.robust/umqtt/robust.py
+++ b/umqtt.robust/umqtt/robust.py
@@ -25,10 +25,11 @@ class MQTTClient(simple.MQTTClient):
         while 1:
             try:
                 ret = super().connect(False)
-                for topic, qos in self.subscriptions:
-                    if self.DEBUG:
-                        print("mqtt resubscribe: %r" % topic)
-                    super().subscribe(topic, qos)
+                if not ret:
+                    for topic, qos in self.subscriptions:
+                        if self.DEBUG:
+                            print("mqtt resubscribe: %r" % topic)
+                        super().subscribe(topic, qos)
                 return ret
             except OSError as e:
                 self.log(True, e)


### PR DESCRIPTION
To address #102: if the broker is restarted then when the client reconnects it needs to resubscribe to previously-subscribed topics in order for them to be delivered.

Other MQTT clients seem to have similar behaviour, including mosquitto_sub.

Tested with mosquitto, by subscribing from a couple of clients, killing and restarting the broker, then publishing to the original topic.