### PR TITLE
aioble/device.py: No default timeout for async disconnected() method.

### DIFF
--- a/micropython/bluetooth/aioble-core/manifest.py
+++ b/micropython/bluetooth/aioble-core/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.0")
+metadata(version="0.3.0")
 
 package(
     "aioble",

--- a/micropython/bluetooth/aioble/aioble/device.py
+++ b/micropython/bluetooth/aioble/aioble/device.py
@@ -212,7 +212,7 @@ class DeviceConnection:
     async def disconnect(self, timeout_ms=2000):
         await self.disconnected(timeout_ms, disconnect=True)
 
-    async def disconnected(self, timeout_ms=60000, disconnect=False):
+    async def disconnected(self, timeout_ms=None, disconnect=False):
         if not self.is_connected():
             return
 

--- a/micropython/bluetooth/aioble/manifest.py
+++ b/micropython/bluetooth/aioble/manifest.py
@@ -3,7 +3,7 @@
 # code. This allows (for development purposes) all the files to live in the
 # one directory.
 
-metadata(version="0.4.1")
+metadata(version="0.5.0")
 
 # Default installation gives you everything. Install the individual
 # components (or a combination of them) if you want a more minimal install.


### PR DESCRIPTION
The value for the `timeout_ms` optional argument to `DeviceConnection.disconnected()` async method is changed from 60000 to None. This way users awaiting a device disconnection using `await connection.disconnected()` won't be surprised by a 1 minute timeout. For instance, in the `temp_sensor.py` usage example I think it's reasonable to expect the connection to the client to stay open indefinitely.