### PR TITLE
micropython/bluetooth/aioble: subscribe must register the connection.

### DIFF
--- a/micropython/bluetooth/aioble/README.md
+++ b/micropython/bluetooth/aioble/README.md
@@ -118,7 +118,7 @@ temp_char = await temp_service.characteristic(_ENV_SENSE_TEMP_UUID)
 
 data = await temp_char.read(timeout_ms=1000)
 
-temp_char.subscribe(notify=True)
+await temp_char.subscribe(notify=True)
 while True:
     data = await temp_char.notified()
 ```

--- a/micropython/bluetooth/aioble/aioble/client.py
+++ b/micropython/bluetooth/aioble/aioble/client.py
@@ -377,6 +377,9 @@ class ClientCharacteristic(BaseClientCharacteristic):
     # Write to the Client Characteristic Configuration to subscribe to
     # notify/indications for this characteristic.
     async def subscribe(self, notify=True, indicate=False):
+        # Ensure that the generated notifications are dispatched in case the app
+        # hasn't awaited on notified/indicated yet.
+        self._register_with_connection()
         if cccd := await self.descriptor(bluetooth.UUID(_CCCD_UUID)):
             await cccd.write(struct.pack("<H", _CCCD_NOTIFY * notify + _CCCD_INDICATE * indicate))
         else:


### PR DESCRIPTION
Reported by @andrewleech

If a client subscribes and then a notification arrives before they await notified(), then they won't see the notification as it won't get dispatched to any registered Characteristic objects.

With this fix, in this scenario the first await to notified() will now immediately return the value that arrived in the meantime.