### PR TITLE
uuid: provide basic random uuid4() implementation

### DIFF
--- a/uuid/metadata.txt
+++ b/uuid/metadata.txt
@@ -1,3 +1,3 @@
-srctype=dummy
+srctype=micropython-lib
 type=module
-version = 0.0.1
+version = 0.0.2

--- a/uuid/setup.py
+++ b/uuid/setup.py
@@ -7,9 +7,9 @@ sys.path.append("..")
 import sdist_upip
 
 setup(name='micropython-uuid',
-      version='0.0.1',
-      description='Dummy uuid module for MicroPython',
-      long_description='This is a dummy implementation of a module for MicroPython standard library.\nIt contains zero or very little functionality, and primarily intended to\navoid import errors (using idea that even if an application imports a\nmodule, it may be not using it onevery code path, so may work at least\npartially). It is expected that more complete implementation of the module\nwill be provided later. Please help with the development if you are\ninterested in this module.',
+      version='0.0.2',
+      description='Basic uuid module for MicroPython',
+      long_description='This implementation only provides a uuid4() function returning a random uuid string',
       url='https://github.com/micropython/micropython-lib',
       author='micropython-lib Developers',
       author_email='micro-python@googlegroups.com',

--- a/uuid/uuid.py
+++ b/uuid/uuid.py
@@ -1,0 +1,10 @@
+import urandom
+import ubinascii
+
+
+def uuid4():
+    r = bytearray([urandom.getrandbits(8) for _ in range(16)])
+    r[7] = (r[7] & 0x0F) | 0x40
+    r[9] = (r[9] & 0x3F) | 0x80
+    h = ubinascii.hexlify(r).decode()
+    return '-'.join((h[0:8], h[8:12], h[12:16], h[16:20], h[20:32]))


### PR DESCRIPTION
This provides a random `uuid4()` function which returns a string, rather than a UUID class like the python builtin.
