### PR TITLE
aioble: Split into optional components.

### DIFF
--- a/micropython/bluetooth/aioble-central/manifest.py
+++ b/micropython/bluetooth/aioble-central/manifest.py
@@ -1,0 +1,5 @@
+metadata(version="0.1.0")
+
+require("aioble-core")
+
+package("aioble", files=("central.py",), base_path="../aioble")

--- a/micropython/bluetooth/aioble-client/manifest.py
+++ b/micropython/bluetooth/aioble-client/manifest.py
@@ -1,0 +1,5 @@
+metadata(version="0.1.0")
+
+require("aioble-core")
+
+package("aioble", files=("client.py",), base_path="../aioble")

--- a/micropython/bluetooth/aioble-core/manifest.py
+++ b/micropython/bluetooth/aioble-core/manifest.py
@@ -1,0 +1,11 @@
+metadata(version="0.1.0")
+
+package(
+    "aioble",
+    files=(
+        "__init__.py",
+        "core.py",
+        "device.py",
+    ),
+    base_path="../aioble",
+)

--- a/micropython/bluetooth/aioble-l2cap/manifest.py
+++ b/micropython/bluetooth/aioble-l2cap/manifest.py
@@ -1,0 +1,5 @@
+metadata(version="0.1.0")
+
+require("aioble-core")
+
+package("aioble", files=("l2cap.py",), base_path="../aioble")

--- a/micropython/bluetooth/aioble-peripheral/manifest.py
+++ b/micropython/bluetooth/aioble-peripheral/manifest.py
@@ -1,0 +1,5 @@
+metadata(version="0.1.0")
+
+require("aioble-core")
+
+package("aioble", files=("peripheral.py",), base_path="../aioble")

--- a/micropython/bluetooth/aioble-security/manifest.py
+++ b/micropython/bluetooth/aioble-security/manifest.py
@@ -1,0 +1,5 @@
+metadata(version="0.1.0")
+
+require("aioble-core")
+
+package("aioble", files=("security.py",), base_path="../aioble")

--- a/micropython/bluetooth/aioble-server/manifest.py
+++ b/micropython/bluetooth/aioble-server/manifest.py
@@ -1,0 +1,5 @@
+metadata(version="0.1.0")
+
+require("aioble-core")
+
+package("aioble", files=("server.py",), base_path="../aioble")

--- a/micropython/bluetooth/aioble/README.md
+++ b/micropython/bluetooth/aioble/README.md
@@ -1,7 +1,8 @@
 aioble
 ======
 
-This library provides an object-oriented, asyncio-based wrapper for MicroPython's [ubluetooth](https://docs.micropython.org/en/latest/library/ubluetooth.html) API.
+This library provides an object-oriented, asyncio-based wrapper for MicroPython's
+[bluetooth](https://docs.micropython.org/en/latest/library/bluetooth.html) API.
 
 **Note**: aioble requires MicroPython v1.17 or higher.
 
@@ -48,6 +49,24 @@ Security:
 * Query encryption/authentication state.
 
 All remote operations (connect, disconnect, client read/write, server indicate, l2cap recv/send, pair) are awaitable and support timeouts.
+
+Installation
+------------
+
+You can install any combination of the following packages.
+- `aioble-central` -- Central (and Observer) role functionality including
+  scanning and connecting.
+- `aioble-client` -- GATT client, typically used by central role devices but
+  can also be used on peripherals.
+- `aioble-l2cap` -- L2CAP Connection-oriented-channels support.
+- `aioble-peripheral` -- Peripheral (and Broadcaster) role functionality
+  including advertising.
+- `aioble-security` -- Pairing and bonding support.
+- `aioble-server` -- GATT server, typically used by peripheral role devices
+  but can also be used on centrals.
+
+For the typical case of implementing a peripheral and GATT server, use the `aioble` package, which
+depends on `aioble-peripheral` and `aioble-server`.
 
 Usage
 -----

--- a/micropython/bluetooth/aioble/manifest.py
+++ b/micropython/bluetooth/aioble/manifest.py
@@ -1,27 +1,11 @@
-_files = (
-    "__init__.py",
-    "core.py",
-    "device.py",
-)
+# This directory contains all aioble code, but the manifest itself just
+# forwards to the component manifests, which themselves reference the actual
+# code.
+# This allows (for development purposes) all the files to live in the one
+# directory.
 
-options.defaults(peripheral=True, server=True)
+metadata(version="0.1.0")
 
-if options.central:
-    _files += ("central.py",)
-
-if options.client:
-    _files += ("client.py",)
-
-if options.peripheral:
-    _files += ("peripheral.py",)
-
-if options.server:
-    _files += ("server.py",)
-
-if options.l2cap:
-    _files += ("l2cap.py",)
-
-if options.security:
-    _files += ("security.py",)
-
-package("aioble", files=_files)
+# Default installation gives you core, peripheral, and server.
+require("aioble-peripheral")
+require("aioble-server")


### PR DESCRIPTION
This replaces the options that could be specified previously to include and require.

The `aioble` package provides the same as the default options did previously. Optional dependencies can now be require()'ed explicitly.
