### PR TITLE
unix-ffi/datetime: make the package importable

### DIFF
--- a/unix-ffi/datetime/datetime.py
+++ b/unix-ffi/datetime/datetime.py
@@ -958,6 +958,10 @@ class tzinfo:
 
     __slots__ = ()
 
+    def __new__(self, *args, **kwargs):
+        """Constructor."""
+        return object.__new__(self)
+
     def tzname(self, dt):
         "datetime -> string name of time zone."
         raise NotImplementedError("tzinfo subclass must override tzname()")


### PR DESCRIPTION
-add constructor to tzinfo class so that the package can be imported without errors