### PR TITLE
wait_msg() return op as indication if there was a message

### DIFF
--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -206,6 +206,7 @@ class MQTTClient:
             self.sock.write(pkt)
         elif op & 6 == 4:
             assert 0
+        return op
 
     # Checks whether a pending message from server is available.
     # If not, returns immediately with None. Otherwise, does


### PR DESCRIPTION
As indicated in this issue: https://github.com/micropython/micropython-lib/issues/328, it would be useful if wait_msg() would return a value if a message was received.
A common use case using this library would be:

```
def callback(topic, msg):
    print(topic, msg)


async def check_messages(mqtt_client, interval):
    while True:
        mqtt_client.check_msg()
        await asyncio.sleep(interval)
```

In the above scenario, if more than one message was published to the topic being subscribed to, it will still get consumed every <interval> seconds. If this change is merged, we would be able to do:

```
def callback(topic, msg):
    print(topic, msg)


async def check_messages(mqtt_client, interval):
    while True:
        while mqtt_client.check_msg() is not None:
            continue
        await asyncio.sleep(interval)
```
And any waiting messages will get consumed immediately.