### PR TITLE
micropython/aioble: Add l2cap channel disconnected().

### DIFF
--- a/micropython/bluetooth/aioble/README.md
+++ b/micropython/bluetooth/aioble/README.md
@@ -123,6 +123,25 @@ while True:
     data = await temp_char.notified()
 ```
 
+Open L2CAP channels: (Listener)
+
+```py
+channel = await connection.l2cap_accept(_L2CAP_PSN, _L2CAP_MTU)
+buf = bytearray(64)
+n = channel.recvinto(buf)
+channel.send(b'response')
+```
+
+Open L2CAP channels: (Initiator)
+
+```py
+channel = await connection.l2cap_connect(_L2CAP_PSN, _L2CAP_MTU)
+channel.send(b'request')
+buf = bytearray(64)
+n = channel.recvinto(buf)
+```
+
+
 Examples
 --------
 


### PR DESCRIPTION
Allows `await channel.disconnected()`.

This also fixes a bug where connection._l2cap_channel wasn't being set to None on disconnect.

Also updates the README.md to show a minimal l2cap channel example.