### PR TITLE
uasyncio.core: run_until_complete should return coroutine's result

### DIFF
--- a/uasyncio.core/test_coro_result.py
+++ b/uasyncio.core/test_coro_result.py
@@ -1,0 +1,26 @@
+try:
+    import uasyncio.core as asyncio
+except ImportError:
+    import asyncio
+import logging
+
+async def async_func_int(value:int) -> int:
+    return value
+
+async def async_func_int_sleep(value:int) -> int:
+    await asyncio.sleep(1)
+    return value
+
+async def async_func_none() -> None:
+    pass
+
+async def async_func_none_sleep() -> None:
+    await asyncio.sleep(1)
+
+
+loop = asyncio.get_event_loop()
+assert loop.run_until_complete(async_func_int(0)) == 0
+assert loop.run_until_complete(async_func_int(-1)) == -1
+assert loop.run_until_complete(async_func_int_sleep(-2)) == -2
+assert loop.run_until_complete(async_func_none()) is None
+assert loop.run_until_complete(async_func_none_sleep()) is None

--- a/uasyncio.core/uasyncio/core.py
+++ b/uasyncio.core/uasyncio/core.py
@@ -151,10 +151,10 @@ class EventLoop:
 
     def run_until_complete(self, coro):
         def _run_and_stop():
-            yield from coro
-            yield StopLoop(0)
+            ret = yield from coro
+            yield StopLoop(ret)
         self.call_soon(_run_and_stop())
-        self.run_forever()
+        return self.run_forever()
 
     def stop(self):
         self.call_soon((lambda: (yield StopLoop(0)))())


### PR DESCRIPTION
According to [CPython reference](https://docs.python.org/3.6/library/asyncio-eventloop.html#asyncio.AbstractEventLoop.run_until_complete), run_until_complete method of EventLoop returns Future's result or raise exception occured inside coroutine, but current run_until_complete method in uasyncio does not return anything.

Since there are no Future object in uasyncio, it's difficult to propagate exception occured inside coroutne. But it's not difficult to return result from coroutine.

This modification fixes the run_until_complete method to return coroutine's result.