### PR TITLE
Add very basic example for mqtt tls

### DIFF
--- a/micropython/umqtt.simple/example_pub_tls.py
+++ b/micropython/umqtt.simple/example_pub_tls.py
@@ -1,0 +1,26 @@
+from umqtt.simple import MQTTClient
+
+# Test reception e.g. with:
+# mosquitto_sub -t foo_topic
+
+
+def main(server="localhost"):
+    # NOTE: Checking server certificate is DISABLE
+    ssl_params = {"server_hostname": server}
+    c = MQTTClient(
+        "umqtt_client",
+        server=server,
+        port=8883,
+        user="<username>",
+        password="<password>",
+        keepalive=60,
+        ssl=True,
+        ssl_params=ssl_params,
+    )
+    c.connect()
+    c.publish(b"foo_topic", b"hello")
+    c.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Tested on next setup: 
- MicroPython 1.17 (without ca-cert's)
- Traefik Proxy 2.5 (Let's Encrypt Cert)
- Mosquitto 2.0.12

Note:
- Unable connect without `ssl_params = {"server_hostname": "<addr>"}`
- If `keepalive` = 0 (default) got `MQTTException(2)`
- Don't found `ssl.CERT_XXX` or `ussl.CERT_XXX` constants, 
  although the constants are specified in the [documentation](https://docs.micropython.org/en/latest/library/ssl.html#constants).
  Only found in inner definitions. But didn't understand how use it outside: 
  https://github.com/micropython/micropython-lib/blob/3c383f6d2864a4b39bbe4ceb2ae8f29b519c9afe/python-stdlib/ssl/ssl.py#L5-L7

  Not sure if all of this is bad defaults or this behavior made by design.