### PR TITLE
umqtt.simple: Added call to main() function in example scripts

### DIFF
--- a/micropython/umqtt.simple/example_pub_button.py
+++ b/micropython/umqtt.simple/example_pub_button.py
@@ -28,3 +28,7 @@ def main(server=SERVER):
         time.sleep_ms(200)
 
     c.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/micropython/umqtt.simple/example_sub_led.py
+++ b/micropython/umqtt.simple/example_sub_led.py
@@ -48,3 +48,7 @@ def main(server=SERVER):
             c.wait_msg()
     finally:
         c.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added call to main() function at end of script after the function definition. Matches other example scripts in umqtt.simple lib and is tested as functional on ESP8266 with MicroPython 1.9.1

Stefan