### PR TITLE
aioble/server: Log warning on out-of-order indication.

### DIFF
--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -231,10 +231,11 @@ class Characteristic(BaseCharacteristic):
                     # Timeout.
                     return
                 # See TODO in __init__ to support multiple concurrent indications.
-                assert connection == characteristic._indicate_connection
-                characteristic._indicate_status = status
-                characteristic._indicate_event.set()
-
+                if connection == characteristic._indicate_connection:
+                    characteristic._indicate_status = status
+                    characteristic._indicate_event.set()
+                else:
+                    log_warn("Received indication for unexpected connection")
 
 class BufferedCharacteristic(Characteristic):
     def __init__(self, service, uuid, max_len=20, append=False):


### PR DESCRIPTION
The assert in indicate_done has the potential to crash an application when indication mis-behave or were not expected.
In our experience it's been safer to just ignore and log these rather than throw an exception that cannot be easily caught.