### PR TITLE
umqtt.robust: fix check_msg() hanging after reconnect

### DIFF
--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -191,7 +191,7 @@ class MQTTClient:
             pid = pid[0] << 8 | pid[1]
             sz -= 2
         msg = self.sock.read(sz)
-        self.cb(topic, msg)
+        self.cb(topic, msg, op&1==1)
         if op & 6 == 2:
             pkt = bytearray(b"\x40\x02\0\0")
             struct.pack_into("!H", pkt, 2, pid)

--- a/umqtt.simple/umqtt/simple.py
+++ b/umqtt.simple/umqtt/simple.py
@@ -41,6 +41,9 @@ class MQTTClient:
                 return n
             sh += 7
 
+    def _next_pid(self):
+        self.pid = ((self.pid)%0xffff)+1
+
     def set_callback(self, f):
         self.cb = f
 
@@ -123,7 +126,7 @@ class MQTTClient:
         self.sock.write(pkt, i + 1)
         self._send_str(topic)
         if qos > 0:
-            self.pid += 1
+            self._next_pid()
             pid = self.pid
             struct.pack_into("!H", pkt, 0, pid)
             self.sock.write(pkt, 2)
@@ -144,7 +147,7 @@ class MQTTClient:
     def subscribe(self, topic, qos=0):
         assert self.cb is not None, "Subscribe callback is not set"
         pkt = bytearray(b"\x82\0\0\0")
-        self.pid += 1
+        self._next_pid()
         struct.pack_into("!BH", pkt, 1, 2 + 2 + len(topic) + 1, self.pid)
         #print(hex(len(pkt)), hexlify(pkt, ":"))
         self.sock.write(pkt)


### PR DESCRIPTION
The patch consist of memorizing the fact that the reconnect comes from a check_msg() call.

Tested for month here on esp8266 connected to a mosquitto server on the local network