### PR TITLE
unittest: fix context manager to store exception for later retrieval

### DIFF
--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -33,6 +33,8 @@ class AssertRaisesContext:
         if exc_type is None:
             assert False, "%r not raised" % self.expected
         if issubclass(exc_type, self.expected):
+            # store exception for later retrieval
+            self.exception = exc_value
             return True
         return False
 


### PR DESCRIPTION
The statement "with assertRaises(errtype) as ctxt" checks the type of a raised exception, but did not store the exception into ctxt like unittest of CPython. The exception instance  is usually used to check its message or other args.

This commit is a one-line fix at the cost of a bit more RAM usage while running unittests.