### PR TITLE
umqtt.{robust,simple}: wait_msg(): select blocking mode by parameter

### DIFF
--- a/umqtt.robust/umqtt/robust.py
+++ b/umqtt.robust/umqtt/robust.py
@@ -34,10 +34,10 @@ class MQTTClient(simple.MQTTClient):
                 self.log(False, e)
             self.reconnect()
 
-    def wait_msg(self):
+    def wait_msg(self, blocking=True):
         while 1:
             try:
-                return super().wait_msg()
+                return super().wait_msg(blocking)
             except OSError as e:
                 self.log(False, e)
             self.reconnect()

--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -164,7 +164,8 @@ class MQTTClient:
     # Subscribed messages are delivered to a callback previously
     # set by .set_callback() method. Other (internal) MQTT
     # messages processed internally.
-    def wait_msg(self):
+    def wait_msg(self, blocking=True):
+        self.sock.setblocking(blocking)
         res = self.sock.read(1)
         self.sock.setblocking(True)
         if res is None:
@@ -200,5 +201,4 @@ class MQTTClient:
     # If not, returns immediately with None. Otherwise, does
     # the same processing as wait_msg.
     def check_msg(self):
-        self.sock.setblocking(False)
-        return self.wait_msg()
+        return self.wait_msg(False)


### PR DESCRIPTION
As described in #192 , `check_msg()` block after reconnect. Saving the blocking state in a parameter allows to reapply the blocking mode to the socket.

This PR did not address the issue that `check_msg()` blocks until reconnected.
