### PR TITLE
Unittest updates from pycopy

### DIFF
--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.4.1
+version = 0.4.2

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.3.2
+version = 0.4

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.4.2
+version = 0.4.3

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.4
+version = 0.4.1

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.5
+version = 0.5.1

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.4.3
+version = 0.4.4

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.5.1
+version = 0.5.2

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.6
+version = 0.6.1

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.5.2
+version = 0.6

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.4.4
+version = 0.5

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.6.2
+version = 0.7

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.6.1
+version = 0.6.2

--- a/python-stdlib/unittest/setup.py
+++ b/python-stdlib/unittest/setup.py
@@ -10,7 +10,7 @@ import sdist_upip
 
 setup(
     name="micropython-unittest",
-    version="0.4.1",
+    version="0.7.0",
     description="unittest module for MicroPython",
     long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
     url="https://github.com/micropython/micropython-lib",

--- a/python-stdlib/unittest/setup.py
+++ b/python-stdlib/unittest/setup.py
@@ -10,7 +10,7 @@ import sdist_upip
 
 setup(
     name="micropython-unittest",
-    version="0.3.2",
+    version="0.4",
     description="unittest module for MicroPython",
     long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
     url="https://github.com/micropython/micropython-lib",

--- a/python-stdlib/unittest/setup.py
+++ b/python-stdlib/unittest/setup.py
@@ -10,7 +10,7 @@ import sdist_upip
 
 setup(
     name="micropython-unittest",
-    version="0.4",
+    version="0.4.1",
     description="unittest module for MicroPython",
     long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
     url="https://github.com/micropython/micropython-lib",

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -37,7 +37,7 @@ class TestUnittestAssertions(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.assertNotAlmostEqual(float("inf"), float("inf"))
 
-    def test_AmostEqualWithDelta(self):
+    def test_AlmostEqualWithDelta(self):
         self.assertAlmostEqual(1.1, 1.0, delta=0.5)
         self.assertAlmostEqual(1.0, 1.1, delta=0.5)
         self.assertNotAlmostEqual(1.1, 1.0, delta=0.05)

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -126,6 +126,22 @@ class TestUnittestAssertions(unittest.TestCase):
         if not e1 or "not raised" not in e1.args[0]:
             self.fail("Expected to catch lack of AssertionError from assert in func_under_test")
 
+    @unittest.expectedFailure
+    def testExpectedFailure(self):
+        self.assertEqual(1, 0)
+
+    def testExpectedFailureNot(self):
+        @unittest.expectedFailure
+        def testInner():
+            self.assertEqual(1, 1)
+
+        try:
+            testInner()
+        except:
+            pass
+        else:
+            self.fail("Unexpected success was not detected")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -109,7 +109,7 @@ class TestUnittestAssertions(unittest.TestCase):
 
     @unittest.skip("test of skipping")
     def testSkip(self):
-        self.assertFail("this should be skipped")
+        self.fail("this should be skipped")
 
     def testAssert(self):
 

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -111,6 +111,21 @@ class TestUnittestAssertions(unittest.TestCase):
     def testSkip(self):
         self.assertFail("this should be skipped")
 
+    def testAssert(self):
+
+        e1 = None
+        try:
+
+            def func_under_test(a):
+                assert a > 10
+
+            self.assertRaises(AssertionError, func_under_test, 20)
+        except AssertionError as e:
+            e1 = e
+
+        if not e1 or "not raised" not in e1.args[0]:
+            self.fail("Expected to catch lack of AssertionError from assert in func_under_test")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -21,6 +21,7 @@ class AssertRaisesContext:
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
+        self.exception = exc_value
         if exc_type is None:
             assert False, "%r not raised" % self.expected
         if issubclass(exc_type, self.expected):

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -30,6 +30,9 @@ class AssertRaisesContext:
 
 
 class TestCase:
+    def __init__(self):
+        pass
+
     def fail(self, msg=""):
         assert False, msg
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -199,6 +199,18 @@ def skipUnless(cond, msg):
     return skip(msg)
 
 
+def expectedFailure(test):
+    def test_exp_fail(*args, **kwargs):
+        try:
+            test(*args, **kwargs)
+        except:
+            pass
+        else:
+            assert False, "unexpected success"
+
+    return test_exp_fail
+
+
 class TestSuite:
     def __init__(self):
         self._tests = []

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -180,7 +180,7 @@ class TestRunner:
     def run(self, suite):
         res = TestResult()
         for c in suite._tests:
-            res.exceptions.extend(run_class(c, res))
+            res.exceptions.extend(run_suite(c, res))
 
         print("Ran %d tests\n" % res.testsRun)
         if res.failuresNum > 0 or res.errorsNum > 0:
@@ -216,8 +216,11 @@ def capture_exc(e):
 
 
 # TODO: Uncompliant
-def run_class(c, test_result):
-    o = c()
+def run_suite(c, test_result):
+    if isinstance(c, type):
+        o = c()
+    else:
+        o = c
     set_up = getattr(o, "setUp", lambda: None)
     tear_down = getattr(o, "tearDown", lambda: None)
     exceptions = []

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -33,6 +33,9 @@ class TestCase:
     def __init__(self):
         pass
 
+    def skipTest(self, reason):
+        raise SkipTest(reason)
+
     def fail(self, msg=""):
         assert False, msg
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -195,12 +195,16 @@ class TestSuite:
     def addTest(self, cls):
         self._tests.append(cls)
 
+    def run(self, result):
+        for c in self._tests:
+            result.exceptions.extend(run_suite(c, result))
+        return result
+
 
 class TestRunner:
     def run(self, suite):
         res = TestResult()
-        for c in suite._tests:
-            res.exceptions.extend(run_suite(c, res))
+        suite.run(res)
 
         print("Ran %d tests\n" % res.testsRun)
         if res.failuresNum > 0 or res.errorsNum > 0:

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -243,6 +243,9 @@ class TestRunner:
         return res
 
 
+TextTestRunner = TestRunner
+
+
 class TestResult:
     def __init__(self):
         self.errorsNum = 0

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -43,6 +43,16 @@ class TestCase:
             msg = "%r not expected to be equal %r" % (x, y)
         assert x != y, msg
 
+    def assertLessEqual(self, x, y, msg=None):
+        if msg is None:
+            msg = "%r is expected to be <= %r" % (x, y)
+        assert x <= y, msg
+
+    def assertGreaterEqual(self, x, y, msg=None):
+        if msg is None:
+            msg = "%r is expected to be >= %r" % (x, y)
+        assert x >= y, msg
+
     def assertAlmostEqual(self, x, y, places=None, msg="", delta=None):
         if x == y:
             return

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -170,16 +170,16 @@ def skipUnless(cond, msg):
 
 class TestSuite:
     def __init__(self):
-        self.tests = []
+        self._tests = []
 
     def addTest(self, cls):
-        self.tests.append(cls)
+        self._tests.append(cls)
 
 
 class TestRunner:
     def run(self, suite):
         res = TestResult()
-        for c in suite.tests:
+        for c in suite._tests:
             res.exceptions.extend(run_class(c, res))
 
         print("Ran %d tests\n" % res.testsRun)

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -161,6 +161,9 @@ class TestCase:
 
         assert False, "%r not raised" % exc
 
+    def assertWarns(self, warn):
+        return NullContext()
+
 
 def skip(msg):
     def _decor(fun):

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -41,6 +41,17 @@ class TestCase:
     def __init__(self):
         pass
 
+    def addCleanup(self, func, *args, **kwargs):
+        if not hasattr(self, "_cleanups"):
+            self._cleanups = []
+        self._cleanups.append((func, args, kwargs))
+
+    def doCleanups(self):
+        if hasattr(self, "_cleanups"):
+            while self._cleanups:
+                func, args, kwargs = self._cleanups.pop()
+                func(*args, **kwargs)
+
     def subTest(self, msg=None, **params):
         return NullContext()
 
@@ -271,6 +282,7 @@ def run_suite(c, test_result):
                 continue
             finally:
                 tear_down()
+                o.doCleanups()
     return exceptions
 
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -223,8 +223,10 @@ def run_class(c, test_result):
     exceptions = []
     for name in dir(o):
         if name.startswith("test"):
-            print("%s (%s) ..." % (name, c.__qualname__), end="")
             m = getattr(o, name)
+            if not callable(m):
+                continue
+            print("%s (%s) ..." % (name, c.__qualname__), end="")
             set_up()
             try:
                 test_result.testsRun += 1

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -219,7 +219,7 @@ def main(module="__main__"):
             if isinstance(c, object) and isinstance(c, type) and issubclass(c, TestCase):
                 yield c
 
-    m = __import__(module)
+    m = __import__(module) if isinstance(module, str) else module
     suite = TestSuite()
     for c in test_cases(m):
         suite.addTest(c)

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -302,36 +302,44 @@ def run_suite(c, test_result):
     set_up = getattr(o, "setUp", lambda: None)
     tear_down = getattr(o, "tearDown", lambda: None)
     exceptions = []
+
+    def run_one(m):
+        print("%s (%s) ..." % (name, c.__qualname__), end="")
+        set_up()
+        try:
+            test_result.testsRun += 1
+            m()
+            print(" ok")
+        except SkipTest as e:
+            print(" skipped:", e.args[0])
+            test_result.skippedNum += 1
+        except Exception as ex:
+            ex_str = capture_exc(ex)
+            if isinstance(ex, AssertionError):
+                test_result.failuresNum += 1
+                test_result.failures.append(((name, c), ex_str))
+                print(" FAIL")
+            else:
+                test_result.errorsNum += 1
+                test_result.errors.append(((name, c), ex_str))
+                print(" ERROR")
+            # Uncomment to investigate failure in detail
+            # raise
+        finally:
+            tear_down()
+            o.doCleanups()
+
+    if hasattr(o, "runTest"):
+        name = str(o)
+        run_one(o.runTest)
+        return
+
     for name in dir(o):
         if name.startswith("test"):
             m = getattr(o, name)
             if not callable(m):
                 continue
-            print("%s (%s) ..." % (name, c.__qualname__), end="")
-            set_up()
-            try:
-                test_result.testsRun += 1
-                m()
-                print(" ok")
-            except SkipTest as e:
-                print(" skipped:", e.args[0])
-                test_result.skippedNum += 1
-            except Exception as ex:
-                ex_str = capture_exc(ex)
-                if isinstance(ex, AssertionError):
-                    test_result.failuresNum += 1
-                    test_result.failures.append(((name, c), ex_str))
-                    print(" FAIL")
-                else:
-                    test_result.errorsNum += 1
-                    test_result.errors.append(((name, c), ex_str))
-                    print(" ERROR")
-                # Uncomment to investigate failure in detail
-                # raise
-                continue
-            finally:
-                tear_down()
-                o.doCleanups()
+            run_one(m)
     return exceptions
 
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -126,11 +126,12 @@ class TestCase:
 
         try:
             func(*args, **kwargs)
-            assert False, "%r not raised" % exc
         except Exception as e:
             if isinstance(e, exc):
                 return
             raise
+
+        assert False, "%r not raised" % exc
 
 
 def skip(msg):

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -237,7 +237,7 @@ class TestRunner:
         else:
             msg = "OK"
             if res.skippedNum > 0:
-                msg += " (%d skipped)" % res.skippedNum
+                msg += " (skipped=%d)" % res.skippedNum
             print(msg)
 
         return res

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -29,9 +29,20 @@ class AssertRaisesContext:
         return False
 
 
+class NullContext:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, a, b, c):
+        pass
+
+
 class TestCase:
     def __init__(self):
         pass
+
+    def subTest(self, msg=None, **params):
+        return NullContext()
 
     def skipTest(self, reason):
         raise SkipTest(reason)

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -237,6 +237,8 @@ def run_class(c, test_result):
                 exceptions.append(capture_exc(ex))
                 print(" FAIL")
                 test_result.failuresNum += 1
+                # Uncomment to investigate failure in detail
+                # raise
                 continue
             finally:
                 tear_down()

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -276,6 +276,10 @@ def capture_exc(e):
 
 # TODO: Uncompliant
 def run_suite(c, test_result):
+    if isinstance(c, TestSuite):
+        c.run(test_result)
+        return
+
     if isinstance(c, type):
         o = c()
     else:


### PR DESCRIPTION
The unittest library has had a number of quality-of-life improvements from a couple of contributors on the pycopy fork of micropython-lib. 
This PR cherry picks / rebases them on current master, with black run over each commit interactivly, eg
```
git rebase -Xtheirs -i --exec 'black --fast --line-length=99 python-stdlib/unittest;git add python-stdlib/unittest; git commit --amend --no-edit' 4c98765e
```

For now, this keeps it largely in sync with https://pypi.org/project/micropython-unittest/