### PR TITLE
ssl: Drop default arguments to wrap_ssl

### DIFF
--- a/ssl/ssl.py
+++ b/ssl/ssl.py
@@ -1,1 +1,6 @@
 from ussl import *
+
+# Constants
+for sym in "CERT_NONE", "CERT_OPTIONAL", "CERT_REQUIRED":
+    if sym not in globals():
+        globals()[sym] = object()

--- a/ssl/ssl.py
+++ b/ssl/ssl.py
@@ -1,6 +1,28 @@
 from ussl import *
+import ussl as _ussl
 
 # Constants
 for sym in "CERT_NONE", "CERT_OPTIONAL", "CERT_REQUIRED":
     if sym not in globals():
         globals()[sym] = object()
+
+
+def wrap_socket(sock, keyfile=None, certfile=None, server_side=False,
+                cert_reqs=CERT_NONE, *, ca_certs=None, server_hostname=None):
+    # TODO: More arguments accepted by CPython could also be handled here.
+    # That would allow us to accept ca_certs as a positional argument, which
+    # we should.
+    kw = {}
+    if keyfile is not None:
+        kw["keyfile"] = keyfile
+    if certfile is not None:
+        kw["certfile"] = certfile
+    if server_side is not False:
+        kw["server_side"] = server_side
+    if cert_reqs is not CERT_NONE:
+        kw["cert_reqs"] = cert_reqs
+    if ca_certs is not None:
+        kw["ca_certs"] = ca_certs
+    if server_hostname is not None:
+        kw["server_hostname"] = server_hostname
+    return _ussl.wrap_socket(sock, **kw)


### PR DESCRIPTION
This is to take care of what I described as "Use case 1" in reporting #198. (Use case 2 needs a separate PR, so I'll leave #198 open for now).

I know `wrap_socket` looks a little repetitive (because it is), but I tried two other implementations, and (especially [without proper support] for `locals()` in MicroPython) it was always significantly more convoluted and harder to read.

[without proper support]: http://docs.micropython.org/en/latest/pyboard/genrst/core_language.html#local-variables-aren-t-included-in-locals-result