### PR TITLE
uaiohttpclient MEM LEAK: Close ClientResponse and handle exceptions to clean the async socket

### DIFF
--- a/uaiohttpclient/example.py
+++ b/uaiohttpclient/example.py
@@ -16,8 +16,13 @@ def print_stream(resp):
 
 def run(url):
     resp = yield from aiohttp.request("GET", url)
-    print(resp)
-    yield from print_stream(resp)
+    try:    
+        print(resp)
+        yield from print_stream(resp)
+    except:
+        pass
+    finally:
+        resp.aclose()
 
 import sys
 import logging


### PR DESCRIPTION
There is no way to close the ClientReponse. That's why the used socket is not unregistered from the uasyncio EventPollLoop and not unregistered from the corresponding uselect poll.

After a few requests, the system runs out of memory.
This patch adds a method for the client to explicitly close the socket.

Moreover, the case when an exception occurs during the processing in request() and request_raw() is not handled and is going to definitively cause a memory leak. The patch adresses this issue too.
 