### PR TITLE
 umqtt.simple: refactor packet de/encoding and fix remaining length encoding (fixes #284)

### DIFF
--- a/umqtt.simple/example_pub.py
+++ b/umqtt.simple/example_pub.py
@@ -1,13 +1,15 @@
 from umqtt.simple import MQTTClient
+#from umqtt_debug import DebugMQTTClient as MQTTClient
 
 # Test reception e.g. with:
 # mosquitto_sub -t foo_topic
 
-def main(server="localhost"):
+def main(server="localhost", topic="foo_topic", msg="hello", qos=0):
     c = MQTTClient("umqtt_client", server)
     c.connect()
-    c.publish(b"foo_topic", b"hello")
+    c.publish(topic.encode('utf-8'), msg.encode('utf-8'), qos=int(qos))
     c.disconnect()
 
 if __name__ == "__main__":
-    main()
+    import sys
+    main(*sys.argv[1:])

--- a/umqtt.simple/example_sub.py
+++ b/umqtt.simple/example_sub.py
@@ -1,5 +1,6 @@
 import time
 from umqtt.simple import MQTTClient
+#from umqtt_debug import DebugMQTTClient as MQTTClient
 
 # Publish test messages e.g. with:
 # mosquitto_pub -t foo_topic -m hello
@@ -7,14 +8,14 @@ from umqtt.simple import MQTTClient
 # Received messages from subscriptions will be delivered to this callback
 def sub_cb(topic, msg):
     print((topic, msg))
-
-def main(server="localhost"):
+    
+def main(server="localhost", topic="foo_topic", qos=0, blocking=True):
     c = MQTTClient("umqtt_client", server)
     c.set_callback(sub_cb)
     c.connect()
-    c.subscribe(b"foo_topic")
+    c.subscribe(topic.encode('utf-8'), int(qos))
     while True:
-        if True:
+        if blocking:
             # Blocking wait for message
             c.wait_msg()
         else:
@@ -27,4 +28,5 @@ def main(server="localhost"):
     c.disconnect()
 
 if __name__ == "__main__":
-    main()
+    import sys
+    main(*sys.argv[1:])

--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -1,5 +1,4 @@
 import usocket as socket
-#from ubinascii import hexlify
 
 class MQTTException(Exception):
     pass
@@ -89,9 +88,7 @@ class MQTTClient:
             msg[7] |= self.lw_retain << 5
 
         plen = self._varlen_encode(sz, premsg, 1)
-        #print(hex(len(premsg[:plen])), hexlify(premsg[:plen], ":"))
         self.sock.write(premsg, plen)
-        #print(hex(len(msg)), hexlify(msg, ":"))
         self.sock.write(msg)
         self._send_str(self.client_id)
         if self.lw_topic:
@@ -121,7 +118,6 @@ class MQTTClient:
         if qos > 0:
             sz += 2
         plen = self._varlen_encode(sz, pkt, 1)
-        #print(hex(len(pkt[:plen])), hexlify(pkt[:plen], ":"))
         self.sock.write(pkt, plen)
         self._send_str(topic)
         if qos > 0:
@@ -148,7 +144,6 @@ class MQTTClient:
         sz = 2 + 2 + len(topic) + 1
         plen = self._varlen_encode(sz, pkt, 1)
         pkt[plen:plen + 2] = self.pid.to_bytes(2, 'big')
-        #print(hex(len(pkt[:plen + 2])), hexlify(pkt[:plen + 2], ":"))
         self.sock.write(pkt, plen + 2)
         self._send_str(topic)
         self.sock.write(qos.to_bytes(1, "little"))
@@ -156,7 +151,6 @@ class MQTTClient:
             op = self.wait_msg()
             if op == 0x90:
                 resp = self.sock.read(4)
-                #print(resp)
                 assert resp[1] == pkt[plen] and resp[2] == pkt[plen + 1]
                 if resp[3] == 0x80:
                     raise MQTTException(resp[3])

--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -65,8 +65,11 @@ class MQTTClient:
         sz = 10 + 2 + len(self.client_id)
         msg[6] = clean_session << 1
         if self.user is not None:
-            sz += 2 + len(self.user) + 2 + len(self.pswd)
-            msg[6] |= 0xC0
+            sz += 2 + len(self.user)
+            msg[6] |= 1 << 7
+            if self.pswd is not None:
+                sz += 2 + len(self.pswd)
+                msg[6] |= 1 << 6
         if self.keepalive:
             assert self.keepalive < 65536
             msg[7] |= self.keepalive >> 8
@@ -92,7 +95,8 @@ class MQTTClient:
             self._send_str(self.lw_msg)
         if self.user is not None:
             self._send_str(self.user)
-            self._send_str(self.pswd)
+            if self.pswd is not None:
+                self._send_str(self.pswd)
         resp = self.sock.read(4)
         assert resp[0] == 0x20 and resp[1] == 0x02
         if resp[3] != 0:

--- a/umqtt.simple/umqtt_debug.py
+++ b/umqtt.simple/umqtt_debug.py
@@ -1,0 +1,38 @@
+from umqtt.simple import MQTTClient
+from ubinascii import hexlify
+
+
+class debug_socket:
+    def __init__(self, sock):
+        self.sock = sock
+    
+    def read(self, len):
+        data = self.sock.read(len)
+        print("RECV:", hexlify(data, ':').decode())
+        return data
+
+    def write(self, data, len=None):
+        print("SEND:", hexlify(data, ':').decode())
+        if len is None:
+            return self.sock.write(data)
+        else:
+            return self.sock.write(data, len)
+
+    def __getattr__(self, name):
+        return getattr(self.sock, name)
+
+
+class DebugMQTTClient(MQTTClient):
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self._sock = None
+
+    @property
+    def sock(self):
+        return self._sock
+
+    @sock.setter
+    def sock(self, val):
+        if val:
+            val = debug_socket(val)
+        self._sock = val


### PR DESCRIPTION
As stated in #284, the `MQTTClient.subscribe` method doesn't handle topic lengths >= 122 correctly, since it only allocates one byte for the remaining length portion of the SUBSCRIPTION packet. I've refactored the variable length encoding of the remaining length bytes to use the new `_varlen_encode` method consistently and also got rid of the usage of the `ustruct` module.

* Add `_varlen_encode` method to write variable length encoded remaining length bytes to packet buffer and use it consistently.
* Use `int.from_bytes/to_bytes` to de/encode short integers and replace `ustruct` usage with it.
* Correctly separate bytes of fixed and variable header in `connect` method.

In a separate commit I've also removed all (commented ou) debug printing calls in `simple.py` and added a debug wrapper for `MQTTClient` (`umqtt_debug.py`) to the examples, which can optionally be used with examples, and I've also expanded `example_pub.py` and `example_sub.py` so that they can be parametrized form the command line. If desired, I can separate this commit into an extra PR.

This PR is based on the branch for PR #302. If the latter is merged, I will rebase this on master.