### PR TITLE
urequests: Add iteration methods to process large responses and support 'with' to close response

### DIFF
--- a/urequests/example_iter.py
+++ b/urequests/example_iter.py
@@ -1,0 +1,15 @@
+# Example of processing large responses, the response is automatically closed
+try:
+    import urequests as requests
+except ImportError:
+    import requests
+
+# Iterate over individual lines of the response
+with requests.get('http://jsonplaceholder.typicode.com/users') as response:
+    for line in response.iter_lines():
+	    print(line.decode(response.encoding))
+		
+# Iterate over 'chunks' of the response
+with requests.get('http://jsonplaceholder.typicode.com/users') as response:
+    for chunk in response.iter_content():
+	    print(chunk.decode(response.encoding))

--- a/urequests/metadata.txt
+++ b/urequests/metadata.txt
@@ -1,4 +1,4 @@
 srctype = micropython-lib
 type = module
-version = 0.6
+version = 0.7
 author = Paul Sokolovsky

--- a/urequests/setup.py
+++ b/urequests/setup.py
@@ -7,7 +7,7 @@ sys.path.append("..")
 import sdist_upip
 
 setup(name='micropython-urequests',
-      version='0.6',
+      version='0.7',
       description='urequests module for MicroPython',
       long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
       url='https://github.com/micropython/micropython-lib',


### PR DESCRIPTION
This change adds the following methods from the [Response class of the Python requests](https://github.com/requests/requests/blob/239ee194318e0b88d6a7b292ec4b68451ceefe68/requests/models.py#L578) module to the urequests Response class:
- iter_lines()
- iter_content()
- \_\_enter__()
- \_\_exit__()
- \_\_iter__()

This enables two things:
* processing of large HTTP responses
* succinct handling of the need to close Responses. 

So for example:
```
# Iterate over individual lines of the response
with urequests.get('http://jsonplaceholder.typicode.com/users') as response:
    for line in response.iter_lines():
        print(line.decode(response.encoding))
		
# Iterate over 'chunks' of the response
with urequests.get('http://jsonplaceholder.typicode.com/users') as response:
    for chunk in response.iter_content():
        print(chunk.decode(response.encoding))
```
The \_\_iter__() method of Response allows this example:
```
for chunk in requests.get('http://jsonplaceholder.typicode.com/users'):
    print(chunk.decode('UTF-8'))
```
I chose to reduce the default size of ITER_CHUNK_SIZE from 512 to 128 to conserve resources, not sure this makes sense?

I have tested this new functionality on ESP8266 and ESP32.

Finally, this obviously increases code size, so maybe the scope can be reduced? The \_\_iter__() method could be dropped as this would not reduce the actual capability. Beyond that we could maybe drop the iter_lines() method? Both \_\_enter__() and \_\_exit__() are small and get rid of nasty try finally syntax so I think these should stay? 