### PR TITLE
hmac: Calculate correct digest when non-trivial key is used.

### DIFF
--- a/hmac/hmac.py
+++ b/hmac/hmac.py
@@ -13,7 +13,7 @@ trans_5C = bytes((x ^ 0x5C) for x in range(256))
 trans_36 = bytes((x ^ 0x36) for x in range(256))
 
 def translate(d, t):
-    return b''.join([ chr(t[x]).encode('ascii') for x in d ])
+    return bytes(t[x] for x in d)
 
 # The size of the digests returned by HMAC depends on the underlying
 # hashing module used.  Use digest_size from the instance of HMAC instead.

--- a/hmac/metadata.txt
+++ b/hmac/metadata.txt
@@ -1,4 +1,4 @@
 srctype = cpython
 type = module
-version = 3.4.2-2
+version = 3.4.2-3
 depends = warnings, hashlib

--- a/hmac/setup.py
+++ b/hmac/setup.py
@@ -7,7 +7,7 @@ sys.path.append("..")
 import optimize_upip
 
 setup(name='micropython-hmac',
-      version='3.4.2-2',
+      version='3.4.2-3',
       description='CPython hmac module ported to MicroPython',
       long_description='This is a module ported from CPython standard library to be compatible with\nMicroPython interpreter. Usually, this means applying small patches for\nfeatures not supported (yet, or at all) in MicroPython. Sometimes, heavier\nchanges are required. Note that CPython modules are written with availability\nof vast resources in mind, and may not work for MicroPython ports with\nlimited heap. If you are affected by such a case, please help reimplement\nthe module from scratch.',
       url='https://github.com/micropython/micropython-lib',

--- a/hmac/test_hmac.py
+++ b/hmac/test_hmac.py
@@ -20,3 +20,29 @@ print(dig)
 if dig != '59942f31b6f5473fb4eb630fabf5358a49bc11d24ebc83b114b4af30d6ef47ea14b673f478586f520a0b9c53b27c8f8dd618c165ef586195bd4e98293d34df1a':
     raise Exception("Error")
 
+key = b'\x06\x1au\x90|Xz;o\x1b<\xafGL\xbfn\x8a\xc94YPfC^\xb9\xdd)\x7f\xaf\x85\xa1\xed\x82\xbexp\xaf\x13\x1a\x9d'
+
+dig = hmac.new(key[:20], msg=msg, digestmod=sha256).hexdigest()
+
+print('59e332b881df09fdecf569c8b142b27fc989638720aeda2813f82442b6e3d91b')
+print(dig)
+
+if dig != '59e332b881df09fdecf569c8b142b27fc989638720aeda2813f82442b6e3d91b':
+    raise Exception("Error")
+
+dig = hmac.new(key[:32], msg=msg, digestmod=sha256).hexdigest()
+
+print('b72fed815cd71acfa3a2f5cf2343679565fa18e7cd92226ab443aabd1fd7b7b0')
+print(dig)
+
+if dig != 'b72fed815cd71acfa3a2f5cf2343679565fa18e7cd92226ab443aabd1fd7b7b0':
+    raise Exception("Error")
+
+dig = hmac.new(key, msg=msg, digestmod=sha256).hexdigest()
+
+print('4e51beae6c2b0f90bb3e99d8e93a32d168b6c1e9b7d2130e2d668a3b3e10358d')
+print(dig)
+
+if dig != '4e51beae6c2b0f90bb3e99d8e93a32d168b6c1e9b7d2130e2d668a3b3e10358d':
+    raise Exception("Error")
+


### PR DESCRIPTION
As per section 3 of [RFC 2104](https://www.ietf.org/rfc/rfc2104.txt), the HMAC algorithm must manipulate the specified key such that its length is the same as the block size of the specified digest algorithm.  If the key is shorter than the block size, then it will be right padded with 0x00 bytes to extend its length.  If the key is longer than the block size, it will be passed through the digest algorithm to produce a derivative key.  As per section 2, XOR operations must then be performed on the resulting key to produce two intermediate keys for internal use.  Every key produced by the algorithm steps described will have a length equal to the block size.

Previously, the HMAC implementation had a defect resulting in keys being used with the wrong value and length when:

- The specified key had a length less than or equal to the block size, and contained a byte with its most significant bit set (i.e. its value was between 128 and 255).

- The specified key had a length greater than the block size.  In this situation, the derivative key would almost certainly have at least one byte with its most significant bit set.

This incorrect behavior was a result of how the function that performs the XOR operation was implemented.  The function first used the `chr(...)` function to convert each resulting XORed byte, represented as an integer, to a string of length one.  Then, the `<str>.encode(...)` function was used to convert the string to a byte string with an intended length of one.  The code attempted to use the `ascii` encoding to accomplish this, but there are two problems in doing so.  

- The MicroPython core implementation ignores the specified encoding and always uses `utf-8` encoding.  This causes single bytes with their most significant bit set to be converted to a sequence of bytes.

- The `ascii` encoding, as defined in CPython, only supports input values in the range 0 to 127. 

This problem does not exist in CPython's HMAC implementation, because it uses the `<bytes>.translate(...)` function for this translation, which is not implemented in MicroPython.