### PR TITLE
aioble: Add shutdown handler for cleanup.

### DIFF
--- a/micropython/bluetooth/aioble/README.md
+++ b/micropython/bluetooth/aioble/README.md
@@ -123,6 +123,25 @@ while True:
     data = await temp_char.notified()
 ```
 
+Open L2CAP channels: (Listener)
+
+```py
+channel = await connection.l2cap_accept(_L2CAP_PSN, _L2CAP_MTU)
+buf = bytearray(64)
+n = channel.recvinto(buf)
+channel.send(b'response')
+```
+
+Open L2CAP channels: (Initiator)
+
+```py
+channel = await connection.l2cap_connect(_L2CAP_PSN, _L2CAP_MTU)
+channel.send(b'request')
+buf = bytearray(64)
+n = channel.recvinto(buf)
+```
+
+
 Examples
 --------
 

--- a/micropython/bluetooth/aioble/aioble/central.py
+++ b/micropython/bluetooth/aioble/aioble/central.py
@@ -86,7 +86,13 @@ def _central_irq(event, data):
             connection._event.set()
 
 
-register_irq_handler(_central_irq)
+def _central_shutdown():
+    global _active_scanner, _connecting
+    _active_scanner = None
+    _connecting = set()
+
+
+register_irq_handler(_central_irq, _central_shutdown)
 
 
 # Cancel an in-progress scan.

--- a/micropython/bluetooth/aioble/aioble/client.py
+++ b/micropython/bluetooth/aioble/aioble/client.py
@@ -71,7 +71,7 @@ def _client_irq(event, data):
         ClientCharacteristic._on_indicate(conn_handle, value_handle, bytes(indicate_data))
 
 
-register_irq_handler(_client_irq)
+register_irq_handler(_client_irq, None)
 
 
 # Async generator for discovering services, characteristics, descriptors.

--- a/micropython/bluetooth/aioble/aioble/core.py
+++ b/micropython/bluetooth/aioble/aioble/core.py
@@ -43,17 +43,24 @@ def config(*args, **kwargs):
     return ble.config(*args, **kwargs)
 
 
+# Because different functionality is enabled by which files are available the
+# different modules can register their IRQ handlers and shutdown handlers
+# dynamically.
+_irq_handlers = []
+_shutdown_handlers = []
+
+
+def register_irq_handler(irq, shutdown):
+    if irq:
+        _irq_handlers.append(irq)
+    if shutdown:
+        _shutdown_handlers.append(shutdown)
+
+
 def stop():
     ble.active(False)
-
-
-# Because different functionality is enabled by which files are available
-# the different modules can register their IRQ handlers dynamically.
-_irq_handlers = []
-
-
-def register_irq_handler(handler):
-    _irq_handlers.append(handler)
+    for handler in _shutdown_handlers:
+        handler()
 
 
 # Dispatch IRQs to the registered sub-modules.

--- a/micropython/bluetooth/aioble/aioble/device.py
+++ b/micropython/bluetooth/aioble/aioble/device.py
@@ -26,7 +26,7 @@ def _device_irq(event, data):
                 device._mtu_event.set()
 
 
-register_irq_handler(_device_irq)
+register_irq_handler(_device_irq, None)
 
 
 # Context manager to allow an operation to be cancelled by timeout or device

--- a/micropython/bluetooth/aioble/aioble/l2cap.py
+++ b/micropython/bluetooth/aioble/aioble/l2cap.py
@@ -54,7 +54,12 @@ def _l2cap_irq(event, data):
             channel._event.set()
 
 
-register_irq_handler(_l2cap_irq)
+def _l2cap_shutdown():
+    global _listening
+    _listening = False
+
+
+register_irq_handler(_l2cap_irq, _l2cap_shutdown)
 
 
 # The channel was disconnected during a send/recvinto/flush.

--- a/micropython/bluetooth/aioble/aioble/peripheral.py
+++ b/micropython/bluetooth/aioble/aioble/peripheral.py
@@ -63,7 +63,13 @@ def _peripheral_irq(event, data):
             connection._event.set()
 
 
-register_irq_handler(_peripheral_irq)
+def _peripheral_shutdown():
+    global _incoming_connection, _connect_event
+    _incoming_connection = None
+    _connect_event = None
+
+
+register_irq_handler(_peripheral_irq, _peripheral_shutdown)
 
 
 # Advertising payloads are repeated packets of the following form:

--- a/micropython/bluetooth/aioble/aioble/security.py
+++ b/micropython/bluetooth/aioble/aioble/security.py
@@ -149,7 +149,14 @@ def _security_irq(event, data):
         #     log_warn("unknown passkey action")
 
 
-register_irq_handler(_security_irq)
+def _security_shutdown():
+    global _secrets, _modified, _path
+    _secrets = {}
+    _modified = False
+    _path = None
+
+
+register_irq_handler(_security_irq, _security_shutdown)
 
 
 # Use device.pair() rather than calling this directly.

--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -56,7 +56,12 @@ def _server_irq(event, data):
         Characteristic._indicate_done(conn_handle, value_handle, status)
 
 
-register_irq_handler(_server_irq)
+def _server_shutdown():
+    global _registered_characteristics
+    _registered_characteristics = {}
+
+
+register_irq_handler(_server_irq, _server_shutdown)
 
 
 class Service:

--- a/micropython/bluetooth/aioble/multitests/ble_shutdown.py
+++ b/micropython/bluetooth/aioble/multitests/ble_shutdown.py
@@ -1,0 +1,128 @@
+# Test for shutting down and restarting the BLE stack.
+
+import sys
+
+sys.path.append("")
+
+from micropython import const
+import time, machine
+
+import uasyncio as asyncio
+import aioble
+import bluetooth
+
+TIMEOUT_MS = 5000
+
+SERVICE_UUID = bluetooth.UUID("A5A5A5A5-FFFF-9999-1111-5A5A5A5A5A5A")
+CHAR_UUID = bluetooth.UUID("00000000-1111-2222-3333-444444444444")
+
+_L2CAP_PSN = const(22)
+_L2CAP_MTU = const(128)
+
+
+# Acting in peripheral role.
+async def instance0_task():
+    multitest.globals(BDADDR=aioble.config("mac"))
+    multitest.next()
+
+    for i in range(3):
+        service = aioble.Service(SERVICE_UUID)
+        characteristic = aioble.Characteristic(service, CHAR_UUID, read=True)
+        aioble.register_services(service)
+
+        # Write initial characteristic value.
+        characteristic.write("periph{}".format(i))
+
+        multitest.broadcast("connect-{}".format(i))
+
+        # Wait for central to connect to us.
+        print("advertise")
+        connection = await aioble.advertise(
+            20_000, adv_data=b"\x02\x01\x06\x04\xffMPY", timeout_ms=TIMEOUT_MS
+        )
+        print("connected")
+
+        multitest.broadcast("connected-{}".format(i))
+
+        for j in range(3):
+            channel = await connection.l2cap_accept(_L2CAP_PSN, _L2CAP_MTU)
+            print("channel accepted")
+
+            buf = bytearray(10)
+            n = await channel.recvinto(buf)
+            print("recv", n, buf[:n])
+
+            multitest.broadcast("recv-{}-{}".format(i, j))
+
+            await channel.disconnected(5000)
+            print("channel disconnected")
+
+        # Wait for the central to disconnect.
+        await connection.disconnected(timeout_ms=TIMEOUT_MS)
+        print("disconnected")
+
+        # Shutdown aioble + modbluetooth.
+        print("shutdown")
+        aioble.stop()
+
+
+def instance0():
+    try:
+        asyncio.run(instance0_task())
+    finally:
+        aioble.stop()
+
+
+# Acting in central role.
+async def instance1_task():
+    multitest.next()
+
+    for i in range(3):
+        multitest.wait("connect-{}".format(i))
+        # Connect to peripheral.
+        print("connect")
+        device = aioble.Device(*BDADDR)
+        connection = await device.connect(timeout_ms=TIMEOUT_MS)
+
+        multitest.wait("connected-{}".format(i))
+
+        # Discover characteristics.
+        service = await connection.service(SERVICE_UUID)
+        print("service", service.uuid)
+        characteristic = await service.characteristic(CHAR_UUID)
+        print("characteristic", characteristic.uuid)
+
+        # Issue read of characteristic, should get initial value.
+        print("read", await characteristic.read(timeout_ms=TIMEOUT_MS))
+
+        for j in range(3):
+            print("connecting channel")
+            channel = await connection.l2cap_connect(_L2CAP_PSN, _L2CAP_MTU)
+            print("channel connected")
+
+            await channel.send("l2cap-{}-{}".format(i, j))
+            await channel.flush()
+
+            multitest.wait("recv-{}-{}".format(i, j))
+
+            print("disconnecting channel")
+            await channel.disconnect()
+            print("channel disconnected")
+
+            await asyncio.sleep_ms(100)
+
+        # Disconnect from peripheral.
+        print("disconnect")
+        await connection.disconnect(timeout_ms=TIMEOUT_MS)
+        print("disconnected")
+
+        # Shutdown aioble.
+        print("shutdown")
+        aioble.stop()
+
+
+def instance1():
+    try:
+        asyncio.run(instance1_task())
+    finally:
+        aioble.stop()

--- a/micropython/bluetooth/aioble/multitests/ble_shutdown.py.exp
+++ b/micropython/bluetooth/aioble/multitests/ble_shutdown.py.exp
@@ -1,0 +1,98 @@
+--- instance0 ---
+advertise
+connected
+channel accepted
+recv 9 bytearray(b'l2cap-0-0')
+channel disconnected
+channel accepted
+recv 9 bytearray(b'l2cap-0-1')
+channel disconnected
+channel accepted
+recv 9 bytearray(b'l2cap-0-2')
+channel disconnected
+disconnected
+shutdown
+advertise
+connected
+channel accepted
+recv 9 bytearray(b'l2cap-1-0')
+channel disconnected
+channel accepted
+recv 9 bytearray(b'l2cap-1-1')
+channel disconnected
+channel accepted
+recv 9 bytearray(b'l2cap-1-2')
+channel disconnected
+disconnected
+shutdown
+advertise
+connected
+channel accepted
+recv 9 bytearray(b'l2cap-2-0')
+channel disconnected
+channel accepted
+recv 9 bytearray(b'l2cap-2-1')
+channel disconnected
+channel accepted
+recv 9 bytearray(b'l2cap-2-2')
+channel disconnected
+disconnected
+shutdown
+--- instance1 ---
+connect
+service UUID('a5a5a5a5-ffff-9999-1111-5a5a5a5a5a5a')
+characteristic UUID('00000000-1111-2222-3333-444444444444')
+read b'periph0'
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+disconnect
+disconnected
+shutdown
+connect
+service UUID('a5a5a5a5-ffff-9999-1111-5a5a5a5a5a5a')
+characteristic UUID('00000000-1111-2222-3333-444444444444')
+read b'periph1'
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+disconnect
+disconnected
+shutdown
+connect
+service UUID('a5a5a5a5-ffff-9999-1111-5a5a5a5a5a5a')
+characteristic UUID('00000000-1111-2222-3333-444444444444')
+read b'periph2'
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+connecting channel
+channel connected
+disconnecting channel
+channel disconnected
+disconnect
+disconnected
+shutdown


### PR DESCRIPTION
This allows `aioble.stop()` to reset all internal state.

(The reported issue here was that after a shutdown, l2cap's internal `_listening` state was still true, so it never re-started accepting).

Note this includes the two commits from #457 as the test depends on it.