### PR TITLE
aioble/security: Only schedule save when needed.

### DIFF
--- a/micropython/bluetooth/aioble-security/manifest.py
+++ b/micropython/bluetooth/aioble-security/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.0")
+metadata(version="0.2.1")
 
 require("aioble-core")
 

--- a/micropython/bluetooth/aioble/aioble/security.py
+++ b/micropython/bluetooth/aioble/aioble/security.py
@@ -57,10 +57,6 @@ def _save_secrets(arg=None):
 
     _path = _path or _DEFAULT_PATH
 
-    if not _modified:
-        # Only save if the secrets changed.
-        return
-
     with open(_path, "w") as f:
         # Convert bytes to hex strings (otherwise JSON will treat them like
         # strings).
@@ -106,8 +102,9 @@ def _security_irq(event, data):
             _secrets[key] = value
 
         # Queue up a save (don't synchronously write to flash).
-        _modified = True
-        schedule(_save_secrets, None)
+        if not _modified:
+            _modified = True
+            schedule(_save_secrets, None)
 
         return True
 

--- a/micropython/bluetooth/aioble/manifest.py
+++ b/micropython/bluetooth/aioble/manifest.py
@@ -3,7 +3,7 @@
 # code. This allows (for development purposes) all the files to live in the
 # one directory.
 
-metadata(version="0.6.1")
+metadata(version="0.6.2")
 
 # Default installation gives you everything. Install the individual
 # components (or a combination of them) if you want a more minimal install.


### PR DESCRIPTION
Was getting occasional: RuntimeError: schedule queue full if there was a flood of BLE activity.

This also consolidates the disk write for back-to-back security operations which are common during pairing.