### PR TITLE
select: Convert float timeout to int with math.ceil.

### DIFF
--- a/select/select.py
+++ b/select/select.py
@@ -4,6 +4,7 @@ import os
 import errno
 import ffilib
 import utime
+import math
 from uselect import *
 
 
@@ -92,7 +93,7 @@ class Epoll:
         return res
 
     def poll(self, timeout=-1):
-        return self.poll_ms(-1 if timeout == -1 else timeout * 1000)
+        return self.poll_ms(-1 if timeout == -1 else math.ceil(timeout * 1000))
 
     def close(self):
         os.close(self.epfd)


### PR DESCRIPTION
In CPython, timeout is a float and the value rounded up to the nearest millisecond. The rounding up is discussed in issues [20311](https://bugs.python.org/issue20311) and [20452](https://bugs.python.org/issue20452).

This will allow users to specify poll timeouts with greater precision than 1 second. But, this solution is susceptible to float round errors and is only accurate to +/- 1ms. E.g. epoll.poll(.001) actually results in a timeout of 2ms.

I don't know if its worth it to introduce an inaccuracy. Until 2008 epoll_wait actually had a resolution between 1 and 10ms: https://lwn.net/Articles/296578/, https://lwn.net/Articles/296398/.

I think the decimal module would help here if it existed.
