### PR TITLE
Fixing TypeError in error message

### DIFF
--- a/urequests/urequests.py
+++ b/urequests/urequests.py
@@ -92,7 +92,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
             #print(l)
             if l.startswith(b"Transfer-Encoding:"):
                 if b"chunked" in l:
-                    raise ValueError("Unsupported " + l)
+                    raise ValueError("Unsupported " + str(l))
             elif l.startswith(b"Location:") and not 200 <= status <= 299:
                 raise NotImplementedError("Redirects not yet supported")
     except OSError:


### PR DESCRIPTION
It is pretty annoying to get
```
File "urequests.py", line 95, in request
TypeError: can't convert 'bytes' object to str implicitly
```
instead of being told what was not supported. :-) Fixing