### PR TITLE
uaiohttpclient: Allow non-standard port number

### DIFF
--- a/uaiohttpclient/uaiohttpclient.py
+++ b/uaiohttpclient/uaiohttpclient.py
@@ -51,7 +51,7 @@ def request_raw(method, url):
 
     host_port = host.rsplit("@", 1)[-1]
     try:
-        host, port = host_port.rsplit(":", 1)[-1]
+        host, port = host_port.rsplit(":", 1)
     except ValueError:
         host = host_port
         port = 80

--- a/uaiohttpclient/uaiohttpclient.py
+++ b/uaiohttpclient/uaiohttpclient.py
@@ -48,9 +48,17 @@ def request_raw(method, url):
     except ValueError:
         proto, dummy, host = url.split("/", 2)
         path = ""
+
+    host_port = host.rsplit("@", 1)[-1]
+    try:
+        host, port = host_port.rsplit(":", 1)[-1]
+    except ValueError:
+        host = host_port
+        port = 80
+
     if proto != "http:":
         raise ValueError("Unsupported protocol: " + proto)
-    reader, writer = yield from asyncio.open_connection(host, 80)
+    reader, writer = yield from asyncio.open_connection(host, port)
     # Use protocol 1.0, because 1.1 always allows to use chunked transfer-encoding
     # But explicitly set Connection: close, even though this should be default for 1.0,
     # because some servers misbehave w/o it.


### PR DESCRIPTION
Parse the port number in URL and use that port number (if specified) when creating connection.