### PR TITLE
close socket after each request

### DIFF
--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -95,6 +95,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
                     raise ValueError("Unsupported " + l)
             elif l.startswith(b"Location:") and not 200 <= status <= 299:
                 raise NotImplementedError("Redirects not yet supported")
+        s.close()
     except OSError:
         s.close()
         raise


### PR DESCRIPTION
When running this library on a LoPy4 it crashes after a couple of requests. The problem has been described here: https://forum.pycom.io/topic/1747/urequests-with-ussl-causes-an-oserror/4 and it seems to be that the memory is limited, and the socket needs to be closed after each request. I have added a s.close() , and the library is now working for me.