### PR TITLE
aioble: Allow send chunk size to be tunable by integrating application

### DIFF
--- a/micropython/bluetooth/aioble/aioble/l2cap.py
+++ b/micropython/bluetooth/aioble/aioble/l2cap.py
@@ -132,10 +132,10 @@ class L2CAPChannel:
 
     # Waits until the channel is free and then sends buf.
     # If the buffer is larger than the MTU it will be sent in chunks.
-    async def send(self, buf, timeout_ms=None):
+    async def send(self, buf, timeout_ms=None, chunk_size=None):
         self._assert_connected()
         offset = 0
-        chunk_size = min(self.our_mtu * 2, self.peer_mtu)
+        chunk_size = min(self.our_mtu * 2, self.peer_mtu, chunk_size or self.peer_mtu)
         mv = memoryview(buf)
         while offset < len(buf):
             if self._stalled:

--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -13,6 +13,7 @@ from .core import (
     log_error,
     log_warn,
     register_irq_handler,
+    GattError,
 )
 from .device import DeviceConnection, DeviceTimeout
 


### PR DESCRIPTION
This number change has come out of testing a wide variety of different configurations on an STM32-based chipset. I'm not at all sure how device-specific this tuning is, hence raising this for discussion and refinement.

The performance impacts of the L2CAP MTU size and optimum L2CAP chunk size behave in a somewhat unusual way.

This was tested with an internal codebase running very little while the transfer was in progress. All tests were to an Android 12 Samsung SE20. The testing code reads 64Kb of data off flash in 4Kb chunks, and sends each chunk to a receiving phone over an L2CAP channel.

The tests were replicated with an iPhone with similar results, in that roughly 235 bytes seems the optimum amount of data to push into the l2cap send at a time.

| Variant | L2CAP MTU | Chunk Size | Average throughput |
|---------|-----------|------------|--------------------|
| 1       | 235       | 235        | 12478 bytes/s      |
| 2       | 235       | 470        | 7388 bytes/s       |
| 3       | 984       | 1968       | 5210 bytes/s       |
| 4       | 235       | 117        | 11826 bytes/s      |
| 5       | 984       | 117        | 10062 bytes/s     |
| 6       | 984       | 254        | 2563 bytes/s       |
| 7       | 984       | 235        | 16850 bytes/s      |



cc: @mattytrentini

