### PR TITLE
Urequests updates

### DIFF
--- a/python-ecosys/urequests/metadata.txt
+++ b/python-ecosys/urequests/metadata.txt
@@ -1,4 +1,3 @@
 srctype = micropython-lib
 type = module
-version = 0.6
-author = Paul Sokolovsky
+version = 0.7.0

--- a/python-ecosys/urequests/setup.py
+++ b/python-ecosys/urequests/setup.py
@@ -10,11 +10,11 @@ import sdist_upip
 
 setup(
     name="micropython-urequests",
-    version="0.6",
+    version="0.7",
     description="urequests module for MicroPython",
     long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
     url="https://github.com/micropython/micropython-lib",
-    author="Paul Sokolovsky",
+    author="micropython-lib Developers",
     author_email="micro-python@googlegroups.com",
     maintainer="micropython-lib Developers",
     maintainer_email="micro-python@googlegroups.com",

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -99,7 +99,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None, parse_he
             # print(l)
             if l.startswith(b"Transfer-Encoding:"):
                 if b"chunked" in l:
-                    raise ValueError("Unsupported " + l)
+                    raise ValueError("Unsupported " + str(l, "utf-8"))
             elif l.startswith(b"Location:") and not 200 <= status <= 299:
                 raise NotImplementedError("Redirects not yet supported")
             if parse_headers is False:

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -111,6 +111,9 @@ def request(
         l = s.readline()
         # print(l)
         l = l.split(None, 2)
+        if len(l) < 2:
+            # Invalid response
+            raise ValueError("HTTP error: BadStatusLine:\n%s" % l)
         status = int(l[1])
         reason = ""
         if len(l) > 2:

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -33,7 +33,17 @@ class Response:
         return ujson.loads(self.content)
 
 
-def request(method, url, data=None, json=None, headers={}, stream=None, parse_headers=True):
+def request(
+    method, url, data=None, json=None, headers={}, stream=None, parse_headers=True, auth=None
+):
+    if auth is not None:
+        import ubinascii
+
+        username, password = auth
+        formated = b"{}:{}".format(username, password)
+        formated = str(ubinascii.b2a_base64(formated)[:-1], "ascii")
+        headers["Authorization"] = "Basic {}".format(formated)
+
     try:
         proto, dummy, host, path = url.split("/", 3)
     except ValueError:
@@ -144,3 +154,4 @@ def patch(url, **kw):
 
 def delete(url, **kw):
     return request("DELETE", url, **kw)
+

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -34,7 +34,15 @@ class Response:
 
 
 def request(
-    method, url, data=None, json=None, headers={}, stream=None, parse_headers=True, auth=None
+    method,
+    url,
+    data=None,
+    json=None,
+    headers={},
+    stream=None,
+    auth=None,
+    timeout=None,
+    parse_headers=True,
 ):
     redirect = None  # redirection url, None means no redirection
     chunked_data = data and getattr(data, "__iter__", None) and not getattr(data, "__len__", None)
@@ -73,6 +81,12 @@ def request(
         resp_d = {}
 
     s = usocket.socket(ai[0], usocket.SOCK_STREAM, ai[2])
+
+    if timeout is not None:
+        # Note: settimeout is not supported on all platforms, will raise
+        # an AttributeError if not available.
+        s.settimeout(timeout)
+
     try:
         s.connect(ai[-1])
         if proto == "https:":

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -81,7 +81,7 @@ def request(method, url, data=None, json=None, headers={}, stream=None, parse_he
             s.write(b"Content-Type: application/json\r\n")
         if data:
             s.write(b"Content-Length: %d\r\n" % len(data))
-        s.write(b"\r\n")
+        s.write(b"Connection: close\r\n\r\n")
         if data:
             s.write(data)
 

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -72,7 +72,7 @@ def request(
     if parse_headers is not False:
         resp_d = {}
 
-    s = usocket.socket(ai[0], ai[1], ai[2])
+    s = usocket.socket(ai[0], usocket.SOCK_STREAM, ai[2])
     try:
         s.connect(ai[-1])
         if proto == "https:":

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -33,7 +33,7 @@ class Response:
         return ujson.loads(self.content)
 
 
-def request(method, url, data=None, json=None, headers={}, stream=None):
+def request(method, url, data=None, json=None, headers={}, stream=None, parse_headers=True):
     try:
         proto, dummy, host, path = url.split("/", 3)
     except ValueError:
@@ -54,6 +54,10 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
 
     ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
     ai = ai[0]
+
+    resp_d = None
+    if parse_headers is not False:
+        resp_d = {}
 
     s = usocket.socket(ai[0], ai[1], ai[2])
     try:
@@ -98,6 +102,14 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
                     raise ValueError("Unsupported " + l)
             elif l.startswith(b"Location:") and not 200 <= status <= 299:
                 raise NotImplementedError("Redirects not yet supported")
+            if parse_headers is False:
+                pass
+            elif parse_headers is True:
+                l = str(l, "utf-8")
+                k, v = l.split(":", 1)
+                resp_d[k] = v.strip()
+            else:
+                parse_headers(l, resp_d)
     except OSError:
         s.close()
         raise
@@ -105,6 +117,8 @@ def request(method, url, data=None, json=None, headers={}, stream=None):
     resp = Response(s)
     resp.status_code = status
     resp.reason = reason
+    if resp_d is not None:
+        resp.headers = resp_d
     return resp
 
 

--- a/python-stdlib/binascii/binascii.py
+++ b/python-stdlib/binascii/binascii.py
@@ -331,7 +331,7 @@ def a2b_base64(ascii):
 table_b2a_base64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 
 
-def b2a_base64(bin):
+def b2a_base64(bin, newline=True):
     "Base64-code line of data."
 
     newlength = (len(bin) + 2) // 3
@@ -357,5 +357,6 @@ def b2a_base64(bin):
     elif leftbits == 4:
         res.append(table_b2a_base64[(leftchar & 0xF) << 2])
         res.append(PAD)
-    res.append("\n")
+    if newline:
+        res.append("\n")
     return "".join(res).encode("ascii")


### PR DESCRIPTION
In the spirit of https://github.com/micropython/micropython-lib/pull/488 I've started to pull together a number of updates to the `urequests` library. So far I haven't contributed any new features myself, simply rebased (past the restructuring), merged together and applied black to all commits. 

Inspired by a similar change in pycopy, but updated to be more compatible. Also closes https://github.com/micropython/micropython-lib/pull/394
* requests: Fix raising unsupported Transfer-Encoding exception.

From https://github.com/micropython/micropython-lib/pull/398 (Note I manually split this into the two separate urequest commits)
* urequests: Added support for redirects.
* urequests: Add support for requests with chunked upload data.
* binascii: newline param in function b2a_base64 (Required dependency update for urequests feature above)
See: https://docs.python.org/3/library/binascii.html#binascii.b2a_base64

From https://github.com/micropython/micropython-lib/pull/311
* urequests: Added Basic Authentication support.
  Usage matches the shorthand version described in 
  https://requests.readthedocs.io/en/latest/user/authentication/#basic-authentication

From: https://github.com/micropython/micropython-lib/pull/469
* urequests: Always open sockets in SOCK_STREAM mode.

Inspired by: https://github.com/micropython/micropython-lib/pull/276:
* urequests: Provide error message when server doesn't respond with valid http.

From https://github.com/micropython/micropython-lib/pull/263:
* urequests: Add timeout, passed to underlying socket if supported.

From pycopy:
* urequests: Explicitly add "Connection: close" to request headers.
* urequests: Add ability to parse response headers.

For reference, the rebase & black on each branch (pre-merge) has been done in a single command:
```
git rebase -Xtheirs -i --exec 'black --fast --line-length=99 */urequests python-stdlib/binascii;git add */urequests python-stdlib/binascii;git commit --amend --no-edit' $(git merge-base HEAD master)
```

Testing TBD - none of the above commits include any  unit tests.

