### PR TITLE
Add the ability to connect if IP is used.

### DIFF
--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -54,7 +54,11 @@ class MQTTClient:
 
     def connect(self, clean_session=True):
         self.sock = socket.socket()
-        addr = socket.getaddrinfo(self.server, self.port)[0][-1]
+        addr=None
+         if(re.match("^((25[0-5]|2[0-4]\d|[01]?\d\d?)\.)((25[0-5]|2[0-4]\d|[01]?\d\d?)\.)((25[0-5]|2[0-4]\d|[01]?\d\d?)\.)(25[0-5]|2[0-4]\d|[01]?\d\d?)$",self.server)):
+            addr=(self.server,self.port)
+        else:
+            addr = socket.getaddrinfo(self.server, self.port)[0][-1]
         self.sock.connect(addr)
         if self.ssl:
             import ussl


### PR DESCRIPTION
When I use the mqtt module I found an OSerror(no entry) will be thrown if I use my mqtt broker's IP for creating a new mqtt instance.
In some limited cases, like in a factory using LAN instead of internet connection, an local lightweight mqtt broker should be allowed to use IP address. I added a simple regex function to check if it is a valid IP. If not, then everything is the same as usual. See if this help. 