### PR TITLE
unittest: Exit with non zero code in case of failures.

### DIFF
--- a/unittest/unittest.py
+++ b/unittest/unittest.py
@@ -1,3 +1,6 @@
+import sys
+
+
 class SkipTest(Exception):
     pass
 
@@ -217,3 +220,5 @@ def main(module="__main__"):
         suite.addTest(c)
     runner = TestRunner()
     result = runner.run(suite)
+    # Terminate with non zero return code in case of failures
+    sys.exit(result.failuresNum > 0)


### PR DESCRIPTION
Fixing #259 

Successful run:
```
$ ./test_server.py; echo "Exit code $?"
testRequestLargeBody (ServerFull) ... ok
....
testMimeTypes (Utils) ... ok
Ran 34 tests

OK
Exit code 0
```

Failures:
```
$ ./test_server.py; echo "Exit code $?"
testRequestLargeBody (ServerFull) ... ok
....
testSendFileManual (StaticContent) ... FAIL
....
testMimeTypes (Utils) ... ok
Ran 34 tests

FAILED (failures=1, errors=0)
Exit code 1
```