### PR TITLE
Add os.dup2 for atomic file descriptor changes

### DIFF
--- a/os/os/__init__.py
+++ b/os/os/__init__.py
@@ -45,6 +45,7 @@ if libc:
     write_ = libc.func("i", "write", "iPi")
     close_ = libc.func("i", "close", "i")
     dup_ = libc.func("i", "dup", "i")
+    dup2_ = libc.func("i", "dup2", "ii")
     access_ = libc.func("i", "access", "si")
     fork_ = libc.func("i", "fork", "")
     pipe_ = libc.func("i", "pipe", "p")
@@ -185,6 +186,11 @@ def close(fd):
 
 def dup(fd):
     r = dup_(fd)
+    check_error(r)
+    return r
+
+def dup2(oldfd, newfd):
+    r = dup2_(oldfd, newfd)
     check_error(r)
     return r
 


### PR DESCRIPTION
From the dup(2) manpages(http://man7.org/linux/man-pages/man2/dup.2.html):
```
The steps of closing and reusing the file descriptor newfd are
performed atomically.  This is important, because trying to implement
equivalent functionality using close(2) and dup() would be subject to
race conditions, whereby newfd might be reused between the two steps.
```