### PR TITLE
aioble updates - generic attribute service/service changed

### DIFF
--- a/micropython/bluetooth/aioble/aioble/device.py
+++ b/micropython/bluetooth/aioble/aioble/device.py
@@ -262,7 +262,7 @@ class DeviceConnection:
     def timeout(self, timeout_ms):
         return DeviceTimeout(self, timeout_ms)
 
-    async def exchange_mtu(self, mtu=None):
+    async def exchange_mtu(self, mtu=None, timeout_ms=1000):
         if not self.is_connected():
             raise ValueError("Not connected")
 
@@ -271,7 +271,8 @@ class DeviceConnection:
 
         self._mtu_event = self._mtu_event or asyncio.ThreadSafeFlag()
         ble.gattc_exchange_mtu(self._conn_handle)
-        await self._mtu_event.wait()
+        with self.timeout(timeout_ms):
+            await self._mtu_event.wait()
         return self.mtu
 
     # Wait for a connection on an L2CAP connection-oriented-channel.

--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -190,10 +190,11 @@ class Characteristic(BaseCharacteristic):
                     # Timeout.
                     return
                 # See TODO in __init__ to support multiple concurrent indications.
-                assert connection == characteristic._indicate_connection
-                characteristic._indicate_status = status
-                characteristic._indicate_event.set()
-
+                if connection == characteristic._indicate_connection:
+                    characteristic._indicate_status = status
+                    characteristic._indicate_event.set()
+                else:
+                    log_warn("Received indication for unexpected connection")
 
 class BufferedCharacteristic(Characteristic):
     def __init__(self, service, uuid, max_len=20, append=False):

--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -83,11 +83,15 @@ class BaseCharacteristic:
             return ble.gatts_read(self._value_handle)
 
     # Write value to local db.
-    def write(self, data):
+    def write(self, data, send_update=False):
         if self._value_handle is None:
             self._initial = data
         else:
-            ble.gatts_write(self._value_handle, data)
+            if send_update:
+                # Send_update arg only added in 1.17, don't pass this arg unless required.
+                ble.gatts_write(self._value_handle, data, True)
+            else:
+                ble.gatts_write(self._value_handle, data)
 
     # Wait for a write on this characteristic.
     # Returns the device that did the write.

--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -228,9 +228,13 @@ class Descriptor(BaseCharacteristic):
 
 # Turn the Service/Characteristic/Descriptor classes into a registration tuple
 # and then extract their value handles.
-def register_services(*services):
+def register_services(*services, include_gatt_svc=True):
     ensure_active()
     _registered_characteristics.clear()
+    if include_gatt_svc:
+        from .services.generic_attribute_service import GenericAttributeService
+        gatt_svc = GenericAttributeService(services)
+        services = (gatt_svc,) + services
     handles = ble.gatts_register_services(tuple(s._tuple() for s in services))
     for i in range(len(services)):
         service_handles = handles[i]

--- a/micropython/bluetooth/aioble/aioble/services/generic_attribute_service.py
+++ b/micropython/bluetooth/aioble/aioble/services/generic_attribute_service.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+#   @file
+#   @brief: Bluetooth Generic Attribute Service
+#
+# Copyright (c) 2021, Planet Innovation
+# 436 Elgar Road, Box Hill, 3128, VIC, Australia
+# Phone: +61 3 9945 7510
+#
+# The copyright to the computer program(s) herein is the property of
+# Planet Innovation, Australia.
+# The program(s) may be used and/or copied only with the written permission
+# of Planet Innovation or in accordance with the terms and conditions
+# stipulated in the agreement/contract under which the program(s) have been
+# supplied.
+#
+
+import ustruct
+import bluetooth
+from aioble import Service, Characteristic, security
+from aioble.core import ble, log_info
+from hashlib import md5
+from ubinascii import hexlify
+try:
+    from utyping import *
+except:
+    pass
+
+
+class GenericAttributeService(Service):
+    # Generic Attribute service UUID
+    SERVICE_UUID = bluetooth.UUID(0x1801)
+
+    # Service Changed Characteristic
+    UUID_SERVICE_CHANGED = bluetooth.UUID(0x2A05)
+    # Database Hash Characteristic (New in BLE 5.1)
+    UUID_DATABASE_HASH = bluetooth.UUID(0x2B2A)
+
+    def __init__(self, services: Tuple[Service]):
+
+        super().__init__(self.SERVICE_UUID)
+
+        # Database hash is typically a 128bit AES-CMAC value, however
+        # is generally only monitored for change as an opaque value.
+        # MD5 is also 128 bit, faster and builtin
+        hasher = md5()
+        for service in services:
+            for char in service.characteristics:
+                hasher.update(char.uuid)
+                hasher.update(str(char.flags))
+        self.digest = hasher.digest()
+        self.hexdigest = hexlify(self.digest).decode()
+        log_info("BLE: DB Hash=", self.hexdigest)
+        security.current_digest = self.hexdigest
+        security.gatt_svc = self
+
+        self.SERVICE_CHANGED = Characteristic(
+            service=self,
+            uuid=self.UUID_SERVICE_CHANGED,
+            read=True,
+            indicate=True,
+            initial=''
+        )
+
+        self.DATABASE_HASH = Characteristic(
+            service=self,
+            uuid=self.UUID_DATABASE_HASH,
+            read=True,
+            initial=self.digest
+        )
+
+    def send_changed(self, connection, start=0, end=0xFFFF):
+        self.SERVICE_CHANGED.write(ustruct.pack('!HH', start, end))
+        log_info("Indicate Service Changed")
+        ble.gatts_indicate(connection._conn_handle, self.SERVICE_CHANGED._value_handle)


### PR DESCRIPTION
This MR includes a few changes in a working branch.
* https://github.com/micropython/micropython-lib/pull/437
* aioble: Add timeout to device.exchange_mtu()
* aioble/security: Store secrets in list. 
    - Ensure newest keys are stored at top to be used/loaded first.
* aioble/server: Log warning on out-of-order indication.
* aioble/service_changed: Add support for BLE service_changed. 

Service Changed is an important feature for any project where the BLE pairing&bonding is used and services/characteristics could be changed, either from modifying application settings, to rolling out in-field updates.

Most BLE clients (eg android/ios phones) will cache the service discovery when bonded to a device. This means that if these are later changed on the device, the phone doesn't know about it and will send the wrong data to a different characteristic.

The BLE service: `Generic Attribute Service` contains a characteristic that can be indicated immediately after connection to tell the client that some/all the services/characteristics have changed and should be re-discovered.

For newer (BLE5.1) clients, there's a separate Database Hash characteristic that contains a hash of all services/characteristics configuration which the client can check directly and check against its stored hash for any change, also prompting re-discovery.

Both are supported in this change, however it needs the existing default gatt service entry removed with https://github.com/micropython/micropython/pull/7675