### PR TITLE
Correction to the mask on the return of the operation, when the opera…

### DIFF
--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -177,7 +177,7 @@ class MQTTClient:
             return None
         op = res[0]
         if op & 0xf0 != 0x30:
-            return op
+            return op & 0xf0
         sz = self._recv_len()
         topic_len = self.sock.read(2)
         topic_len = (topic_len[0] << 8) | topic_len[1]


### PR DESCRIPTION
Correction to the mask on the return of the operation, when the operation type returns to subscribe channel it should be taking into account the 9 part of  0x9x, not the entire byte, as 1001 represent acknowledgement, regardless.  0x92 for example, and 0x90 should return the same operation code back to subscribe function to avoid a deadlock. Thingsboard implementation of mqtt  for example, returns a 0x92 code as the ack for a subscribe instead of 0x90 as mosquitto. This fixes deadlock issues while trying to subscribe to Java MQTT implementations.