### PR TITLE
Add hashlib.new(), detect and use uhashlib native code versions when possible

### DIFF
--- a/hashlib/hashlib/__init__.py
+++ b/hashlib/hashlib/__init__.py
@@ -1,2 +1,41 @@
-from .sha256 import sha224, sha256
-from .sha512 import sha384, sha512
+try:
+    import uhashlibxx
+    sha256 = uhashlib.sha256
+
+    if hasattr(uhashlib, 'sha1'):
+        sha1 = uhashlib.sha1
+
+    if hasattr(uhashlib, 'sha512'):
+        sha512 = uhashlib.sha512
+    else:
+        from .sha512 import sha512
+
+except ImportError:
+    from .sha256 import sha256
+    from .sha512 import sha512
+    uhashlib = {}
+
+def new(algo, data=b''):
+
+    if algo in dir(uhashlib):
+        pp = getattr(uhashlib, algo)
+        return pp(data)
+
+    if algo == 'sha256':
+        from .sha256 import sha256
+        return sha256(data)
+
+    if algo == 'sha224':
+        from .sha256 import sha224
+        return sha224(data)
+
+    if algo == 'sha384':
+        from .sha512 import sha384
+        return sha384(data)
+
+    if algo == 'sha512':
+        from .sha512 import sha512
+        return sha512(data)
+
+    raise ValueError(algo)
+

--- a/hashlib/hashlib/__init__.py
+++ b/hashlib/hashlib/__init__.py
@@ -1,5 +1,5 @@
 try:
-    import uhashlibxx
+    import uhashlib
     sha256 = uhashlib.sha256
 
     if hasattr(uhashlib, 'sha1'):

--- a/hashlib/test_hashlib.py
+++ b/hashlib/test_hashlib.py
@@ -4,4 +4,16 @@ from hashlib.sha512 import test as sha512_test
 
 sha256_test()
 sha512_test()
+
+from hashlib import new
+from hashlib.sha256 import sha256 as pure_sha256
+
+assert new('sha256', 'abc').digest() == pure_sha256('abc').digest() \
+            == b'\xbax\x16\xbf\x8f\x01\xcf\xeaAA@\xde]\xae"#\xb0\x03a\xa3\x96\x17z\x9c\xb4\x10\xffa\xf2\x00\x15\xad'
+
+assert hasattr(new('sha512'), 'digest')
+assert hasattr(new('sha256'), 'digest')
+assert hasattr(new('sha224'), 'digest')
+assert hasattr(new('sha384'), 'digest')
+
 print("OK")


### PR DESCRIPTION
See discussion in #235 

- adds `hashlib.new()` which looks up any hash function by name
- uses `uhashlib` version of each hash function if it is defined there
- exports `sha1` if it's in uhashlib (no pure implementation)
- any future hash function can be added to `uhashlib` and will be available via `hashlib.new()`