### PR TITLE
Unittest: Extend cpython compatility including discover command

### DIFF
--- a/python-stdlib/fnmatch/fnmatch.py
+++ b/python-stdlib/fnmatch/fnmatch.py
@@ -9,11 +9,21 @@ expression.  They cache the compiled regular expressions for speed.
 The function translate(PATTERN) returns a regular expression
 corresponding to PATTERN.  (It does not compile it.)
 """
-import os
-import os.path
 import re
 
-# import functools
+try:
+    from os.path import normcase
+except ImportError:
+
+    def normcase(s):
+        """
+        From os.path.normcase
+        Normalize the case of a pathname. On Windows, convert all characters
+        in the pathname to lowercase, and also convert forward slashes to
+        backward slashes. On other operating systems, return the path unchanged.
+        """
+        return s
+
 
 __all__ = ["filter", "fnmatch", "fnmatchcase", "translate"]
 
@@ -35,8 +45,8 @@ def fnmatch(name, pat):
     if the operating system requires it.
     If you don't want this, use fnmatchcase(FILENAME, PATTERN).
     """
-    name = os.path.normcase(name)
-    pat = os.path.normcase(pat)
+    name = normcase(name)
+    pat = normcase(pat)
     return fnmatchcase(name, pat)
 
 
@@ -59,10 +69,10 @@ def _compile_pattern(pat):
 def filter(names, pat):
     """Return the subset of the list NAMES that match PAT."""
     result = []
-    pat = os.path.normcase(pat)
+    pat = normcase(pat)
     match = _compile_pattern(pat)
     for name in names:
-        if match(os.path.normcase(name)):
+        if match(normcase(name)):
             result.append(name)
     return result
 

--- a/python-stdlib/fnmatch/metadata.txt
+++ b/python-stdlib/fnmatch/metadata.txt
@@ -1,4 +1,4 @@
 srctype = cpython
 type = module
 version = 0.5.2
-depends = os, os.path, re-pcre
+depends = os, os.path

--- a/python-stdlib/fnmatch/metadata.txt
+++ b/python-stdlib/fnmatch/metadata.txt
@@ -1,3 +1,3 @@
 srctype = cpython
 type = module
-version = 0.5.2
+version = 0.6.0

--- a/python-stdlib/fnmatch/metadata.txt
+++ b/python-stdlib/fnmatch/metadata.txt
@@ -1,4 +1,3 @@
 srctype = cpython
 type = module
 version = 0.5.2
-depends = os, os.path

--- a/python-stdlib/fnmatch/setup.py
+++ b/python-stdlib/fnmatch/setup.py
@@ -21,5 +21,5 @@ setup(
     license="Python",
     cmdclass={"sdist": sdist_upip.sdist},
     py_modules=["fnmatch"],
-    install_requires=["micropython-os", "micropython-os.path", "micropython-re-pcre"],
+    install_requires=["micropython-os", "micropython-os.path"],
 )

--- a/python-stdlib/fnmatch/setup.py
+++ b/python-stdlib/fnmatch/setup.py
@@ -21,5 +21,4 @@ setup(
     license="Python",
     cmdclass={"sdist": sdist_upip.sdist},
     py_modules=["fnmatch"],
-    install_requires=["micropython-os", "micropython-os.path"],
 )

--- a/python-stdlib/fnmatch/setup.py
+++ b/python-stdlib/fnmatch/setup.py
@@ -10,7 +10,7 @@ import sdist_upip
 
 setup(
     name="micropython-fnmatch",
-    version="0.5.2",
+    version="0.6.0",
     description="CPython fnmatch module ported to MicroPython",
     long_description="This is a module ported from CPython standard library to be compatible with\nMicroPython interpreter. Usually, this means applying small patches for\nfeatures not supported (yet, or at all) in MicroPython. Sometimes, heavier\nchanges are required. Note that CPython modules are written with availability\nof vast resources in mind, and may not work for MicroPython ports with\nlimited heap. If you are affected by such a case, please help reimplement\nthe module from scratch.",
     url="https://github.com/micropython/micropython-lib",

--- a/python-stdlib/fnmatch/test_fnmatch.py
+++ b/python-stdlib/fnmatch/test_fnmatch.py
@@ -10,7 +10,8 @@ class FnmatchTestCase(unittest.TestCase):
     def check_match(self, filename, pattern, should_match=1, fn=fnmatch):
         if should_match:
             self.assertTrue(
-                fn(filename, pattern), "expected %r to match pattern %r" % (filename, pattern)
+                fn(filename, pattern),
+                "expected %r to match pattern %r" % (filename, pattern),
             )
         else:
             self.assertTrue(
@@ -80,9 +81,9 @@ class FilterTestCase(unittest.TestCase):
         self.assertEqual(filter(["a", "b"], "a"), ["a"])
 
 
-def test_main():
+def main():
     support.run_unittest(FnmatchTestCase, TranslateTestCase, FilterTestCase)
 
 
 if __name__ == "__main__":
-    test_main()
+    main()

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,4 +1,4 @@
 srctype = micropython-lib
 type = module
-version = 0.3.2
+version = 0.9.0
 depends = argparse, fnmatch

--- a/python-stdlib/unittest/metadata.txt
+++ b/python-stdlib/unittest/metadata.txt
@@ -1,3 +1,4 @@
 srctype = micropython-lib
 type = module
 version = 0.3.2
+depends = argparse, fnmatch

--- a/python-stdlib/unittest/setup.py
+++ b/python-stdlib/unittest/setup.py
@@ -10,7 +10,7 @@ import sdist_upip
 
 setup(
     name="micropython-unittest",
-    version="0.3.2",
+    version="0.9.0",
     description="unittest module for MicroPython",
     long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
     url="https://github.com/micropython/micropython-lib",

--- a/python-stdlib/unittest/setup.py
+++ b/python-stdlib/unittest/setup.py
@@ -21,4 +21,5 @@ setup(
     license="MIT",
     cmdclass={"sdist": sdist_upip.sdist},
     py_modules=["unittest"],
+    install_requires=["micropython-argparse", "micropython-fnmatch"],
 )

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -37,7 +37,7 @@ class TestUnittestAssertions(unittest.TestCase):
         with self.assertRaises(AssertionError):
             self.assertNotAlmostEqual(float("inf"), float("inf"))
 
-    def test_AmostEqualWithDelta(self):
+    def test_AlmostEqualWithDelta(self):
         self.assertAlmostEqual(1.1, 1.0, delta=0.5)
         self.assertAlmostEqual(1.0, 1.1, delta=0.5)
         self.assertNotAlmostEqual(1.1, 1.0, delta=0.05)

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -1,4 +1,5 @@
 import unittest
+from test_unittest_isolated import global_context
 
 
 class TestUnittestAssertions(unittest.TestCase):
@@ -141,6 +142,11 @@ class TestUnittestAssertions(unittest.TestCase):
             pass
         else:
             self.fail("Unexpected success was not detected")
+
+    def test_NotChangedByOtherTest(self):
+        global global_context
+        assert global_context is None
+        global_context = True
 
 
 if __name__ == "__main__":

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -148,6 +148,14 @@ class TestUnittestAssertions(unittest.TestCase):
         assert global_context is None
         global_context = True
 
+    def test_subtest_even(self):
+        """
+        Test that numbers between 0 and 5 are all even.
+        """
+        for i in range(0, 10, 2):
+            with self.subTest("Should only pass for even numbers", i=i):
+                self.assertEqual(i % 2, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -126,6 +126,22 @@ class TestUnittestAssertions(unittest.TestCase):
         if not e1 or "not raised" not in e1.args[0]:
             self.fail("Expected to catch lack of AssertionError from assert in func_under_test")
 
+    @unittest.expectedFailure
+    def testExpectedFailure(self):
+        self.assertEqual(1, 0)
+
+    def testExpectedFailureNot(self):
+        @unittest.expectedFailure
+        def testInner():
+            self.assertEqual(1, 1)
+
+        try:
+            testInner()
+        except:
+            pass
+        else:
+            self.fail("Unexpected success was not detected")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -109,7 +109,7 @@ class TestUnittestAssertions(unittest.TestCase):
 
     @unittest.skip("test of skipping")
     def testSkip(self):
-        self.assertFail("this should be skipped")
+        self.fail("this should be skipped")
 
     def testAssert(self):
 

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -111,6 +111,21 @@ class TestUnittestAssertions(unittest.TestCase):
     def testSkip(self):
         self.assertFail("this should be skipped")
 
+    def testAssert(self):
+
+        e1 = None
+        try:
+
+            def func_under_test(a):
+                assert a > 10
+
+            self.assertRaises(AssertionError, func_under_test, 20)
+        except AssertionError as e:
+            e1 = e
+
+        if not e1 or "not raised" not in e1.args[0]:
+            self.fail("Expected to catch lack of AssertionError from assert in func_under_test")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python-stdlib/unittest/test_unittest.py
+++ b/python-stdlib/unittest/test_unittest.py
@@ -157,5 +157,24 @@ class TestUnittestAssertions(unittest.TestCase):
                 self.assertEqual(i % 2, 0)
 
 
+class TestUnittestSetup(unittest.TestCase):
+    class_setup_var = 0
+
+    def setUpClass(self):
+        TestUnittestSetup.class_setup_var += 1
+
+    def tearDownClass(self):
+        # Not sure how to actually test this, but we can check (in the test case below)
+        # that it hasn't been run already at least.
+        TestUnittestSetup.class_setup_var = -1
+
+    def testSetUpTearDownClass_1(self):
+        assert TestUnittestSetup.class_setup_var == 1, TestUnittestSetup.class_setup_var
+
+    def testSetUpTearDownClass_2(self):
+        # Test this twice, as if setUpClass() gets run like setUp() it would be run twice
+        assert TestUnittestSetup.class_setup_var == 1, TestUnittestSetup.class_setup_var
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python-stdlib/unittest/test_unittest_isolated.py
+++ b/python-stdlib/unittest/test_unittest_isolated.py
@@ -1,0 +1,15 @@
+import unittest
+
+
+global_context = None
+
+
+class TestUnittestIsolated(unittest.TestCase):
+    def test_NotChangedByOtherTest(self):
+        global global_context
+        assert global_context is None
+        global_context = True
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -21,6 +21,7 @@ class AssertRaisesContext:
         return self
 
     def __exit__(self, exc_type, exc_value, tb):
+        self.exception = exc_value
         if exc_type is None:
             assert False, "%r not raised" % self.expected
         if issubclass(exc_type, self.expected):

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -30,6 +30,9 @@ class AssertRaisesContext:
 
 
 class TestCase:
+    def __init__(self):
+        pass
+
     def fail(self, msg=""):
         assert False, msg
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -199,6 +199,18 @@ def skipUnless(cond, msg):
     return skip(msg)
 
 
+def expectedFailure(test):
+    def test_exp_fail(*args, **kwargs):
+        try:
+            test(*args, **kwargs)
+        except:
+            pass
+        else:
+            assert False, "unexpected success"
+
+    return test_exp_fail
+
+
 class TestSuite:
     def __init__(self):
         self._tests = []

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -180,7 +180,7 @@ class TestRunner:
     def run(self, suite):
         res = TestResult()
         for c in suite._tests:
-            res.exceptions.extend(run_class(c, res))
+            res.exceptions.extend(run_suite(c, res))
 
         print("Ran %d tests\n" % res.testsRun)
         if res.failuresNum > 0 or res.errorsNum > 0:
@@ -216,8 +216,11 @@ def capture_exc(e):
 
 
 # TODO: Uncompliant
-def run_class(c, test_result):
-    o = c()
+def run_suite(c, test_result):
+    if isinstance(c, type):
+        o = c()
+    else:
+        o = c
     set_up = getattr(o, "setUp", lambda: None)
     tear_down = getattr(o, "tearDown", lambda: None)
     exceptions = []

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -33,6 +33,9 @@ class TestCase:
     def __init__(self):
         pass
 
+    def skipTest(self, reason):
+        raise SkipTest(reason)
+
     def fail(self, msg=""):
         assert False, msg
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -195,12 +195,16 @@ class TestSuite:
     def addTest(self, cls):
         self._tests.append(cls)
 
+    def run(self, result):
+        for c in self._tests:
+            result.exceptions.extend(run_suite(c, result))
+        return result
+
 
 class TestRunner:
     def run(self, suite):
         res = TestResult()
-        for c in suite._tests:
-            res.exceptions.extend(run_suite(c, res))
+        suite.run(res)
 
         print("Ran %d tests\n" % res.testsRun)
         if res.failuresNum > 0 or res.errorsNum > 0:

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -243,6 +243,9 @@ class TestRunner:
         return res
 
 
+TextTestRunner = TestRunner
+
+
 class TestResult:
     def __init__(self):
         self.errorsNum = 0

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -10,6 +10,13 @@ except ImportError:
     traceback = None
 
 
+def _snapshot_modules():
+    return {k: v for k, v in sys.modules.items()}
+
+
+__modules__ = _snapshot_modules()
+
+
 class SkipTest(Exception):
     pass
 
@@ -375,6 +382,13 @@ def _test_cases(mod):
 
 
 def run_module(runner, module, path, top):
+    if not module:
+        raise ValueError("Empty module name")
+
+    # Reset the python environment before running test
+    sys.modules.clear()
+    sys.modules.update(__modules__)
+
     sys_path_initial = sys.path[:]
     # Add script dir and top dir to import path
     sys.path.insert(0, str(path))
@@ -395,6 +409,8 @@ def run_module(runner, module, path, top):
 def discover(runner: TestRunner):
     from unittest_discover import discover
 
+    global __modules__
+    __modules__ = _snapshot_modules()
     return discover(runner=runner)
 
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -43,6 +43,16 @@ class TestCase:
             msg = "%r not expected to be equal %r" % (x, y)
         assert x != y, msg
 
+    def assertLessEqual(self, x, y, msg=None):
+        if msg is None:
+            msg = "%r is expected to be <= %r" % (x, y)
+        assert x <= y, msg
+
+    def assertGreaterEqual(self, x, y, msg=None):
+        if msg is None:
+            msg = "%r is expected to be >= %r" % (x, y)
+        assert x >= y, msg
+
     def assertAlmostEqual(self, x, y, places=None, msg="", delta=None):
         if x == y:
             return

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -170,16 +170,16 @@ def skipUnless(cond, msg):
 
 class TestSuite:
     def __init__(self):
-        self.tests = []
+        self._tests = []
 
     def addTest(self, cls):
-        self.tests.append(cls)
+        self._tests.append(cls)
 
 
 class TestRunner:
     def run(self, suite):
         res = TestResult()
-        for c in suite.tests:
+        for c in suite._tests:
             res.exceptions.extend(run_class(c, res))
 
         print("Ran %d tests\n" % res.testsRun)

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -161,6 +161,9 @@ class TestCase:
 
         assert False, "%r not raised" % exc
 
+    def assertWarns(self, warn):
+        return NullContext()
+
 
 def skip(msg):
     def _decor(fun):

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -212,15 +212,16 @@ def expectedFailure(test):
 
 
 class TestSuite:
-    def __init__(self):
+    def __init__(self, name=""):
         self._tests = []
+        self.name = name
 
     def addTest(self, cls):
         self._tests.append(cls)
 
     def run(self, result):
         for c in self._tests:
-            run_suite(c, result)
+            run_suite(c, result, self.name)
         return result
 
 
@@ -290,7 +291,7 @@ def capture_exc(e):
 
 
 # TODO: Uncompliant
-def run_suite(c, test_result):
+def run_suite(c, test_result, suite_name=""):
     if isinstance(c, TestSuite):
         c.run(test_result)
         return
@@ -302,9 +303,13 @@ def run_suite(c, test_result):
     set_up = getattr(o, "setUp", lambda: None)
     tear_down = getattr(o, "tearDown", lambda: None)
     exceptions = []
+    try:
+        suite_name += "." + c.__qualname__
+    except AttributeError:
+        pass
 
     def run_one(m):
-        print("%s (%s) ..." % (name, c.__qualname__), end="")
+        print("%s (%s) ..." % (name, suite_name), end="")
         set_up()
         try:
             test_result.testsRun += 1
@@ -351,7 +356,7 @@ def main(module="__main__"):
                 yield c
 
     m = __import__(module) if isinstance(module, str) else module
-    suite = TestSuite()
+    suite = TestSuite(m.__name__)
     for c in test_cases(m):
         suite.addTest(c)
     runner = TestRunner()

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -41,6 +41,17 @@ class TestCase:
     def __init__(self):
         pass
 
+    def addCleanup(self, func, *args, **kwargs):
+        if not hasattr(self, "_cleanups"):
+            self._cleanups = []
+        self._cleanups.append((func, args, kwargs))
+
+    def doCleanups(self):
+        if hasattr(self, "_cleanups"):
+            while self._cleanups:
+                func, args, kwargs = self._cleanups.pop()
+                func(*args, **kwargs)
+
     def subTest(self, msg=None, **params):
         return NullContext()
 
@@ -271,6 +282,7 @@ def run_suite(c, test_result):
                 continue
             finally:
                 tear_down()
+                o.doCleanups()
     return exceptions
 
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -223,8 +223,10 @@ def run_class(c, test_result):
     exceptions = []
     for name in dir(o):
         if name.startswith("test"):
-            print("%s (%s) ..." % (name, c.__qualname__), end="")
             m = getattr(o, name)
+            if not callable(m):
+                continue
+            print("%s (%s) ..." % (name, c.__qualname__), end="")
             set_up()
             try:
                 test_result.testsRun += 1

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -219,7 +219,7 @@ def main(module="__main__"):
             if isinstance(c, object) and isinstance(c, type) and issubclass(c, TestCase):
                 yield c
 
-    m = __import__(module)
+    m = __import__(module) if isinstance(module, str) else module
     suite = TestSuite()
     for c in test_cases(m):
         suite.addTest(c)

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -302,36 +302,44 @@ def run_suite(c, test_result):
     set_up = getattr(o, "setUp", lambda: None)
     tear_down = getattr(o, "tearDown", lambda: None)
     exceptions = []
+
+    def run_one(m):
+        print("%s (%s) ..." % (name, c.__qualname__), end="")
+        set_up()
+        try:
+            test_result.testsRun += 1
+            m()
+            print(" ok")
+        except SkipTest as e:
+            print(" skipped:", e.args[0])
+            test_result.skippedNum += 1
+        except Exception as ex:
+            ex_str = capture_exc(ex)
+            if isinstance(ex, AssertionError):
+                test_result.failuresNum += 1
+                test_result.failures.append(((name, c), ex_str))
+                print(" FAIL")
+            else:
+                test_result.errorsNum += 1
+                test_result.errors.append(((name, c), ex_str))
+                print(" ERROR")
+            # Uncomment to investigate failure in detail
+            # raise
+        finally:
+            tear_down()
+            o.doCleanups()
+
+    if hasattr(o, "runTest"):
+        name = str(o)
+        run_one(o.runTest)
+        return
+
     for name in dir(o):
         if name.startswith("test"):
             m = getattr(o, name)
             if not callable(m):
                 continue
-            print("%s (%s) ..." % (name, c.__qualname__), end="")
-            set_up()
-            try:
-                test_result.testsRun += 1
-                m()
-                print(" ok")
-            except SkipTest as e:
-                print(" skipped:", e.args[0])
-                test_result.skippedNum += 1
-            except Exception as ex:
-                ex_str = capture_exc(ex)
-                if isinstance(ex, AssertionError):
-                    test_result.failuresNum += 1
-                    test_result.failures.append(((name, c), ex_str))
-                    print(" FAIL")
-                else:
-                    test_result.errorsNum += 1
-                    test_result.errors.append(((name, c), ex_str))
-                    print(" ERROR")
-                # Uncomment to investigate failure in detail
-                # raise
-                continue
-            finally:
-                tear_down()
-                o.doCleanups()
+            run_one(m)
     return exceptions
 
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -366,6 +366,8 @@ def run_suite(c, test_result, suite_name=""):
         o = c()
     else:
         o = c
+    set_up_class = getattr(o, "setUpClass", lambda: None)
+    tear_down_class = getattr(o, "tearDownClass", lambda: None)
     set_up = getattr(o, "setUp", lambda: None)
     tear_down = getattr(o, "tearDown", lambda: None)
     exceptions = []
@@ -410,6 +412,8 @@ def run_suite(c, test_result, suite_name=""):
             except AttributeError:
                 pass
 
+    set_up_class()
+
     if hasattr(o, "runTest"):
         name = str(o)
         run_one(o.runTest)
@@ -425,6 +429,8 @@ def run_suite(c, test_result, suite_name=""):
     if callable(o):
         name = o.__name__
         run_one(o)
+
+    tear_down_class()
 
     return exceptions
 

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -126,11 +126,12 @@ class TestCase:
 
         try:
             func(*args, **kwargs)
-            assert False, "%r not raised" % exc
         except Exception as e:
             if isinstance(e, exc):
                 return
             raise
+
+        assert False, "%r not raised" % exc
 
 
 def skip(msg):

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -237,7 +237,7 @@ class TestRunner:
         else:
             msg = "OK"
             if res.skippedNum > 0:
-                msg += " (%d skipped)" % res.skippedNum
+                msg += " (skipped=%d)" % res.skippedNum
             print(msg)
 
         return res

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -29,9 +29,20 @@ class AssertRaisesContext:
         return False
 
 
+class NullContext:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, a, b, c):
+        pass
+
+
 class TestCase:
     def __init__(self):
         pass
+
+    def subTest(self, msg=None, **params):
+        return NullContext()
 
     def skipTest(self, reason):
         raise SkipTest(reason)

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -237,6 +237,8 @@ def run_class(c, test_result):
                 exceptions.append(capture_exc(ex))
                 print(" FAIL")
                 test_result.failuresNum += 1
+                # Uncomment to investigate failure in detail
+                # raise
                 continue
             finally:
                 tear_down()

--- a/python-stdlib/unittest/unittest.py
+++ b/python-stdlib/unittest/unittest.py
@@ -276,6 +276,10 @@ def capture_exc(e):
 
 # TODO: Uncompliant
 def run_suite(c, test_result):
+    if isinstance(c, TestSuite):
+        c.run(test_result)
+        return
+
     if isinstance(c, type):
         o = c()
     else:

--- a/python-stdlib/unittest/unittest_discover.py
+++ b/python-stdlib/unittest/unittest_discover.py
@@ -1,0 +1,70 @@
+import argparse
+import sys
+import uos
+from fnmatch import fnmatch
+
+from unittest import TestRunner, TestResult, run_module
+
+
+def discover(runner: TestRunner):
+    """
+    Implements discover function inspired by https://docs.python.org/3/library/unittest.html#test-discovery
+    """
+    parser = argparse.ArgumentParser()
+    # parser.add_argument(
+    #     "-v",
+    #     "--verbose",
+    #     action="store_true",
+    #     help="Verbose output",
+    # )
+    parser.add_argument(
+        "-s",
+        "--start-directory",
+        dest="start",
+        default=".",
+        help="Directory to start discovery",
+    )
+    parser.add_argument(
+        "-p",
+        "--pattern ",
+        dest="pattern",
+        default="test*.py",
+        help="Pattern to match test files",
+    )
+    parser.add_argument(
+        "-t",
+        "--top-level-directory",
+        dest="top",
+        help="Top level directory of project (defaults to start directory)",
+    )
+    args = parser.parse_args(args=sys.argv[2:])
+
+    path = args.start
+    top = args.top or path
+
+    return run_all_in_dir(
+        runner=runner,
+        path=path,
+        pattern=args.pattern,
+        top=top,
+    )
+
+
+def run_all_in_dir(runner: TestRunner, path: str, pattern: str, top: str):
+    DIR_TYPE = 0x4000
+
+    result = TestResult()
+    for fname, type, *_ in uos.ilistdir(path):
+        if fname in ("..", "."):
+            continue
+        if type == DIR_TYPE:
+            result += run_all_in_dir(
+                runner=runner,
+                path="/".join((path, fname)),
+                pattern=pattern,
+                top=top,
+            )
+        if fnmatch(fname, pattern):
+            modname = fname[: fname.rfind(".")]
+            result += run_module(runner, modname, path, top)
+    return result


### PR DESCRIPTION
PR primary goal is to provide `discover` argument matching cpython/unittest module.
Also improves other compatibility with cpython, mostly around running as a module (`micropython-coverage -m unittest`) and test stdout format.

This is sitting on top of https://github.com/micropython/micropython-lib/pull/487 and also includes some related module fixes which should get split out into separate PR's.

I also plan to investifate splitting `discover` and hopefully the rest of the new dependencies into a separate module (with auto-import on use like in uasyncio) that can be left out of deployment to device to reduce size if desired.