### PR TITLE
uasyncio submodule for synchronization primitives, Lock implemented.

### DIFF
--- a/uasyncio.synchro/example_lock.py
+++ b/uasyncio.synchro/example_lock.py
@@ -1,0 +1,27 @@
+try:
+    import uasyncio.core as asyncio
+    from uasyncio.synchro import Lock
+except ImportError:
+    import asyncio
+    from asyncio import Lock
+
+
+def task(i, lock):
+    print(lock)
+    while 1:
+        yield from lock.acquire()
+        print("Acquired lock in task", i)
+        yield from asyncio.sleep(0.5)
+#        yield lock.release()
+        lock.release()
+
+
+loop = asyncio.get_event_loop()
+
+lock = Lock()
+
+loop.create_task(task(1, lock))
+loop.create_task(task(2, lock))
+loop.create_task(task(3, lock))
+
+loop.run_forever()

--- a/uasyncio.synchro/uasyncio/synchro.py
+++ b/uasyncio.synchro/uasyncio/synchro.py
@@ -1,0 +1,28 @@
+from uasyncio import core
+
+class Lock:
+
+    def __init__(self):
+        self.locked = False
+        self.wlist = []
+
+    def release(self):
+        assert self.locked
+        self.locked = False
+        if self.wlist:
+#            print(self.wlist)
+            coro = self.wlist.pop(0)
+            core.get_event_loop().call_soon(coro)
+
+    def acquire(self):
+        # As release() is not coro, assume we just released and going to acquire again
+        # so, yield first to let someone else to acquire it first
+        yield
+#        print("acquire:", self.locked)
+        while 1:
+            if not self.locked:
+                self.locked = True
+                return True
+#            print("putting", core.get_event_loop().cur_coro, "on waiting list")
+            self.wlist.append(core.get_event_loop().cur_coro)
+            yield False


### PR DESCRIPTION
@dpgeorge , @peterhinch : Please reviews. Points to consider:

* Name of the submodule. I wished to use uasyncio.sync for qstr reuse, but that may be not clear enough.
* Correctness of implementation. Note that this is compatible with CPython Lock API, which asyncio liking to confusingly introduce non-coroutines methods here and there, .release() being such. So, that was worked around by putting extra yield into acquire(), and even works without scheduling artifacts with the provided example, though in general, it might lead to such.
