### PR TITLE
logging: Make compliant to PEP8

### DIFF
--- a/logging/logging.py
+++ b/logging/logging.py
@@ -1,11 +1,12 @@
 import sys
 
+
 CRITICAL = 50
-ERROR    = 40
-WARNING  = 30
-INFO     = 20
-DEBUG    = 10
-NOTSET   = 0
+ERROR = 40
+WARNING = 30
+INFO = 20
+DEBUG = 10
+NOTSET = 0
 
 _level_dict = {
     CRITICAL: "CRIT",
@@ -16,6 +17,7 @@ _level_dict = {
 }
 
 _stream = sys.stderr
+
 
 class Logger:
 
@@ -30,7 +32,8 @@ class Logger:
 
     def log(self, level, msg, *args):
         if level >= (self.level or _level):
-            print(("%s:%s:" + msg) % ((self._level_str(level), self.name) + args), file=_stream)
+            print(("%s:%s:" + msg) %
+                  ((self._level_str(level), self.name) + args), file=_stream)
 
     def debug(self, msg, *args):
         self.log(DEBUG, msg, *args)
@@ -51,18 +54,22 @@ class Logger:
 _level = INFO
 _loggers = {}
 
+
 def getLogger(name):
     if name in _loggers:
         return _loggers[name]
-    l = Logger(name)
+    l = Logger(name)  # noqa: E741
     _loggers[name] = l
     return l
+
 
 def info(msg, *args):
     getLogger(None).info(msg, *args)
 
+
 def debug(msg, *args):
     getLogger(None).debug(msg, *args)
+
 
 def basicConfig(level=INFO, filename=None, stream=None, format=None):
     global _level, _stream

--- a/typing/typing.py
+++ b/typing/typing.py
@@ -1,0 +1,62 @@
+class Any: pass
+class NoReturn: pass
+class ClassVar: pass
+class Union: pass
+class Optional: pass
+class Generic: pass
+class NamedTuple: pass
+class Hashable: pass
+class Awaitable: pass
+class Coroutine: pass
+class AsyncIterable: pass
+class AsyncIterator: pass
+class Iterable: pass
+class Iterator: pass
+class Reversible: pass
+class Sized: pass
+class Container: pass
+class Collection: pass
+class Callable: pass
+class AbstractSet: pass
+class MutableSet: pass
+class Mapping: pass
+class MutableMapping: pass
+class Sequence: pass
+class MutableSequence: pass
+class ByteString: pass
+class Tuple: pass
+class List: pass
+class Deque: pass
+class Set: pass
+class FrozenSet: pass
+class MappingView: pass
+class KeysView: pass
+class ItemsView: pass
+class ValuesView: pass
+class ContextManager: pass
+class AsyncContextManager: pass
+class Dict: pass
+class DefaultDict: pass
+class Counter: pass
+class ChainMap: pass
+class Generator: pass
+class AsyncGenerator: pass
+class Type: pass
+
+
+def cast(typ, val):
+    return val
+
+
+def _overload_dummy(*args, **kwds):
+    """Helper for @overload to raise when called."""
+    raise NotImplementedError(
+        "You should not call an overloaded function. "
+        "A series of @overload-decorated functions "
+        "outside a stub module should always be followed "
+        "by an implementation that is not @overload-ed."
+    )
+
+
+def overload():
+    return _overload_dummy


### PR DESCRIPTION
In the contribution guidelines there is a clear statement that modules should be compliant to PEP8. The logging modules wasn't so far so I quickly fixed this.