### PR TITLE
os.path: Add uos compatibility.

### DIFF
--- a/python-stdlib/os.path/os/path.py
+++ b/python-stdlib/os.path/os/path.py
@@ -1,4 +1,4 @@
-import os
+import uos as os
 
 
 sep = "/"
@@ -47,7 +47,11 @@ def basename(path):
 
 
 def exists(path):
-    return os.access(path, os.F_OK)
+    try:
+        os.stat(path)
+        return True
+    except OSError:
+        return False
 
 
 # TODO


### PR DESCRIPTION
The os.access function is only provided on unix/ffi os module, so replace with basic os.stat call.
Everything else in this module is already compatible with on-device uos module.