### PR TITLE
pprint: add simple pprint(), pp(), and pformat() methods for simple container types

### DIFF
--- a/python-stdlib/pprint/manifest.py
+++ b/python-stdlib/pprint/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.0.4")
+metadata(version="0.1.0")
 
 module("pprint.py")

--- a/python-stdlib/pprint/pprint.py
+++ b/python-stdlib/pprint/pprint.py
@@ -53,9 +53,13 @@ def pp(obj, *args, sort_dicts=False, **kwargs):
 def pprint(obj, stream=None, indent=1, depth=1, sort_dicts=True):
     """Simple implementation of a pretty-printer.
 
-    For simplicity, this does not recurse down.  It does not produce the same
-    output as the CPython implementation.  Instead, it is intended to simply
-    expand lists and dictionaries to multiple lines for easy viewing.
+    It does not produce the same output as the CPython implementation, but it's
+    close.  Instead, it is intended to simply expand lists and dictionaries to
+    multiple lines for easy viewing.  When the recursion depth has been
+    reached, the elements will be printed with repl(item) instead of the
+    CPython implementation of eliding the results (e.g., "{...}").  This is
+    because this implementation is not as safe as the CPython implementation
+    for deep recursion, which is detailed two paragraphs lower.
 
     Only expands containers.  Currently supported containers are set, list,
     dict, and tuple.

--- a/python-stdlib/pprint/pprint.py
+++ b/python-stdlib/pprint/pprint.py
@@ -1,11 +1,36 @@
 from io import StringIO as _StringIO
 from sys import stdout as _stdout
+from machine import const as _const
+
+
+class PrettyPrinter:
+    """A convenience class for storing pretty printer settings.
+
+    Wraps around pformat() and pprint() calls, saving the settings for each
+    call.  For parameter descriptions, look at pprint() documentation.
+    """
+
+    def __init__(self, indent=1, stream=None, sort_dicts=True):
+        self.indent = indent
+        self.stream = stream if stream else _stdout
+        self.sort_dicts = sort_dicts
+
+    def pformat(self, obj):
+        """Call pformat() function with cached constructor values"""
+        return pformat(obj, indent=self.indent, sort_dicts=self.sort_dicts)
+
+    def pprint(self, obj):
+        """Call pprint() function with cached constructor values"""
+        pprint(obj, stream=self.stream, indent=self.indent, sort_dicts=self.sort_dicts)
 
 
 def pformat(obj, indent=1, sort_dicts=True):
-    """Simply calls pprint() but capturing prints into a string and returning"""
+    """Simply calls pprint() but capturing prints into a string and returning.
+
+    Does not add a newline to the end like pprint() does.
+    """
     stream = _StringIO()
-    pprint(obj, stream=stream, indent=indent, sort_dicts=sort_dicts)
+    _pprint_impl(obj, stream=stream, indent=indent, sort_dicts=sort_dicts)
     return stream.getvalue()
 
 
@@ -20,31 +45,29 @@ def pprint(obj, stream=None, indent=1, sort_dicts=True):
     For simplicity, this does not recurse down.  It does not produce the same
     output as the CPython implementation.  Instead, it is intended to simply
     expand lists and dictionaries to multiple lines for easy viewing.
+
+    Only expands containers.  Currently supported containers are set, list,
+    dict, and tuple.
+
+    stream
+        The desired output stream.  If omitted (or False), the standard output
+        stream will be used.
+
+    indent
+        Number of space to indent for each level of nesting.
+
+    sort_dicts
+        If true, dict keys are sorted.  You must ensure that the dicts
+        encountered can be sorted against each other (for example, int cannot
+        compare against a tuple, both of which can be dict keys).
+
+    Note: raises TypeError if sort_dicts is on and sorting finds a type
+    mismatch
     """
     if not stream:
         stream = _stdout
-    islist = isinstance(obj, list)
-    isset = isinstance(obj, set)
-    isdict = isinstance(obj, dict)
-    if (islist or isset or isdict) and len(obj) > 1:
-        print("[" if islist else "{", end="", file=stream)
-        print(" " * (indent - 1), end="", file=stream)
-        items = obj
-        if isdict:
-            items = obj.items()
-            if sort_dicts:
-                items = sorted(items, key=lambda x: x[0])
-        first = True
-        for i in items:
-            if not first:
-                print(",\n" + " " * indent, end="", file=stream)
-            first = False
-            print(f"{repr(i[0])}: {repr(i[1])}" if isdict else repr(i), end="", file=stream)
-        print("]" if islist else "}", file=stream)
-    else:
-        # for non-builtin types or builtin types with only one element, just
-        # print
-        print(repr(obj), file=stream)
+    _pprint_impl(obj, stream, indent, sort_dicts)
+    stream.write("\n")  # end in a newline
 
 
 def ppdir(obj, *args, hidden=False, **kwargs):
@@ -57,3 +80,75 @@ def ppdir(obj, *args, hidden=False, **kwargs):
     Additional arguments are forwarded on to pprint().
     """
     pprint([x for x in dir(obj) if not x.startswith("_")], *args, **kwargs)
+
+
+# Private implementation
+
+
+def _pprint_impl(obj, stream, indent, sort_dicts):
+    type_code = _container_type(obj)
+    if type_code != _NONCONTAINER and len(obj) > 1:
+        if type_code & _SIMPLE:
+            _pprint_simple_container(obj, type_code, stream, indent, sort_dicts)
+        else:  # type_code & _DICT:
+            _pprint_dict(obj, type_code, stream, indent, sort_dicts)
+    else:
+        # directly print noncontainers or containers with one or fewer elements
+        stream.write(repr(obj))
+
+
+_NONCONTAINER = _const(0)
+_SIMPLE = _const(1)
+_LIST = _const(2)
+_SET = _const(4)
+_TUPLE = _const(8)
+_DICT = _const(16)
+
+
+def _container_type(obj):
+    typ = type(obj)
+    if issubclass(typ, list):
+        return _LIST | _SIMPLE
+    if issubclass(typ, set):
+        return _SET | _SIMPLE
+    if issubclass(typ, dict):
+        return _DICT
+    if issubclass(typ, tuple):
+        return _TUPLE | _SIMPLE
+    return _NONCONTAINER
+
+
+def _pprint_simple_container(obj, type_code, stream, indent, sort_dicts):
+    if type_code & _LIST:
+        chars = "[]"
+    elif type_code & _TUPLE:
+        chars = "()"
+    else:  # type_code & _SET:
+        chars = "{}"
+
+    stream.write(chars[0] + " " * (indent - 1))
+    first = True
+    for item in obj:
+        if not first:
+            stream.write(",\n" + " " * indent)
+        first = False
+        # TODO: would recurse here
+        stream.write(repr(item))
+    stream.write(chars[1])
+
+
+def _pprint_dict(obj, type_code, stream, indent, sort_dicts):
+    stream.write("{" + " " * (indent - 1))
+    first = True
+    items = obj.items()
+    if sort_dicts:
+        items = sorted(items, key=lambda x: x[0])
+    for key, val in items:
+        if not first:
+            stream.write(",\n" + " " * indent)
+        first = False
+        # TODO: would recurse here
+        stream.write(repr(key))
+        stream.write(": ")
+        stream.write(repr(val))
+    stream.write("}")

--- a/python-stdlib/pprint/pprint.py
+++ b/python-stdlib/pprint/pprint.py
@@ -1,6 +1,59 @@
-def pformat(obj):
-    return repr(obj)
+from io import StringIO as _StringIO
+from sys import stdout as _stdout
 
 
-def pprint(obj):
-    print(repr(obj))
+def pformat(obj, indent=1, sort_dicts=True):
+    """Simply calls pprint() but capturing prints into a string and returning"""
+    stream = _StringIO()
+    pprint(obj, stream=stream, indent=indent, sort_dicts=sort_dicts)
+    return stream.getvalue()
+
+
+def pp(obj, *args, sort_dicts=False, **kwargs):
+    """Same as pprint() except the default value of sort_dicts is False"""
+    pprint(obj, *args, sort_dicts=sort_dicts, **kwargs)
+
+
+def pprint(obj, stream=None, indent=1, sort_dicts=True):
+    """Simple implementation of a pretty-printer.
+
+    For simplicity, this does not recurse down.  It does not produce the same
+    output as the CPython implementation.  Instead, it is intended to simply
+    expand lists and dictionaries to multiple lines for easy viewing.
+    """
+    if not stream:
+        stream = _stdout
+    islist = isinstance(obj, list)
+    isset = isinstance(obj, set)
+    isdict = isinstance(obj, dict)
+    if (islist or isset or isdict) and len(obj) > 1:
+        print("[" if islist else "{", end="", file=stream)
+        print(" " * (indent - 1), end="", file=stream)
+        items = obj
+        if isdict:
+            items = obj.items()
+            if sort_dicts:
+                items = sorted(items, key=lambda x: x[0])
+        first = True
+        for i in items:
+            if not first:
+                print(",\n" + " " * indent, end="", file=stream)
+            first = False
+            print(f"{repr(i[0])}: {repr(i[1])}" if isdict else repr(i), end="", file=stream)
+        print("]" if islist else "}", file=stream)
+    else:
+        # for non-builtin types or builtin types with only one element, just
+        # print
+        print(repr(obj), file=stream)
+
+
+def ppdir(obj, *args, hidden=False, **kwargs):
+    """Like calling pprint(dir(obj))
+
+    This method is for listing the available attributes and methods of an
+    object.  The main difference is that you can hide elements that start with
+    an underscore by specifying hidden=False, which is the default.
+
+    Additional arguments are forwarded on to pprint().
+    """
+    pprint([x for x in dir(obj) if not x.startswith("_")], *args, **kwargs)

--- a/python-stdlib/pprint/pprint.py
+++ b/python-stdlib/pprint/pprint.py
@@ -1,10 +1,13 @@
-import io as _io
-import sys as _sys
+import io
+import sys
+from micropython import const
 
-try:
-    from micropython import const as _const
-except ImportError:
-    _const = lambda x: x
+_NONCONTAINER = const(0)
+_SIMPLE = const(1)
+_LIST = const(2)
+_SET = const(4)
+_TUPLE = const(8)
+_DICT = const(16)
 
 
 class PrettyPrinter:
@@ -17,7 +20,7 @@ class PrettyPrinter:
     def __init__(self, indent=1, depth=1, stream=None, sort_dicts=True):
         self._indent = indent
         self._depth = depth
-        self._stream = stream if stream else _sys.stdout
+        self._stream = stream if stream else sys.stdout
         self._sort_dicts = sort_dicts
 
     def pformat(self, obj):
@@ -40,7 +43,7 @@ def pformat(obj, indent=1, depth=1, sort_dicts=True):
 
     Does not add a newline to the end like pprint() does.
     """
-    stream = _io.StringIO()
+    stream = io.StringIO()
     _pprint_impl(obj, stream, 0, sort_dicts, depth, 0, indent)
     return stream.getvalue()
 
@@ -93,7 +96,7 @@ def pprint(obj, stream=None, indent=1, depth=1, sort_dicts=True):
     mismatch
     """
     if not stream:
-        stream = _sys.stdout
+        stream = sys.stdout
     _pprint_impl(obj, stream, 0, sort_dicts, depth, 0, indent)
     stream.write("\n")  # end in a newline
 
@@ -143,14 +146,6 @@ def _pprint_impl(obj, stream, indent, sort_dicts, maxlevel, level, indent_per_le
                 level + 1,
                 indent_per_level,
             )
-
-
-_NONCONTAINER = _const(0)
-_SIMPLE = _const(1)
-_LIST = _const(2)
-_SET = _const(4)
-_TUPLE = _const(8)
-_DICT = _const(16)
 
 
 def _container_type(obj):

--- a/python-stdlib/pprint/test_pprint.py
+++ b/python-stdlib/pprint/test_pprint.py
@@ -1,0 +1,481 @@
+import pprint
+from io import StringIO
+import sys
+
+# setup
+
+
+def pformat_as_pprint(*args, stream=None, **kwargs):
+    """Use pformat() to provide pprint() interface"""
+    val = pprint.pformat(*args, **kwargs)
+    if not stream:
+        stream = sys.stdout
+    stream.write(val)
+    stream.write("\n")
+
+
+def pp_as_pprint(*args, sort_dicts=True, **kwargs):
+    """Use pp() to provide pprint() interface"""
+    pprint.pp(*args, sort_dicts=sort_dicts, **kwargs)
+
+
+def PrettyPrinter_pprint_as_pprint(obj, *args, **kwargs):
+    """Use PrettyPrinter.pprint() to provide pprint() interface"""
+    p = pprint.PrettyPrinter(*args, **kwargs)
+    p.pprint(obj)
+
+
+def PrettyPrinter_pformat_as_pprint(obj, *args, **kwargs):
+    """Use PrettyPrinter.pformat() to provide pprint() interface"""
+    p = pprint.PrettyPrinter(*args, **kwargs)
+    val = p.pformat(obj)
+    p._stream.write(val)
+    p._stream.write("\n")
+
+
+pprint_func_map = {
+    "pprint": pprint.pprint,
+    "pformat": pformat_as_pprint,
+    "pp": pp_as_pprint,
+    "PrettyPrinter.pprint": PrettyPrinter_pprint_as_pprint,
+    "PrettyPrinter.pformat": PrettyPrinter_pformat_as_pprint,
+}
+
+
+def pprint_func_to_pformat_func(pprint_func):
+    """Convert pprint() interface into the pformat() interface"""
+
+    def pformat_func(*args, **kwargs):
+        sio = StringIO()
+        pprint_func(*args, stream=sio, **kwargs)
+        return sio.getvalue()[:-1]  # return all but the trailing newline
+
+    return pformat_func
+
+
+pformat_func_map = {key: pprint_func_to_pformat_func(val) for key, val in pprint_func_map.items()}
+# reset the pformat function instead of two indirect wrappers
+pformat_func_map["pformat"] = pprint.pformat
+
+
+# test functions
+
+
+def test_stream(name, pprint_func):
+    # TODO: somehow test that stream=None goes to stdout
+    # This method of mocking stdout works in CPython, but not Micropython
+    # try:
+    #    # mock standard out
+    #    oldstdout = sys.stdout
+    #    sys.stdout = sio
+    #    # run test
+    #    #...
+    # finally:
+    #    # restore standard out
+    #    sys.stdout = oldstdout
+
+    sio = StringIO()
+    sio2 = StringIO()
+    gen_msg = lambda s: f"{name}: {repr(s.getvalue())}"
+    pprint_func("abcdefg", stream=sio2)
+    assert sio.getvalue() == "", gen_msg(sio)
+    assert sio2.getvalue() == "'abcdefg'\n", gen_msg(sio2)
+    pprint_func("zxcvbnm", stream=sio)
+    assert sio.getvalue() == "'zxcvbnm'\n", gen_msg(sio)
+    assert sio2.getvalue() == "'abcdefg'\n", gen_msg(sio2)
+
+
+def test_non_containers(name, pformat_func):
+    class A:
+        def __repr__(self):
+            return "\n\ncocoa\n\nnuts\n\n"
+
+    assert pformat_func(1) == repr(1), f"{name}, {pformat_func(1)}"
+    assert pformat_func(1.423) == repr(1.423), name
+    assert pformat_func("hello") == repr("hello"), name
+    assert pformat_func(b"my grail diary") == repr(b"my grail diary"), name
+    assert pformat_func(A()) == repr(A()), name
+
+
+def test_empty_containers(name, pformat_func):
+    assert pformat_func(list()) == "[]", name
+    assert pformat_func(tuple()) == "()", name
+    assert pformat_func(set()) == "set()", name
+    assert pformat_func(dict()) == "{}", name
+
+
+def test_containers_with_one_item(name, pformat_func):
+    assert pformat_func(["abc"]) == repr(["abc"]), name
+    assert pformat_func({123}) == repr({123}), name
+    assert pformat_func({"abc": 123}) == repr({"abc": 123}), name
+    assert pformat_func(("my tuple",)) == repr(("my tuple",)), name
+
+
+X = {
+    "widget": {
+        "debug": "on",
+        "window": {
+            "title": "Sample Konfabulator Widget",
+            "name": "main_window",
+            "width": 500,
+            "height": 500,
+        },
+        "image": {
+            "src": "Images/Sun.png",
+            "name": "sun1",
+            "hOffset": 250,
+            "vOffset": 250,
+            "alignment": "center",
+        },
+        "text": {
+            "data": "Click Here",
+            "size": 36,
+            "style": "bold",
+            "name": "text1",
+            "hOffset": 250,
+            "vOffset": 100,
+            "alignment": "center",
+            "onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;",
+        },
+    },
+    "name": "King Arthur",
+}
+
+expected_X_depth0_indent0 = repr(X)
+expected_X_depth0_indent1 = expected_X_depth0_indent0
+expected_X_depth0_indent2 = expected_X_depth0_indent0
+expected_X_depth0_indent3 = expected_X_depth0_indent0
+
+# note: these are sorted by key and will be tested that way
+expected_X_depth1_indent0 = (
+    "{'name': " + repr(X["name"]) + ",\n" + "'widget': " + repr(X["widget"]) + "}"
+)
+expected_X_depth1_indent1 = (
+    "{'name': " + repr(X["name"]) + ",\n" + " 'widget': " + repr(X["widget"]) + "}"
+)
+expected_X_depth1_indent2 = (
+    "{ 'name': " + repr(X["name"]) + ",\n" + "  'widget': " + repr(X["widget"]) + "}"
+)
+expected_X_depth1_indent3 = (
+    "{  'name': " + repr(X["name"]) + ",\n" + "   'widget': " + repr(X["widget"]) + "}"
+)
+
+expected_X_depth2_indent0 = (
+    "{'name': 'King Arthur',\n"
+    "'widget': {'debug': "
+    + repr(X["widget"]["debug"])
+    + ",\n"
+    + "          'image': "
+    + repr(X["widget"]["image"])
+    + ",\n"
+    + "          'text': "
+    + repr(X["widget"]["text"])
+    + ",\n"
+    + "          'window': "
+    + repr(X["widget"]["window"])
+    + "}}"
+)
+expected_X_depth2_indent1 = (
+    "{'name': 'King Arthur',\n"
+    " 'widget': {'debug': "
+    + repr(X["widget"]["debug"])
+    + ",\n"
+    + "            'image': "
+    + repr(X["widget"]["image"])
+    + ",\n"
+    + "            'text': "
+    + repr(X["widget"]["text"])
+    + ",\n"
+    + "            'window': "
+    + repr(X["widget"]["window"])
+    + "}}"
+)
+expected_X_depth2_indent2 = (
+    "{ 'name': 'King Arthur',\n"
+    "  'widget': { 'debug': "
+    + repr(X["widget"]["debug"])
+    + ",\n"
+    + "              'image': "
+    + repr(X["widget"]["image"])
+    + ",\n"
+    + "              'text': "
+    + repr(X["widget"]["text"])
+    + ",\n"
+    + "              'window': "
+    + repr(X["widget"]["window"])
+    + "}}"
+)
+expected_X_depth2_indent3 = (
+    "{  'name': 'King Arthur',\n"
+    "   'widget': {  'debug': "
+    + repr(X["widget"]["debug"])
+    + ",\n"
+    + "                'image': "
+    + repr(X["widget"]["image"])
+    + ",\n"
+    + "                'text': "
+    + repr(X["widget"]["text"])
+    + ",\n"
+    + "                'window': "
+    + repr(X["widget"]["window"])
+    + "}}"
+)
+
+expected_X_depth3_indent0 = (
+    "{'name': 'King Arthur',\n"
+    "'widget': {'debug': 'on',\n"
+    "          'image': {'alignment': "
+    + repr(X["widget"]["image"]["alignment"])
+    + ",\n"
+    + "                   'hOffset': "
+    + repr(X["widget"]["image"]["hOffset"])
+    + ",\n"
+    "                   'name': " + repr(X["widget"]["image"]["name"]) + ",\n"
+    "                   'src': " + repr(X["widget"]["image"]["src"]) + ",\n"
+    "                   'vOffset': " + repr(X["widget"]["image"]["vOffset"]) + "},\n"
+    "          'text': {'alignment': "
+    + repr(X["widget"]["text"]["alignment"])
+    + ",\n"
+    + "                  'data': "
+    + repr(X["widget"]["text"]["data"])
+    + ",\n"
+    + "                  'hOffset': "
+    + repr(X["widget"]["text"]["hOffset"])
+    + ",\n"
+    + "                  'name': "
+    + repr(X["widget"]["text"]["name"])
+    + ",\n"
+    + "                  'onMouseUp': "
+    + repr(X["widget"]["text"]["onMouseUp"])
+    + ",\n"
+    + "                  'size': "
+    + repr(X["widget"]["text"]["size"])
+    + ",\n"
+    + "                  'style': "
+    + repr(X["widget"]["text"]["style"])
+    + ",\n"
+    + "                  'vOffset': "
+    + repr(X["widget"]["text"]["vOffset"])
+    + "},\n"
+    + "          'window': {'height': "
+    + repr(X["widget"]["window"]["height"])
+    + ",\n"
+    + "                    'name': "
+    + repr(X["widget"]["window"]["name"])
+    + ",\n"
+    + "                    'title': "
+    + repr(X["widget"]["window"]["title"])
+    + ",\n"
+    + "                    'width': "
+    + repr(X["widget"]["window"]["width"])
+    + "}}}"
+)
+expected_X_depth3_indent1 = (
+    "{'name': 'King Arthur',\n"
+    " 'widget': {'debug': 'on',\n"
+    "            'image': {'alignment': "
+    + repr(X["widget"]["image"]["alignment"])
+    + ",\n"
+    + "                      'hOffset': "
+    + repr(X["widget"]["image"]["hOffset"])
+    + ",\n"
+    "                      'name': " + repr(X["widget"]["image"]["name"]) + ",\n"
+    "                      'src': " + repr(X["widget"]["image"]["src"]) + ",\n"
+    "                      'vOffset': " + repr(X["widget"]["image"]["vOffset"]) + "},\n"
+    "            'text': {'alignment': "
+    + repr(X["widget"]["text"]["alignment"])
+    + ",\n"
+    + "                     'data': "
+    + repr(X["widget"]["text"]["data"])
+    + ",\n"
+    + "                     'hOffset': "
+    + repr(X["widget"]["text"]["hOffset"])
+    + ",\n"
+    + "                     'name': "
+    + repr(X["widget"]["text"]["name"])
+    + ",\n"
+    + "                     'onMouseUp': "
+    + repr(X["widget"]["text"]["onMouseUp"])
+    + ",\n"
+    + "                     'size': "
+    + repr(X["widget"]["text"]["size"])
+    + ",\n"
+    + "                     'style': "
+    + repr(X["widget"]["text"]["style"])
+    + ",\n"
+    + "                     'vOffset': "
+    + repr(X["widget"]["text"]["vOffset"])
+    + "},\n"
+    + "            'window': {'height': "
+    + repr(X["widget"]["window"]["height"])
+    + ",\n"
+    + "                       'name': "
+    + repr(X["widget"]["window"]["name"])
+    + ",\n"
+    + "                       'title': "
+    + repr(X["widget"]["window"]["title"])
+    + ",\n"
+    + "                       'width': "
+    + repr(X["widget"]["window"]["width"])
+    + "}}}"
+)
+expected_X_depth3_indent2 = (
+    "{ 'name': 'King Arthur',\n"
+    "  'widget': { 'debug': 'on',\n"
+    "              'image': { 'alignment': "
+    + repr(X["widget"]["image"]["alignment"])
+    + ",\n"
+    + "                         'hOffset': "
+    + repr(X["widget"]["image"]["hOffset"])
+    + ",\n"
+    "                         'name': " + repr(X["widget"]["image"]["name"]) + ",\n"
+    "                         'src': " + repr(X["widget"]["image"]["src"]) + ",\n"
+    "                         'vOffset': " + repr(X["widget"]["image"]["vOffset"]) + "},\n"
+    "              'text': { 'alignment': "
+    + repr(X["widget"]["text"]["alignment"])
+    + ",\n"
+    + "                        'data': "
+    + repr(X["widget"]["text"]["data"])
+    + ",\n"
+    + "                        'hOffset': "
+    + repr(X["widget"]["text"]["hOffset"])
+    + ",\n"
+    + "                        'name': "
+    + repr(X["widget"]["text"]["name"])
+    + ",\n"
+    + "                        'onMouseUp': "
+    + repr(X["widget"]["text"]["onMouseUp"])
+    + ",\n"
+    + "                        'size': "
+    + repr(X["widget"]["text"]["size"])
+    + ",\n"
+    + "                        'style': "
+    + repr(X["widget"]["text"]["style"])
+    + ",\n"
+    + "                        'vOffset': "
+    + repr(X["widget"]["text"]["vOffset"])
+    + "},\n"
+    + "              'window': { 'height': "
+    + repr(X["widget"]["window"]["height"])
+    + ",\n"
+    + "                          'name': "
+    + repr(X["widget"]["window"]["name"])
+    + ",\n"
+    + "                          'title': "
+    + repr(X["widget"]["window"]["title"])
+    + ",\n"
+    + "                          'width': "
+    + repr(X["widget"]["window"]["width"])
+    + "}}}"
+)
+expected_X_depth3_indent3 = (
+    "{  'name': 'King Arthur',\n"
+    "   'widget': {  'debug': 'on',\n"
+    "                'image': {  'alignment': "
+    + repr(X["widget"]["image"]["alignment"])
+    + ",\n"
+    + "                            'hOffset': "
+    + repr(X["widget"]["image"]["hOffset"])
+    + ",\n"
+    "                            'name': " + repr(X["widget"]["image"]["name"]) + ",\n"
+    "                            'src': " + repr(X["widget"]["image"]["src"]) + ",\n"
+    "                            'vOffset': " + repr(X["widget"]["image"]["vOffset"]) + "},\n"
+    "                'text': {  'alignment': "
+    + repr(X["widget"]["text"]["alignment"])
+    + ",\n"
+    + "                           'data': "
+    + repr(X["widget"]["text"]["data"])
+    + ",\n"
+    + "                           'hOffset': "
+    + repr(X["widget"]["text"]["hOffset"])
+    + ",\n"
+    + "                           'name': "
+    + repr(X["widget"]["text"]["name"])
+    + ",\n"
+    + "                           'onMouseUp': "
+    + repr(X["widget"]["text"]["onMouseUp"])
+    + ",\n"
+    + "                           'size': "
+    + repr(X["widget"]["text"]["size"])
+    + ",\n"
+    + "                           'style': "
+    + repr(X["widget"]["text"]["style"])
+    + ",\n"
+    + "                           'vOffset': "
+    + repr(X["widget"]["text"]["vOffset"])
+    + "},\n"
+    + "                'window': {  'height': "
+    + repr(X["widget"]["window"]["height"])
+    + ",\n"
+    + "                             'name': "
+    + repr(X["widget"]["window"]["name"])
+    + ",\n"
+    + "                             'title': "
+    + repr(X["widget"]["window"]["title"])
+    + ",\n"
+    + "                             'width': "
+    + repr(X["widget"]["window"]["width"])
+    + "}}}"
+)
+
+expected_X_depth4_indent0 = expected_X_depth3_indent0
+expected_X_depth4_indent1 = expected_X_depth3_indent1
+expected_X_depth4_indent2 = expected_X_depth3_indent2
+expected_X_depth4_indent3 = expected_X_depth3_indent3
+
+expected_X_depth_None_indent0 = expected_X_depth3_indent0
+expected_X_depth_None_indent1 = expected_X_depth3_indent1
+expected_X_depth_None_indent2 = expected_X_depth3_indent2
+expected_X_depth_None_indent3 = expected_X_depth3_indent3
+
+
+def test_depth_and_indent(name, pformat_func):
+    gen_msg = lambda d, i: f"{name} depth={d} indent={i}:\n{pformat_func(X, depth=d, indent=i)}\n"
+
+    assert pformat_func(X, depth=0, indent=0) == expected_X_depth0_indent0, gen_msg(0, 0)
+    assert pformat_func(X, depth=0, indent=1) == expected_X_depth0_indent1, gen_msg(0, 1)
+    assert pformat_func(X, depth=0, indent=2) == expected_X_depth0_indent2, gen_msg(0, 3)
+    assert pformat_func(X, depth=0, indent=3) == expected_X_depth0_indent3, gen_msg(0, 3)
+
+    assert pformat_func(X, depth=1, indent=0) == expected_X_depth1_indent0, gen_msg(1, 0)
+    assert pformat_func(X, depth=1, indent=1) == expected_X_depth1_indent1, gen_msg(1, 1)
+    assert pformat_func(X, depth=1, indent=2) == expected_X_depth1_indent2, gen_msg(1, 3)
+    assert pformat_func(X, depth=1, indent=3) == expected_X_depth1_indent3, gen_msg(1, 3)
+
+    assert pformat_func(X, depth=2, indent=0) == expected_X_depth2_indent0, gen_msg(2, 0)
+    assert pformat_func(X, depth=2, indent=1) == expected_X_depth2_indent1, gen_msg(2, 1)
+    assert pformat_func(X, depth=2, indent=2) == expected_X_depth2_indent2, gen_msg(2, 3)
+    assert pformat_func(X, depth=2, indent=3) == expected_X_depth2_indent3, gen_msg(2, 3)
+
+    assert pformat_func(X, depth=3, indent=0) == expected_X_depth3_indent0, gen_msg(3, 0)
+    assert pformat_func(X, depth=3, indent=1) == expected_X_depth3_indent1, gen_msg(3, 1)
+    assert pformat_func(X, depth=3, indent=2) == expected_X_depth3_indent2, gen_msg(3, 3)
+    assert pformat_func(X, depth=3, indent=3) == expected_X_depth3_indent3, gen_msg(3, 3)
+
+    assert pformat_func(X, depth=4, indent=0) == expected_X_depth4_indent0, gen_msg(4, 0)
+    assert pformat_func(X, depth=4, indent=1) == expected_X_depth4_indent1, gen_msg(4, 1)
+    assert pformat_func(X, depth=4, indent=2) == expected_X_depth4_indent2, gen_msg(4, 3)
+    assert pformat_func(X, depth=4, indent=3) == expected_X_depth4_indent3, gen_msg(4, 3)
+
+    assert pformat_func(X, depth=None, indent=0) == expected_X_depth_None_indent0, gen_msg(None, 0)
+    assert pformat_func(X, depth=None, indent=1) == expected_X_depth_None_indent1, gen_msg(None, 1)
+    assert pformat_func(X, depth=None, indent=2) == expected_X_depth_None_indent2, gen_msg(None, 3)
+    assert pformat_func(X, depth=None, indent=3) == expected_X_depth_None_indent3, gen_msg(None, 3)
+
+
+# TODO: it would be good to test with sort_dicts=False
+
+
+# run tests
+
+for name, func in pprint_func_map.items():
+    test_stream(name, func)
+
+for name, func in pformat_func_map.items():
+    test_non_containers(name, func)
+    test_empty_containers(name, func)
+    test_depth_and_indent(name, func)
+
+#
+# def test_depth(pformat_func):
+#

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -71,6 +71,7 @@ function ci_package_tests_run {
         python-stdlib/operator/test_operator.py \
         python-stdlib/os-path/test_path.py \
         python-stdlib/pickle/test_pickle.py \
+        python-stdlib/pprint/test_pprint.py \
         python-stdlib/string/test_translate.py \
         python-stdlib/unittest/tests/exception.py \
         unix-ffi/gettext/test_gettext.py \


### PR DESCRIPTION
# Description

This change is to provide a simple implementation of pprint to replace the dummy placeholder implementation.  This implementation should not be too slow nor take too much space on disk nor memory (which is the point of Micropython).

This does not implement the full specification from CPython, but enough for simple uses.  It simply expands lists, sets, and dictionaries to multiple lines if there are more than one element.  Useful for simple printing of lists, dictionaries, and sets to the console, especially when using the REPL.

I added one additional function that is not in the CPython implementation: `ppdir()`.  This is a convenience function for calling `pprint(dir(obj))`, except by default, attributes that begin with an underscore will not be displayed (which can be changed by specifying `hidden=True`).  I personally find this useful when using the REPL, similar to how printing works by default in iPython.  If this additional convenience function is not wanted, it can be removed.

_Note: this is my first pull request for Micropython.  In fact, I've only been playing with it for about a week now.  Please be gentle :)_