### PR TITLE
add tzinfo constructor (fixes #319)

### DIFF
--- a/datetime/datetime.py
+++ b/datetime/datetime.py
@@ -914,6 +914,11 @@ class tzinfo:
     Subclasses must override the name(), utcoffset() and dst() methods.
     """
     __slots__ = ()
+
+    def __new__(cls):
+        self = object.__new__(cls)
+        return self
+
     def tzname(self, dt):
         "datetime -> string name of time zone."
         raise NotImplementedError("tzinfo subclass must override tzname()")


### PR DESCRIPTION
This patch addresses the following `datetime` error:

```
AttributeError: type object 'tzinfo' has no attribute 'new'
```