### PR TITLE
aioble/server: Add missing import for GattError.

### DIFF
--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -13,6 +13,7 @@ from .core import (
     log_error,
     log_warn,
     register_irq_handler,
+    GattError,
 )
 from .device import DeviceConnection, DeviceTimeout
 


### PR DESCRIPTION
GattError is used in `async def indicate()` but was missing from the import from `.core`