### PR TITLE
urequests: Fix OSError when connecting to IPv6 adress.

### DIFF
--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -53,7 +53,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
     ai = usocket.getaddrinfo(host, port)
     addr = ai[0][-1]
 
-    s = usocket.socket()
+    s = usocket.socket(ai[0][0], ai[0][1])
     try:
         s.connect(addr)
         if proto == "https:":


### PR DESCRIPTION
If the first address returned by `getaddrinfo()` is a IPv6 address, `usocket.socket()` must be called with the correct address family and socket type, otherwise `connect()` on the socket will fail with `OSError: 97` (`EAFNOSUPPORT`).