### PR TITLE
ffilib:fix Traceback in Unix port due to missing 'maxsize'

### DIFF
--- a/ffilib/ffilib.py
+++ b/ffilib/ffilib.py
@@ -1,4 +1,4 @@
-import sys
+import usys as sys
 try:
     import ffi
 except ImportError:

--- a/ffilib/ffilib.py
+++ b/ffilib/ffilib.py
@@ -1,4 +1,4 @@
-import usys as sys
+import sys
 try:
     import ffi
 except ImportError:

--- a/sys/sys.py
+++ b/sys/sys.py
@@ -1,0 +1,1 @@
+from usys import *


### PR DESCRIPTION
>>> from machine import I2C
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/.micropython/lib/machine/__init__.py", line 2, in <module>
  File "/root/.micropython/lib/machine/timer.py", line 1, in <module>
  File "/root/.micropython/lib/ffilib.py", line 43, in <module>
AttributeError: 'module' object has no attribute 'maxsize'