### PR TITLE
python-ecosys/ujwt: Add ujwt module.

### DIFF
--- a/python-ecosys/ujwt/metadata.txt
+++ b/python-ecosys/ujwt/metadata.txt
@@ -1,0 +1,3 @@
+srctype = micropython-lib
+type = module
+version = 0.1.0

--- a/python-ecosys/ujwt/setup.py
+++ b/python-ecosys/ujwt/setup.py
@@ -1,0 +1,25 @@
+import sys
+
+# Remove current dir from sys.path, otherwise setuptools will peek up our
+# module instead of system's.
+sys.path.pop(0)
+from setuptools import setup
+
+sys.path.append("..")
+import sdist_upip
+
+setup(
+    name="micropython-ujwt",
+    version="0.1",
+    description="ujwt module for MicroPython",
+    long_description="This is a module reimplemented specifically for MicroPython standard library,\nwith efficient and lean design in mind. Note that this module is likely work\nin progress and likely supports just a subset of CPython's corresponding\nmodule. Please help with the development if you are interested in this\nmodule.",
+    url="https://github.com/micropython/micropython-lib",
+    author="micropython-lib Developers",
+    author_email="micro-python@googlegroups.com",
+    maintainer="micropython-lib Developers",
+    maintainer_email="micro-python@googlegroups.com",
+    license="MIT",
+    cmdclass={"sdist": sdist_upip.sdist},
+    py_modules=["ujwt"],
+    install_requires=["micropython-hmac"],
+)

--- a/python-ecosys/ujwt/test_ujwt.py
+++ b/python-ecosys/ujwt/test_ujwt.py
@@ -1,0 +1,26 @@
+import ujwt
+from time import time
+
+secret_key = "top-secret!"
+
+jwt = ujwt.encode({"user": "joe"}, secret_key)
+decoded = ujwt.decode(jwt, secret_key)
+if decoded != {"user": "joe"}:
+    raise Exception("Invalid decoded JWT")
+else:
+    print("Encode/decode test: OK")
+
+try:
+    decoded = ujwt.decode(jwt, "wrong-secret")
+except ujwt.exceptions.InvalidSignatureError:
+    print("Invalid signature test: OK")
+else:
+    raise Exception("Invalid JWT should have failed decoding")
+
+jwt = ujwt.encode({"user": "joe", "exp": time() - 1}, secret_key)
+try:
+    decoded = ujwt.decode(jwt, secret_key)
+except ujwt.exceptions.ExpiredTokenError:
+    print("Expired token test: OK")
+else:
+    raise Exception("Expired JWT should have failed decoding")

--- a/python-ecosys/ujwt/ujwt.py
+++ b/python-ecosys/ujwt/ujwt.py
@@ -1,0 +1,79 @@
+import binascii
+import hashlib
+import hmac
+import json
+from time import time
+
+
+def _to_b64url(data):
+    return (
+        binascii.b2a_base64(data)
+        .rstrip(b"\n")
+        .rstrip(b"=")
+        .replace(b"+", b"-")
+        .replace(b"/", b"_")
+    )
+
+
+def _from_b64url(data):
+    return binascii.a2b_base64(data.replace(b"-", b"+").replace(b"_", b"/") + b"===")
+
+
+class exceptions:
+    class PyJWTError(Exception):
+        pass
+
+    class InvalidTokenError(PyJWTError):
+        pass
+
+    class InvalidAlgorithmError(PyJWTError):
+        pass
+
+    class InvalidSignatureError(PyJWTError):
+        pass
+
+    class ExpiredTokenError(PyJWTError):
+        pass
+
+
+def encode(payload, key, algorithm="HS256"):
+    if algorithm != "HS256":
+        raise exceptions.InvalidAlgorithmError()
+
+    if isinstance(key, str):
+        key = key.encode()
+    header = _to_b64url(json.dumps({"typ": "JWT", "alg": algorithm}).encode())
+    payload = _to_b64url(json.dumps(payload).encode())
+    signature = _to_b64url(hmac.new(key, header + b"." + payload, hashlib.sha256).digest())
+    return (header + b"." + payload + b"." + signature).decode()
+
+
+def decode(token, key, algorithms=["HS256"]):
+    if "HS256" not in algorithms:
+        raise exceptions.InvalidAlgorithmError()
+
+    parts = token.encode().split(b".")
+    if len(parts) != 3:
+        raise exceptions.InvalidTokenError()
+
+    try:
+        header = json.loads(_from_b64url(parts[0]).decode())
+        payload = json.loads(_from_b64url(parts[1]).decode())
+        signature = _from_b64url(parts[2])
+    except Exception:
+        raise exceptions.InvalidTokenError()
+
+    if header["alg"] not in algorithms or header["alg"] != "HS256":
+        raise exceptions.InvalidAlgorithmError()
+
+    if isinstance(key, str):
+        key = key.encode()
+    calculated_signature = hmac.new(key, parts[0] + b"." + parts[1], hashlib.sha256).digest()
+    if signature != calculated_signature:
+        raise exceptions.InvalidSignatureError()
+
+    if "exp" in payload:
+        if time() > payload["exp"]:
+            raise exceptions.ExpiredTokenError()
+
+    return payload

--- a/python-stdlib/hashlib/hashlib/__init__.py
+++ b/python-stdlib/hashlib/hashlib/__init__.py
@@ -6,10 +6,11 @@ except ImportError:
 
 def init():
     for i in ("sha1", "sha224", "sha256", "sha384", "sha512"):
-        c = getattr(uhashlib, i, None)
-        if not c:
+        try:
             c = __import__("_" + i, None, None, (), 1)
-            c = getattr(c, i)
+        except ImportError:
+            c = uhashlib
+        c = getattr(c, i, None)
         globals()[i] = c
 
 


### PR DESCRIPTION
Fixes #510 

Here is my ujwt module. Note that I had to fix a small issue in the hashlib library, which prefers to import the built-in `sha256` class even when micropython-hashlib is installed. Unfortunately the hmac library does not work with the built-in hashlib.

Let me know if you need anything else. I have added the packaging files, but I have no idea if there is anything I need to include to push the package to pypi.