### PR TITLE
sdist_upip.py: fix list index out of range

### DIFF
--- a/sdist_upip.py
+++ b/sdist_upip.py
@@ -85,7 +85,7 @@ def make_resource_module(manifest_files):
         resources = []
         # Any non-python file included in manifest is resource
         for fname in manifest_files:
-            ext = fname.rsplit(".", 1)[1]
+            ext = fname.rsplit(".", 1)[-1]
             if ext != "py":
                 resources.append(fname)
 


### PR DESCRIPTION
When looping over the list of files in MANIFEST it rsplits the file suffix
and compares against `py`, however this results in an error for file without
a suffix such as `LICENSE`. By changing index from `1` to `-1` it supports
files with and without suffix.