### PR TITLE
Fix false negative in assertRaises when exception type is AssertionError

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/unittest/unittest.py
+++ b/unittest/unittest.py
@@ -120,12 +120,12 @@ class TestCase:
 
         try:
             func(*args, **kwargs)
-            assert False, "%r not raised" % exc
         except Exception as e:
             if isinstance(e, exc):
                 return
             raise
 
+        assert False, "%r not raised" % exc
 
 
 def skip(msg):


### PR DESCRIPTION
The test expected that exception will be raised and test shall fail if the exception is not raised.

But when the user passes exception type AssertionError,  and code under test do not produce this exception. It is expected that the test would fail. but in fact, the test passes.

This is because of line  `assert False, "%r not raised" % exc`
inside the line in the try-except block produces similar excepton and test framework thinks it was raised by user code.


