### PR TITLE
urequests: Add timeout option

### DIFF
--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -32,7 +32,7 @@ class Response:
         return ujson.loads(self.content)
 
 
-def request(method, url, data=None, json=None, headers={}, stream=None):
+def request(method, url, data=None, json=None, headers={}, stream=None, timeout=None):
     try:
         proto, dummy, host, path = url.split("/", 3)
     except ValueError:
@@ -54,6 +54,10 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
     ai = ai[0]
 
     s = usocket.socket(ai[0], ai[1], ai[2])
+
+    if timeout is not None:
+        assert hasattr(usocket.socket, 'settimeout'), 'Socket does not support timeout'
+        s.settimeout(timeout)
     try:
         s.connect(ai[-1])
         if proto == "https:":


### PR DESCRIPTION
Timeout is a 'must have' option for urequests-lib. We got a lot of problems caused by this missing option. I know not all micropython ports supports timemout but in this case they will receive assertion error 'Socket does not support timeout'. Thank you ! 