### PR TITLE
umqtt.simple: add force_close parameter to disconnect() to ensure soc…

### DIFF
--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -99,9 +99,15 @@ class MQTTClient:
             raise MQTTException(resp[3])
         return resp[2] & 1
 
-    def disconnect(self):
-        self.sock.write(b"\xe0\0")
-        self.sock.close()
+    def disconnect(self, force_close=False):
+        try:
+            self.sock.write(b"\xe0\0")
+        except OSError:
+            if force_close:
+                self.sock.close()
+            raise
+        else:
+            self.sock.close()
 
     def ping(self):
         self.sock.write(b"\xc0\0")


### PR DESCRIPTION

Add `force_close` argument to `umqtt.simple.MQTTClient.disconnect()` that, when set, ensures `socket.close()` is called even if there's an error while sending the disconnect message to the MQTT server.

The default behavior is the same as before - I was tempted to change it since I believe it would be a better default, but I don't want to break any backward compatibility.

