### PR TITLE
urequests: Added parsing response headers

### DIFF
--- a/urequests/example_xively.py
+++ b/urequests/example_xively.py
@@ -7,7 +7,6 @@ r = requests.get("http://api.xively.com/")
 print(r)
 print(r.content)
 print(r.text)
-print(r.content)
 print(r.json())
 
 # It's mandatory to close response objects as soon as you finished

--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -91,10 +91,10 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
         if l.startswith(b"Transfer-Encoding:"):
             if b"chunked" in l:
                 raise ValueError("Unsupported " + l)
-        elif l.startswith(b"Location:") and not 200 <= status <= 299:
+        elif l.startswith(b"Location:") and not 200 <= resp.status_code <= 299:
             raise NotImplementedError("Redirects not yet supported")
         else:
-            key, value = l.decode("utf-8").split(":",1)
+            key, value = l.decode("utf-8").split(":", 1)
             # RFC 2616 Section 4.2: Field names are case-insensitive.
             resp.response_headers[key.lower()] = value.rstrip()
 


### PR DESCRIPTION
Uses response header content-length to determine how many bytes to read when reading the body.

Tested on 3 servers (xively, aws, other) using unix and esp micropython.  urequest never finished when doing a GET from AWS before this change.

removed redundant print from example_xively.

