### PR TITLE
urequests: fix empty body response with some formatings

### DIFF
--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -87,7 +87,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
             reason = l[2].rstrip()
         while True:
             l = s.readline()
-            if not l or l == b"\r\n":
+            if not l or l == b"\n" or l == b"\r\n":
                 break
             #print(l)
             if l.startswith(b"Transfer-Encoding:"):


### PR DESCRIPTION
Some engines generate responses with break lines using only \n instead of \r\n, so in order to support that kind of request response body format I have also added this check. Without the fix the body response comes empty as it does not stop on the if and empty the buffer with `readline()`