### PR TITLE
weakref: Add basic stub function to aid in porting.

### DIFF
--- a/python-stdlib/weakref/manifest.py
+++ b/python-stdlib/weakref/manifest.py
@@ -1,0 +1,3 @@
+metadata(version="0.0.1")
+
+module("weakref.py")

--- a/python-stdlib/weakref/weakref.py
+++ b/python-stdlib/weakref/weakref.py
@@ -1,0 +1,11 @@
+"""
+# weakref
+https://docs.python.org/3/library/weakref.html
+
+Micropython does not have support for weakref in the VM, so currently this is a simple stub
+module that directly assigns the object reference to simplify porting of other libraries.
+"""
+
+
+def ref(obj):
+    return lambda: obj


### PR DESCRIPTION
This just allows most basic usages of weakref in other modules to "work" unless they test for actual cleanup via gc.collect etc.

Docs: https://docs.python.org/3/library/weakref.html#weakref.ref