### PR TITLE
upip numerical version extention

### DIFF
--- a/upip/upip.py
+++ b/upip/upip.py
@@ -254,7 +254,7 @@ def parse_version(string):
         Parse Version
 
         This function takes a string and gets all versioning infromation for
-        pypi according to PEP508
+        pypi according to PEP508 and PEP440
 
         Written by: Stephan Kashkarov 2019
     """
@@ -268,6 +268,7 @@ def parse_version(string):
         versioning = versioning.split(";")[0].split(",")
 
     # split version parameters ie "<=3.2.3, > 2.7.1, !=3.0.1" -> [('<=', [3, 2, 3]), ('>', [2, 7, 1]), ('!=', [3, 0, 1])]
+    # Does not support letters in the version name (i.e. 1.2.5rc3)
     parameters = []
     index = 0
     while len(versioning):
@@ -288,7 +289,7 @@ def parse_version(string):
 
     # reduces list using operators
     while parameters:
-        operator, version = parameters.pop()
+        operator, version = parameters.pop(0)
         if operator == "==" or operator == "===":
             if version in versions:
                 pkg['version'] = version
@@ -320,22 +321,21 @@ def ver_list_cmp(list1, list2):
         This function takes two version lists (i.e [3,2,7]) and
         returns -1 if list zero is larger and 1 list one is larger
         otherwise the function will return 0
+
+        Written by: Stephan Kashkarov 2019
     """
 
     # ensures verion lengths are equivelent
     if len(list1) != len(list2):
-        print("diff")
         if len(list1) > len(list2):
             list2.append(0)
             list1 = list1[:len(list2)]
         else:
             list1.append(0)
             list2 = list2[:len(list1)]
-        print(f"new: {list1}, {list2}")
 
     # checks versions iteratatively
     for x, y in zip(list1, list2):
-        print(x, y)
         if x > y:
             return -1
         elif y > x:

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -294,6 +294,7 @@ def parse_version(string):
             # Check wildcard
             if "*" in versions:
                 parameters.append((">=", version[:-1])) # queues wildcard
+                continue
 
             # direct version
             elif version in versions:
@@ -303,7 +304,7 @@ def parse_version(string):
         # removes wildcards
         version.pop()
 
-        elif operator == ">":
+        if operator == ">":
             versions = filter(versions, lambda x: ver_list_cmp(version, x) > 0)
 
         elif operator == ">=":
@@ -318,6 +319,7 @@ def parse_version(string):
         # Arbitrary operator
         elif operator == "~=":
             parameters.extend([("<=", version[:-1]), (">=", version)])
+            continue
 
     # returns max suitable operator
     pkg['version'] = max(versions)

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -321,6 +321,8 @@ def parse_version(string):
             parameters.extend([("<=", version[:-1]), (">=", version)])
             continue
 
+    if not versions:
+        raise NoVersionError
     # returns max suitable operator
     pkg['version'] = max(versions)
     return pkg, data

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -305,16 +305,16 @@ def parse_version(string):
         version.pop()
 
         if operator == ">":
-            versions = filter(versions, lambda x: ver_list_cmp(version, x) > 0)
-
-        elif operator == ">=":
-            versions = filter(versions, lambda x: ver_list_cmp(version, x) >= 0)
-
-        elif operator == "<":
             versions = filter(versions, lambda x: ver_list_cmp(version, x) < 0)
 
-        elif operator == "<=":
+        elif operator == ">=":
             versions = filter(versions, lambda x: ver_list_cmp(version, x) <= 0)
+
+        elif operator == "<":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) > 0)
+
+        elif operator == "<=":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) >= 0)
 
         # Arbitrary operator
         elif operator == "~=":

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -267,7 +267,7 @@ def parse_version(string):
     if ";" in versioning:
         versioning = versioning.split(";")[0].split(",")
 
-    # split version parameters ie "<=3.2.3, > 2.7.1, !=3.0.1" -> [('<=', '3.2.3'), ('>', '2.7.1'), ('!=', '3.0.1')]
+    # split version parameters ie "<=3.2.3, > 2.7.1, !=3.0.1" -> [('<=', [3, 2, 3]), ('>', [2, 7, 1]), ('!=', [3, 0, 1])]
     parameters = []
     index = 0
     while len(versioning):
@@ -281,10 +281,10 @@ def parse_version(string):
         while substr[index - 1] not in ['=', '>', '<']:
             index -= 1
         operation = substr[:index].strip()
-        version = substr[index:].strip()
+        version = [int(x) for x in substr[index:].strip().split('.')]  # "3.0.1" -> [3, 0, 1]
         parameters.append((operation, version))
 
-    versions = data["releases"].keys()
+    versions = [[int(y) for y in x.split(".")] for x in data["releases"].keys()]
 
     for operator, version in parameters:
         if operator == "==":
@@ -292,11 +292,41 @@ def parse_version(string):
                 pkg['version'] = version
                 return pkg, data
 
+        if operator == ">":
+            pass
 
 
     # return pkg, data
 
+def ver_list_cmp(list1, list2):
+    """
+        version list compaire
 
+        This function takes two version lists (i.e [3,2,7]) and
+        returns 0 if list zero is larger and 1 list one is larger
+        otherwise the function will return -1
+    """
+
+    # ensures verion lengths are equivelent
+    if len(list1) != len(list2):
+        print("diff")
+        if len(list1) > len(list2):
+            list2.append(0)
+            list1 = list1[:len(list2)]
+        else:
+            list1.append(0)
+            list2 = list2[:len(list1)]
+        print(f"new: {list1}, {list2}")
+
+    # checks versions iteratatively
+    for x, y in zip(list1, list2):
+        print(x, y)
+        if x > y:
+            return 0
+        elif y > x:
+            return 1
+
+    return -1
 
 def help():
     print("""\

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -286,25 +286,40 @@ def parse_version(string):
 
     versions = [[int(y) for y in x.split(".")] for x in data["releases"].keys()]
 
-    for operator, version in parameters:
-        if operator == "==":
+    # reduces list using operators
+    while parameters:
+        operator, version = parameters.pop()
+        if operator == "==" or operator == "===":
             if version in versions:
                 pkg['version'] = version
                 return pkg, data
 
-        if operator == ">":
-            pass
+        elif operator == ">":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) > 0)
 
+        elif operator == ">=":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) >= 0)
 
-    # return pkg, data
+        elif operator == "<":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) < 0)
+
+        elif operator == "<=":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) <= 0)
+
+        elif operator == "~=":
+            parameters.extend([("<=", version[:-1]), (">=", version)])
+
+    # returns max suitable operator
+    pkg['version'] = max(versions)
+    return pkg, data
 
 def ver_list_cmp(list1, list2):
     """
         version list compaire
 
         This function takes two version lists (i.e [3,2,7]) and
-        returns 0 if list zero is larger and 1 list one is larger
-        otherwise the function will return -1
+        returns -1 if list zero is larger and 1 list one is larger
+        otherwise the function will return 0
     """
 
     # ensures verion lengths are equivelent
@@ -322,11 +337,11 @@ def ver_list_cmp(list1, list2):
     for x, y in zip(list1, list2):
         print(x, y)
         if x > y:
-            return 0
+            return -1
         elif y > x:
             return 1
 
-    return -1
+    return 0
 
 def help():
     print("""\

--- a/upip/upip.py
+++ b/upip/upip.py
@@ -285,7 +285,7 @@ def parse_version(string):
         version = [int(x) if x != "*" else "*" for x in substr[index:].strip().split('.')]  # "3.0.1" -> [3, 0, 1] && "4.2.*" -> [4, 2, "*"]
         parameters.append((operation, version))
 
-    versions = [[int(y) for y in x.split(".")] for x in data["releases"].keys()]
+    versions = [[int(y) for y in x.split(".")] for x in data["releases"].keys()] # makes list of versions in ver_list format
 
     # reduces list using operators
     while parameters:
@@ -293,37 +293,27 @@ def parse_version(string):
         if operator == "==":
             # Check wildcard
             if "*" in versions:
-                for v in versions:
-                    if len(v) > len(version):
-                        if v[:len(version)] != version:
-                            versions.remove(v)
+                parameters.append((">=", version[:-1])) # queues wildcard
 
             # direct version
             elif version in versions:
                 pkg['version'] = version
                 return pkg, data
         
-        # more then operators
-        elif ">" in operator:
-            # removes wildcards
-            version.pop()
+        # removes wildcards
+        version.pop()
 
-            if operator == ">":
-                versions = filter(versions, lambda x: ver_list_cmp(version, x) > 0)
+        elif operator == ">":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) > 0)
 
-            elif operator == ">=":
-                versions = filter(versions, lambda x: ver_list_cmp(version, x) >= 0)
+        elif operator == ">=":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) >= 0)
 
-        # less then operator
-        if "<" in operator:
-            # removes wildcards
-            version.replace("*", 0)
+        elif operator == "<":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) < 0)
 
-            if operator == "<":
-                versions = filter(versions, lambda x: ver_list_cmp(version, x) < 0)
-
-            elif operator == "<=":
-                versions = filter(versions, lambda x: ver_list_cmp(version, x) <= 0)
+        elif operator == "<=":
+            versions = filter(versions, lambda x: ver_list_cmp(version, x) <= 0)
 
         # Arbitrary operator
         elif operator == "~=":


### PR DESCRIPTION
I have written the functionality to provide a numerical package version according to PEP508 and PEP440. I have not implemented letter based versioning systems such as >=1.2.5rc5 but versions can have infinite subversions. The implemented operators include >, >=, <, <=, ==, ~=, ===, !=. Extra arguments are dumped as I am unsure how meta tags for upython are handled, i.e. `upip install example;python_version<"2.7"`. Wildcard characters are also included. Thanks for looking at this pull request