### PR TITLE
logging: Add Textcolor-Option

### DIFF
--- a/logging/logging.py
+++ b/logging/logging.py
@@ -1,5 +1,20 @@
 import sys
 
+class s:
+   CYAN = str('\033[96m')
+   BLUE = str('\033[94m')
+   GREEN = str('\033[92m')
+   YELLOW = str('\033[93m')
+   RED = str('\033[91m')
+   BOLD = str('\033[1m')
+   WHITE = str('\033[37m')
+   BLACK = str('\033[30m')
+   ON_RED = str('\033[41m')
+   MSG = str('\033[37m')
+   NAME = str('\033[96m')
+   END = str('\033[0m')
+
+
 CRITICAL = 50
 ERROR    = 40
 WARNING  = 30
@@ -7,12 +22,20 @@ INFO     = 20
 DEBUG    = 10
 NOTSET   = 0
 
-_level_dict = {
+_nocolor_dict = {
     CRITICAL: "CRIT",
     ERROR: "ERROR",
     WARNING: "WARN",
     INFO: "INFO",
     DEBUG: "DEBUG",
+}
+
+_level_dict = {
+    CRITICAL: s.ON_RED+s.BOLD+s.WHITE+"CRIT"+s.END,
+    ERROR: s.BOLD+s.RED+"ERROR"+s.END,
+    WARNING: s.BOLD+s.YELLOW+"WARN"+s.END,
+    INFO: s.BLUE+"INFO"+s.END,
+    DEBUG: s.GREEN+"DEBUG"+s.END,
 }
 
 _stream = sys.stderr
@@ -22,7 +45,7 @@ class Logger:
     level = NOTSET
 
     def __init__(self, name):
-        self.name = name
+        self.name = s.NAME+name+s.END
 
     def _level_str(self, level):
         l = _level_dict.get(level)
@@ -40,9 +63,9 @@ class Logger:
         if level >= (self.level or _level):
             _stream.write("%s:%s:" % (self._level_str(level), self.name))
             if not args:
-                print(msg, file=_stream)
+                print(s.MSG+msg+s.END, file=_stream)
             else:
-                print(msg % args, file=_stream)
+                print(s.MSG+msg+s.END, file=_stream)
 
     def debug(self, msg, *args):
         self.log(DEBUG, msg, *args)
@@ -83,11 +106,14 @@ def info(msg, *args):
 def debug(msg, *args):
     getLogger(None).debug(msg, *args)
 
-def basicConfig(level=INFO, filename=None, stream=None, format=None):
-    global _level, _stream
+def basicConfig(level=INFO, filename=None, stream=None, format=None, color=False):
+    global _level, _stream, _level_dict
     _level = level
     if stream:
         _stream = stream
+    if not color:
+        _level_dict = _nocolor_dict
+        s.NAME, s.MSG = "", ""
     if filename is not None:
         print("logging.basicConfig: filename arg is not supported")
     if format is not None:


### PR DESCRIPTION
Since this module only prints out the Log to the console, I added nonobligatory Colored-Text Option. Making it easier to distinguish Log from the normal Print outputs.
Adding the "color" argument to the basigConfig function. Which is set to "False" by default.
`def basicConfig(level=INFO, filename=None, stream=None, format=None, color=False):`

Self-explanatory image of the functionality: 
<img width="792" alt="Log-Example" src="https://user-images.githubusercontent.com/29541742/64427977-cfc41100-d0b2-11e9-83a8-f88d35e6f724.png">


