### PR TITLE
urequest socket instance issue

### DIFF
--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -52,7 +52,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
     try:
         ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
     except:
-         ai = usocket.getaddrinfo(host, port)
+        ai = usocket.getaddrinfo(host, port)
     s = usocket.socket()
     ai = ai[0]
 

--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -49,11 +49,13 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
     if ":" in host:
         host, port = host.split(":", 1)
         port = int(port)
-
-    ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
+    try:
+        ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
+    except:
+         ai = usocket.getaddrinfo(host, port)
+    s = usocket.socket()
     ai = ai[0]
 
-    s = usocket.socket(ai[0], ai[1], ai[2])
     try:
         s.connect(ai[-1])
         if proto == "https:":


### PR DESCRIPTION
Recently, new usocket release does not accept four parameters to retrieve the address information using DNS. This PR fixes the method instance (with backward compatibility) and the usocket instantiation