### PR TITLE
aioble/examples/temp_client.py: check connection before reading temp

### DIFF
--- a/micropython/bluetooth/aioble/examples/temp_client.py
+++ b/micropython/bluetooth/aioble/examples/temp_client.py
@@ -55,7 +55,7 @@ async def main():
             print("Timeout discovering services/characteristics")
             return
 
-        while True:
+        while connection.is_connected():
             temp_deg_c = _decode_temperature(await temp_characteristic.read())
             print("Temperature: {:.2f}".format(temp_deg_c))
             await asyncio.sleep_ms(1000)


### PR DESCRIPTION
Only read from the temp characteristic if the connection is still
active. Improves the example by avoiding a TypeError exception when the
sensor disconnects.