### PR TITLE
python-stdlib/logging: add formatter, handlers

### DIFF
--- a/python-stdlib/logging/example_logging.py
+++ b/python-stdlib/logging/example_logging.py
@@ -1,3 +1,4 @@
+#### Example 1 - basic stream log ####
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -22,3 +23,103 @@ class MyHandler(logging.Handler):
 
 logging.getLogger().addHandler(MyHandler())
 logging.info("Test message7")
+
+
+#### Example 2.1 - simple logger using basicConfig with explicit filename ####
+import logging
+logging.basicConfig(level=logging.INFO, filename="log.txt")
+logging.info("Test message logged into a file")
+
+
+#### Example 2.2 - simple logger using basicConfig with explicit stream ####
+import logging
+import sys
+logging.basicConfig(level=logging.INFO, stream=sys.stderr)
+logging.info("Test message logged into sys.stderr")
+
+
+#### Example 2.3 - simple logger using basicConfig with both stream and filename ####
+import logging
+logging.basicConfig(level=logging.INFO, stream=sys.stderr, filename="log.txt")
+logging.info("Test message logged into a sys.stderr and a file")
+
+
+#### Example 2.4 - simple logger using basicConfig with custom format string, %-style ####
+import logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s", style="%")
+logging.info("Test message logged into sys.stderr, (%d) %s", 42, "foo")
+
+
+#### Example 2.4 - simple logger using basicConfig with custom format string, {-style ####
+import logging
+logging.basicConfig(level=logging.INFO, format="{asctime} {message}", style="{")
+logging.info("Test message logged into sys.stderr")
+
+
+#### Example 3 - Circular Log File with custom parameters ####
+import logging
+log = logging.getLogger("test")
+f = logging.Formatter(fmt="%(asctime)s %(uptime)s %(levelname)s %(message)s")
+h = logging.CircularFileHandler('log.txt', maxsize=512_000)   # 512 kB log file
+h.setFormatter(f)
+log.addHandler(h)
+
+log.info("Test message 1 logged into a file")
+log.info("Test message 2 logged into a file")
+
+
+#### Example 4 - log to a custom log receiver at 198.51.100.1 UDP port 3000 ####
+import logging
+log = logging.getLogger("test")
+log.addHandler(logging.SocketHandler('198.51.100.1', 3000))
+log.info("Test message 1 logged into a UDP socket")
+log.info("Test message 2 logged into a UDP socket")
+
+
+#### Example 5 - log to a custom log receiver at 198.51.100.1 TCP port 3000 ####
+import logging
+import socket
+log = logging.getLogger("test")
+log.addHandler(logging.SocketHandler('198.51.100.1', 3000, socktype=socket.SOCK_STREAM))
+log.info("Test message 1 logged into a TCP socket")
+log.info("Test message 2 logged into a TCP socket")
+
+
+#### Example 6 - log to a syslog server at 198.51.100.1 using UDP transport ####
+import logging
+log = logging.getLogger("test")
+log.addHandler(logging.SysLogHandler('198.51.100.1'))
+log.info("Test message 1 logged to a syslog server over UDP")
+log.info("Test message 2 logged to a syslog server over UDP")
+
+
+#### Example 7 - log to a syslog server at 198.51.100.1 using TCP transport ####
+import logging
+import socket
+import network
+
+log_defaults = {
+    "ip": network.WLAN(network.STA_IF).ifconfig()[0],
+    "hostname": network.WLAN(network.STA_IF).config("dhcp_hostname"),
+}
+
+log = logging.getLogger("test")
+f = logging.Formatter(fmt=logging.SYSLOG_FORMAT, defaults=log_defaults)
+h = logging.SysLogHandler('198.51.100.1', socktype=socket.SOCK_STREAM)
+h.setFormatter(f)
+log.addHandler(h)
+
+log.info("Test message 1 logged to a syslog server over TCP")
+log.info("Test message 2 logged to a syslog server over TCP")
+
+
+#### Example 8 - Circular Log File with custom parameters and {-style formatting string ####
+import logging
+log = logging.getLogger("test")
+f = logging.Formatter(fmt="{asctime} {uptime} {message}", style="{")
+h = logging.CircularFileHandler('log.txt', maxsize=512_000)
+h.setFormatter(f)
+log.addHandler(h)
+
+log.info("Test message 1 logged into a file")
+log.info("Test message 2 logged into a file")

--- a/python-stdlib/logging/logging.py
+++ b/python-stdlib/logging/logging.py
@@ -1,4 +1,7 @@
+import os
+import socket
 import sys
+import time
 
 CRITICAL = 50
 ERROR = 40
@@ -6,6 +9,14 @@ WARNING = 30
 INFO = 20
 DEBUG = 10
 NOTSET = 0
+
+SYSLOG_FORMAT = "<%(pri)s>1 %(asctime)s %(ip)s - - - - %(message)s"
+SYSLOG_DATE_FORMAT = "{0}-{1:02}-{2:02}T{3:02}:{4:02}:{5:02}Z"
+
+DEFAULT_FORMAT = "%(levelname)s:%(name)s:%(message)s"
+DEFAULT_DATE_FORMAT = "%d-%02d-%02d %02d:%02d:%02d"
+
+SYSLOG_LOCAL_0 = 16
 
 _level_dict = {
     CRITICAL: "CRIT",
@@ -15,7 +26,13 @@ _level_dict = {
     DEBUG: "DEBUG",
 }
 
-_stream = sys.stderr
+_syslog_severity = {
+    CRITICAL: 2,
+    ERROR: 3,
+    WARNING: 4,
+    INFO: 6,
+    DEBUG: 7,
+}
 
 
 class LogRecord:
@@ -30,8 +47,11 @@ class Handler:
     def __init__(self):
         pass
 
-    def setFormatter(self, fmtr):
-        pass
+    def setFormatter(self, fmt):
+        self.formatter = fmt
+
+    def format(self, record):
+        return self.formatter.format(record)
 
 
 class Logger:
@@ -57,19 +77,20 @@ class Logger:
 
     def log(self, level, msg, *args):
         if self.isEnabledFor(level):
-            levelname = self._level_str(level)
-            if args:
-                msg = msg % args
+            d = self.record.__dict__
+            d["levelname"] = self._level_str(level)
+            d["levelno"] = level
+            d["msg"] = msg
+            d["args"] = args
+            d["name"] = self.name
+            d["created"] = time.time()
+            d["uptime"] = time.ticks_ms() // 1000
+            d["pri"] = (SYSLOG_LOCAL_0 << 3) + _syslog_severity[level]
             if self.handlers:
-                d = self.record.__dict__
-                d["levelname"] = levelname
-                d["levelno"] = level
-                d["message"] = msg
-                d["name"] = self.name
                 for h in self.handlers:
                     h.emit(self.record)
             else:
-                print(levelname, ":", self.name, ":", msg, sep="", file=_stream)
+                print(_formatter.format(self.record), file=_stream)
 
     def debug(self, msg, *args):
         self.log(DEBUG, msg, *args)
@@ -97,9 +118,152 @@ class Logger:
         self.handlers.append(hndlr)
 
 
+class Formatter():
+    def __init__(self, fmt=None, datefmt=None, style="%", defaults=None):
+        self.fmt = fmt or DEFAULT_FORMAT
+        self.datefmt = datefmt or DEFAULT_DATE_FORMAT
+
+        if style not in ("%", "{"):
+            raise ValueError("Style must be one of: %, {")
+
+        self.style = style
+        self.defaults = defaults if defaults else {}
+
+    def usesTime(self):
+        if self.style == "%":
+            return "%(asctime)" in self.fmt
+        elif self.style == "{":
+            return "{asctime" in self.fmt
+
+    def format(self, record):
+        # merge formatter defaults dict
+        if self.defaults:
+            record.__dict__.update(self.defaults)
+
+        # The message attribute of the record is computed using msg % args.
+        if record.args:
+            record.__dict__["message"] = record.msg % record.args
+        else:
+            record.__dict__["message"] = record.msg
+
+        # If the formatting string contains "(asctime)", formatTime() is called to
+        # format the event time.
+        if self.usesTime():
+            record.__dict__["asctime"] = self.formatTime(record, self.datefmt)
+
+        # The record’s attribute dictionary is used as the operand to a string
+        # formatting operation.
+        if self.style == "%":
+            return self.fmt % record.__dict__
+        else:
+            return self.fmt.format(**record.__dict__)
+
+    def formatTime(self, record, datefmt=None):
+        if not datefmt:
+            datefmt = self.datefmt
+        created = time.gmtime(record.created)[:6]
+        _result = datefmt.format(*created)
+        return _result if _result != datefmt else datefmt % created
+
+    def formatException(self, exc_info):
+        raise NotImplementedError()
+
+    def formatStack(self, stack_info):
+        raise NotImplementedError()
+
+
+class StreamHandler(Handler):
+    def __init__(self, stream=None):
+        self.stream = stream or sys.stderr
+        self.formatter = Formatter()
+
+    def emit(self, record):
+        try:
+            self.stream.write(self.format(record))
+        except OSError:
+            pass
+
+    def flush(self):
+        pass
+
+
+class SocketHandler(Handler):
+    def __init__(self, host, port, socktype=socket.SOCK_DGRAM):
+        if socktype not in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
+            raise ValueError("Invalid socktype")
+
+        self.s = socket.socket(socket.AF_INET, socktype)
+        self.addr = socket.getaddrinfo(host, port)[0][-1]
+        self.terminator = ""
+        self.socktype = socktype
+        self.formatter = Formatter()
+        self.connected = False
+
+        if socktype == socket.SOCK_STREAM:
+            self.terminator = "\n"    # adds PUSH flag to TCP packets
+            try:
+                self.s.connect(self.addr)
+                self.connected = True
+            except OSError as e:
+                if e.errno == 118:
+                    print("No network connection. ", end="")
+                elif e.errno == 113:
+                    print("Connection timeout. ", end="")
+                else:
+                    print("Network error. ", end="")
+                print("Cannot connect to server {0} on TCP port {1}.".format(self.addr[0], self.addr[1]))
+
+    def emit(self, record):
+        try:
+            if self.socktype == socket.SOCK_DGRAM or self.connected:
+                self.s.sendto(self.format(record) + self.terminator, self.addr)
+        except OSError:
+            print("Network error, cannot send log to the server.")
+
+
+class SysLogHandler(SocketHandler):
+    """Mostly RFC 5424 compliant logging handler. Does not implement TLS-based transport."""
+    def __init__(self, host, port=514, socktype=socket.SOCK_DGRAM):
+        super().__init__(host, port, socktype)
+        self.formatter = Formatter(fmt=SYSLOG_FORMAT, datefmt=SYSLOG_DATE_FORMAT, defaults={"ip": "-"})
+
+
+class CircularFileHandler(Handler):
+    def __init__(self, filename, maxsize=128_000):
+        if maxsize < 256:
+            raise ValueError("maxsize must be at least 256 B")
+        self.filename = filename
+        self.maxsize = maxsize
+        self.formatter = Formatter()
+
+        try:
+            # checks if file exists and prevents overwriting it
+            self.pos = os.stat(self.filename)[6]
+            self.file = open(filename, "r+")
+        except OSError:
+            self.pos = 0
+            self.file = open(filename, "w+")
+
+        self.file.seek(self.pos)
+
+    def emit(self, record):
+        message = self.format(record)
+        if len(message) + self.pos > self.maxsize:
+            remaining = self.maxsize - self.pos
+            self.file.write(message[:remaining])
+            message = message[remaining:]
+            self.pos = 0
+            self.file.seek(self.pos)
+        self.file.write(message)
+        self.file.write("\n")
+        self.file.flush()
+        self.pos += len(message) + 1
+
+
+_stream = sys.stderr
 _level = INFO
 _loggers = {}
-
+_formatter = Formatter()
 
 def getLogger(name="root"):
     if name in _loggers:
@@ -108,21 +272,34 @@ def getLogger(name="root"):
     _loggers[name] = l
     return l
 
+def critical(msg, *args):
+    getLogger().critical(msg, *args)
+
+def error(msg, *args):
+    getLogger().error(msg, *args)
+
+def warning(msg, *args):
+    getLogger().warning(msg, *args)
 
 def info(msg, *args):
     getLogger().info(msg, *args)
 
-
 def debug(msg, *args):
     getLogger().debug(msg, *args)
 
-
-def basicConfig(level=INFO, filename=None, stream=None, format=None):
-    global _level, _stream
+def basicConfig(level=INFO, filename=None, stream=None, format=None, datefmt=None, style=None):
+    global _level, _stream, _formatter
     _level = level
+    getLogger().handlers = []
     if stream:
         _stream = stream
-    if filename is not None:
-        print("logging.basicConfig: filename arg is not supported")
-    if format is not None:
-        print("logging.basicConfig: format arg is not supported")
+    if filename:
+        if stream:
+            getLogger().addHandler(StreamHandler(stream))
+        getLogger().addHandler(CircularFileHandler(filename))
+    if format:
+        if not style:
+            raise ValueError("style must be specified when the `format` option is used")
+        _formatter = Formatter(fmt=format, datefmt=datefmt, style=style)
+        for handler in getLogger().handlers:
+            handler.setFormatter(_formatter)

--- a/python-stdlib/logging/metadata.txt
+++ b/python-stdlib/logging/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.3
+version = 0.4

--- a/python-stdlib/logging/setup.py
+++ b/python-stdlib/logging/setup.py
@@ -10,7 +10,7 @@ import sdist_upip
 
 setup(
     name="micropython-logging",
-    version="0.3",
+    version="0.4",
     description="logging module for MicroPython",
     long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
     url="https://github.com/micropython/micropython-lib",


### PR DESCRIPTION
The current version 0.3 of logging.py is very lightweight. Too lightweight, in fact, as all it does out of the box is print into sys.stderr. 

I'm suggesting to add features focused on embedded devices where MicroPython is mostly used. What I mean by that are specifically `CircularFileHandler` and `SysLogHandler`.

`CircularFileHandler` is a handler that writes logs into a file and starts at the beginning of the file once it reaches a defined limit. This prevents the exhaustion of free space that is a risk of naive file handlers. This handler does not overwrite existing log file which preserves logs across device reboots.

`SysLogHandler` extends `SocketHandler` and mostly implements [RFC 5424 - The Syslog Protocol](https://datatracker.ietf.org/doc/html/rfc5424). I say "mostly" because it does not implement TLS transport due to memory constraints. It does implement the protocol message format, and supports both TCP and UDP transport.

To implement `SyslogHandler` custom log message formatting is required. I borrowed `Formatter` from [pycopy-lib/logging/logging/__init__.py](https://github.com/pfalcon/pycopy-lib/blob/master/logging/logging/__init__.py) with minimal changes. I added support for `defaults` argument which allows to pass system IP or hostname into the formatter used for SysLogHandler without adding undesired dependency of `logging` on `network`. Both %-style and {-style string formats are supported.

Finally, I extended `basicConfig` to support `filename` (uses `CircularFileHandler`), `format` and `datefmt` arguments which simplifies the usage of most of the functionality of the module.