### PR TITLE
umqtt.robust: Fix check_msg blocking after reconnect

### DIFF
--- a/micropython/umqtt.robust/example_check_msg_robust.py
+++ b/micropython/umqtt.robust/example_check_msg_robust.py
@@ -1,0 +1,14 @@
+import umqtt.robust
+import time
+
+# Instantiate an MQTTClient with a keepalive time of 5 seconds (to help us test
+# what happens to check_msg() with a broken connection)
+m = umqtt.robust.MQTTClient(host="localhost", debug=True, keepalive=5)
+
+m.connect()
+
+# Wait for the broker to consider us dead
+time.sleep(6)
+
+# This should initiate a reconnect() and return immediately
+m.check_msg()

--- a/micropython/umqtt.robust/manifest.py
+++ b/micropython/umqtt.robust/manifest.py
@@ -1,5 +1,5 @@
 metadata(
-    description='Lightweight MQTT client for MicroPython ("robust" version).', version="1.0.1"
+    description='Lightweight MQTT client for MicroPython ("robust" version).', version="1.0.2"
 )
 
 # Originally written by Paul Sokolovsky.

--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -36,11 +36,18 @@ class MQTTClient(simple.MQTTClient):
             self.reconnect()
 
     def wait_msg(self):
-        timeout_ms = float(str(self.sock).split(' ')[2].split('=')[1])
         while 1:
             try:
                 return super().wait_msg()
             except OSError as e:
                 self.log(False, e)
             self.reconnect()
-            self.sock.settimeout(timeout_ms / 1000 if timeout >= 0 else None)
+
+    def check_msg(self):
+        while 1:
+            self.sock.setblocking(False)
+            try:
+                return super().wait_msg()
+            except OSError as e:
+                self.log(False, e)
+            self.reconnect()

--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -43,11 +43,12 @@ class MQTTClient(simple.MQTTClient):
                 self.log(False, e)
             self.reconnect()
 
-    def check_msg(self):
-        while 1:
+    def check_msg(self, attempts=2):
+        while attempts:
             self.sock.setblocking(False)
             try:
                 return super().wait_msg()
             except OSError as e:
                 self.log(False, e)
             self.reconnect()
+            attempts -= 1

--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -36,9 +36,11 @@ class MQTTClient(simple.MQTTClient):
             self.reconnect()
 
     def wait_msg(self):
+        timeout_ms = float(str(self.sock).split(' ')[2].split('=')[1])
         while 1:
             try:
                 return super().wait_msg()
             except OSError as e:
                 self.log(False, e)
             self.reconnect()
+            self.sock.settimeout(timeout_ms / 1000 if timeout >= 0 else None)


### PR DESCRIPTION
After `reconnect()`, MQTTClient.socket is blocking by default. This
commit aims to supplement that behaviour at times when `check_msg()`
sets the socket to non-blocking. It may fix errors reported in #102 and
#192.

This fix:
* avoids using an additional instance attribute to record the intended
  state of the socket (Edit: this would involve changes to umqtt.simple which should 'know' nothing about robustness)
* ~~only adds two additional lines of code to one file in the codebase~~ (Edit: a new approach was taken based on feedback: it's now 8 additional code lines)
* ~~depends on socket's `__str__()` method to retrieve the current timeout
  value: `<socket state=0 timeout=-1 incoming=0 off=0>` - not ideal~~
* (Edit: overrides umqtt.simple's `check_msg()` method in order to `sock.setblocking(False)` before all calls to `wait_msg()`, even after `reconnect()`)

Edit: An additional note: This fix calls `super().wait_msg()` as opposed to `self.wait_msg()` to avoid nested reconnect() retries which would simply reintroduce the original behaviour.