### PR TITLE
Updates for new PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ problems on bare-metal ports, not just on "Unix" port (e.g. pyboard).
 Usage
 -----
 micropython-lib packages are published on PyPI (Python Package Index),
-the standard Python community package repository: http://pypi.python.org/ .
+the standard Python community package repository: https://pypi.org/ .
 On PyPI, you can search for MicroPython related packages and read
 additional package information. By convention, all micropython-lib package
 names are prefixed with "micropython-" (the reverse is not true - some
 package starting with "micropython-" aren't part of micropython-lib and
 were released by 3rd parties).
 
-Browse available packages
-[via this URL](https://pypi.python.org/pypi?%3Aaction=search&term=micropython).
+Browse available packages [via this
+URL](https://pypi.org/search/?q=&o=&c=Programming+Language+%3A%3A+Python+%3A%3A+Implementation+%3A%3A+MicroPython).
 
 To install packages from PyPI for usage on your local system, use the
 `upip` tool, which is MicroPython's native package manager, similar to

--- a/upip/bootstrap_upip.sh
+++ b/upip/bootstrap_upip.sh
@@ -9,7 +9,7 @@ fi
 
 # Remove any stale old version
 rm -rf micropython-upip-*
-wget -nd -r -l1 https://pypi.python.org/pypi/micropython-upip/ --accept-regex ".*pypi.python.org/packages/source/.*.gz" --reject=html
+wget -nd -rH -l1 -D files.pythonhosted.org https://pypi.org/project/micropython-upip/ --reject=html
 
 tar xfz micropython-upip-*.tar.gz
 mkdir -p ~/.micropython/lib/

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -156,7 +156,7 @@ def url_open(url):
 
 
 def get_pkg_metadata(name):
-    f = url_open("https://pypi.python.org/pypi/%s/json" % name)
+    f = url_open("https://pypi.org/pypi/%s/json" % name)
     try:
         return json.load(f)
     finally:


### PR DESCRIPTION
Hi! These changes should make `upip` compatible with the new PyPI at https://pypi.org.

I also updated a few old links in `README.md` which were pointing to `pypi.python.org`.

Fixes #274.