### PR TITLE
umqtt.simple: Close old socket on connect

### DIFF
--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -53,6 +53,8 @@ class MQTTClient:
         self.lw_retain = retain
 
     def connect(self, clean_session=True):
+        if self.sock:
+            self.sock.close()
         self.sock = socket.socket()
         addr = socket.getaddrinfo(self.server, self.port)[0][-1]
         self.sock.connect(addr)


### PR DESCRIPTION
This closes the old socket of the client if one is present during a connection attempt to prevent the initialization of multiple sockets when the function is called repeatedly. It comes in handy if properly disconnecting from the broker isn't possible.