### PR TITLE
binascii: Add required argument to <int>.to_bytes(...) call.

### DIFF
--- a/binascii/binascii.py
+++ b/binascii/binascii.py
@@ -68,7 +68,7 @@ def a2b_base64(ascii):
             #
             if leftbits >= 8:
                 leftbits -= 8
-                res.append((leftchar >> leftbits).to_bytes(1))
+                res.append((leftchar >> leftbits).to_bytes(1, 'big'))
                 leftchar &= ((1 << leftbits) - 1)
             #
             last_char_was_a_pad = False

--- a/binascii/metadata.txt
+++ b/binascii/metadata.txt
@@ -1,3 +1,3 @@
 srctype=pypy
 type=module
-version = 2.4.0-4
+version = 2.4.0-5

--- a/binascii/setup.py
+++ b/binascii/setup.py
@@ -7,7 +7,7 @@ sys.path.append("..")
 import optimize_upip
 
 setup(name='micropython-binascii',
-      version='2.4.0-4',
+      version='2.4.0-5',
       description='PyPy binascii module ported to MicroPython',
       long_description='This is a module ported from PyPy standard library to be compatible with\nMicroPython interpreter. Usually, this means applying small patches for\nfeatures not supported (yet, or at all) in MicroPython. Sometimes, heavier\nchanges are required. Note that CPython modules are written with availability\nof vast resources in mind, and may not work for MicroPython ports with\nlimited heap. If you are affected by such a case, please help reimplement\nthe module from scratch.',
       url='https://github.com/micropython/micropython-lib',


### PR DESCRIPTION
The `a2b_base64(...)` function in the `binascii` module was failing due to an invalid call being made to the `<int>.to_bytes(...)` function.  The `<int>.to_bytes(...)` function requires two arguments.  The first specifies the number of bytes to return, and the second specifies the endianness of those bytes.  By definition, Base64 encoding is big endian.

This change also fixed the test cases for the `base64` module.