### PR TITLE
fnmatch: Add ure compatibility.

### DIFF
--- a/python-stdlib/fnmatch/fnmatch.py
+++ b/python-stdlib/fnmatch/fnmatch.py
@@ -9,11 +9,21 @@ expression.  They cache the compiled regular expressions for speed.
 The function translate(PATTERN) returns a regular expression
 corresponding to PATTERN.  (It does not compile it.)
 """
-import os
-import os.path
 import re
 
-# import functools
+try:
+    from os.path import normcase
+except ImportError:
+
+    def normcase(s):
+        """
+        From os.path.normcase
+        Normalize the case of a pathname. On Windows, convert all characters
+        in the pathname to lowercase, and also convert forward slashes to
+        backward slashes. On other operating systems, return the path unchanged.
+        """
+        return s
+
 
 __all__ = ["filter", "fnmatch", "fnmatchcase", "translate"]
 
@@ -35,8 +45,8 @@ def fnmatch(name, pat):
     if the operating system requires it.
     If you don't want this, use fnmatchcase(FILENAME, PATTERN).
     """
-    name = os.path.normcase(name)
-    pat = os.path.normcase(pat)
+    name = normcase(name)
+    pat = normcase(pat)
     return fnmatchcase(name, pat)
 
 
@@ -59,10 +69,10 @@ def _compile_pattern(pat):
 def filter(names, pat):
     """Return the subset of the list NAMES that match PAT."""
     result = []
-    pat = os.path.normcase(pat)
+    pat = normcase(pat)
     match = _compile_pattern(pat)
     for name in names:
-        if match(os.path.normcase(name)):
+        if match(normcase(name)):
             result.append(name)
     return result
 

--- a/python-stdlib/fnmatch/metadata.txt
+++ b/python-stdlib/fnmatch/metadata.txt
@@ -1,4 +1,4 @@
 srctype = cpython
 type = module
 version = 0.5.2
-depends = os, os.path, re-pcre
+depends = os, os.path

--- a/python-stdlib/fnmatch/metadata.txt
+++ b/python-stdlib/fnmatch/metadata.txt
@@ -1,3 +1,3 @@
 srctype = cpython
 type = module
-version = 0.5.2
+version = 0.6.0

--- a/python-stdlib/fnmatch/metadata.txt
+++ b/python-stdlib/fnmatch/metadata.txt
@@ -1,4 +1,3 @@
 srctype = cpython
 type = module
 version = 0.5.2
-depends = os, os.path

--- a/python-stdlib/fnmatch/setup.py
+++ b/python-stdlib/fnmatch/setup.py
@@ -21,5 +21,5 @@ setup(
     license="Python",
     cmdclass={"sdist": sdist_upip.sdist},
     py_modules=["fnmatch"],
-    install_requires=["micropython-os", "micropython-os.path", "micropython-re-pcre"],
+    install_requires=["micropython-os", "micropython-os.path"],
 )

--- a/python-stdlib/fnmatch/setup.py
+++ b/python-stdlib/fnmatch/setup.py
@@ -21,5 +21,4 @@ setup(
     license="Python",
     cmdclass={"sdist": sdist_upip.sdist},
     py_modules=["fnmatch"],
-    install_requires=["micropython-os", "micropython-os.path"],
 )

--- a/python-stdlib/fnmatch/setup.py
+++ b/python-stdlib/fnmatch/setup.py
@@ -10,7 +10,7 @@ import sdist_upip
 
 setup(
     name="micropython-fnmatch",
-    version="0.5.2",
+    version="0.6.0",
     description="CPython fnmatch module ported to MicroPython",
     long_description="This is a module ported from CPython standard library to be compatible with\nMicroPython interpreter. Usually, this means applying small patches for\nfeatures not supported (yet, or at all) in MicroPython. Sometimes, heavier\nchanges are required. Note that CPython modules are written with availability\nof vast resources in mind, and may not work for MicroPython ports with\nlimited heap. If you are affected by such a case, please help reimplement\nthe module from scratch.",
     url="https://github.com/micropython/micropython-lib",

--- a/python-stdlib/fnmatch/test_fnmatch.py
+++ b/python-stdlib/fnmatch/test_fnmatch.py
@@ -10,7 +10,8 @@ class FnmatchTestCase(unittest.TestCase):
     def check_match(self, filename, pattern, should_match=1, fn=fnmatch):
         if should_match:
             self.assertTrue(
-                fn(filename, pattern), "expected %r to match pattern %r" % (filename, pattern)
+                fn(filename, pattern),
+                "expected %r to match pattern %r" % (filename, pattern),
             )
         else:
             self.assertTrue(
@@ -80,9 +81,9 @@ class FilterTestCase(unittest.TestCase):
         self.assertEqual(filter(["a", "b"], "a"), ["a"])
 
 
-def test_main():
+def main():
     support.run_unittest(FnmatchTestCase, TranslateTestCase, FilterTestCase)
 
 
 if __name__ == "__main__":
-    test_main()
+    main()


### PR DESCRIPTION
Removes dependency on re-pcre which is only available on unix port.

Used in #488