### PR TITLE
umqtt.robust: let reconnect() call the connect() method of the top class

### DIFF
--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -20,7 +20,7 @@ class MQTTClient(simple.MQTTClient):
         i = 0
         while 1:
             try:
-                return super().connect(False)
+                return self.connect(False)
             except OSError as e:
                 self.log(True, e)
                 i += 1


### PR DESCRIPTION
Not sure, why `reconnect()` call `connect()` of the base class (`super().connect(False)`).

Here are my reasons to change this:
- `umqtt.robust` did not implement a new `connect()` method
- `connect()` can now be easily overwritten by a subclass. Allow, e.g., the implementation of a `after_connect()` method as suggested in [#3186 (comment)](https://github.com/micropython/micropython-lib/pull/186#issuecomment-306708563):

```python
from umqtt import robust

class MQTTClient(robust.MQTTClient):
    def connect(self, clean_session=True):
        res = super().connect(clean_session)
        self.after_connect()
        return res

    def after_connect():
        #use for mqtt subscribe
        return
```