### PR TITLE
copy: Add stub dispatch_table for use in copy().

### DIFF
--- a/copy/copy.py
+++ b/copy/copy.py
@@ -52,6 +52,7 @@ import types
 #import weakref
 #from copyreg import dispatch_table
 #import builtins
+dispatch_table = {}
 
 class Error(Exception):
     pass


### PR DESCRIPTION
`copy()` depends on `dispatch_table` which was previously / cpython imported from `copyreg` module. 
Without this module the attribute is not available when `copy()` function tries to check it.