### PR TITLE
aioble: Ordered handling of char.written().

### DIFF
--- a/micropython/bluetooth/aioble/multitests/ble_write_order.py
+++ b/micropython/bluetooth/aioble/multitests/ble_write_order.py
@@ -1,0 +1,119 @@
+# Test characteristic write capture.
+
+import sys
+
+sys.path.append("")
+
+from micropython import const
+import time, machine
+
+import uasyncio as asyncio
+import aioble
+import bluetooth
+
+TIMEOUT_MS = 5000
+
+# Test passes with delay of 1, fails some at 5, fails more at 50
+DUMMY_DELAY = 50
+
+SERVICE_UUID = bluetooth.UUID("A5A5A5A5-FFFF-9999-1111-5A5A5A5A5A5A")
+CHAR_FIRST_UUID = bluetooth.UUID("00000000-1111-2222-3333-444444444444")
+CHAR_SECOND_UUID = bluetooth.UUID("00000000-1111-2222-3333-555555555555")
+
+import uos
+
+# Acting in peripheral role.
+async def instance0_task():
+    service = aioble.Service(SERVICE_UUID)
+    characteristic_first = aioble.Characteristic(
+        service,
+        CHAR_FIRST_UUID,
+        write=True,
+        capture=True,
+    )
+    # Second characteristic enabled write capture.
+    characteristic_second = aioble.Characteristic(
+        service,
+        CHAR_SECOND_UUID,
+        write=True,
+        capture=True,
+    )
+    aioble.register_services(service)
+
+    # Register characteristic.written() handlers as asyncio background tasks.
+    # The order of these is important!
+    asyncio.create_task(task_written(characteristic_second, "second"))
+    asyncio.create_task(task_written(characteristic_first, "first"))
+
+    # This dummy task simulates background processing on a real system that
+    # can block the asyncio loop for brief periods of time
+    asyncio.create_task(task_dummy())
+
+    multitest.globals(BDADDR=aioble.config("mac"))
+    multitest.next()
+
+    # Wait for central to connect to us.
+    print("advertise")
+    async with await aioble.advertise(
+        20_000, adv_data=b"\x02\x01\x06\x04\xffMPY", timeout_ms=TIMEOUT_MS
+    ) as connection:
+        print("connected")
+
+        await connection.disconnected()
+
+
+async def task_written(chr, label):
+    while True:
+        await chr.written()
+        data = chr.read().decode()
+        print(f"written: {label} {data}")
+
+
+async def task_dummy():
+    while True:
+        time.sleep_ms(DUMMY_DELAY)
+        await asyncio.sleep_ms(5)
+
+
+def instance0():
+    try:
+        asyncio.run(instance0_task())
+    finally:
+        aioble.stop()
+
+
+# Acting in central role.
+async def instance1_task():
+    multitest.next()
+
+    # Connect to peripheral and then disconnect.
+    print("connect")
+    device = aioble.Device(*BDADDR)
+    async with await device.connect(timeout_ms=TIMEOUT_MS) as connection:
+        # Discover characteristics.
+        service = await connection.service(SERVICE_UUID)
+        print("service", service.uuid)
+        characteristic_first = await service.characteristic(CHAR_FIRST_UUID)
+        characteristic_second = await service.characteristic(CHAR_SECOND_UUID)
+        print("characteristic", characteristic_first.uuid, characteristic_second.uuid)
+
+        for i in range(5):
+            print(f"write c{i}")
+            await characteristic_first.write("c" + str(i), timeout_ms=TIMEOUT_MS)
+            await characteristic_second.write("c" + str(i), timeout_ms=TIMEOUT_MS)
+
+            await asyncio.sleep_ms(300)
+
+        for i in range(5):
+            print(f"write r{i}")
+            await characteristic_second.write("r" + str(i), timeout_ms=TIMEOUT_MS)
+            await characteristic_first.write("r" + str(i), timeout_ms=TIMEOUT_MS)
+
+            await asyncio.sleep_ms(300)
+
+
+def instance1():
+    try:
+        asyncio.run(instance1_task())
+    finally:
+        aioble.stop()

--- a/micropython/bluetooth/aioble/multitests/ble_write_order.py.exp
+++ b/micropython/bluetooth/aioble/multitests/ble_write_order.py.exp
@@ -1,0 +1,37 @@
+--- instance0 ---
+advertise
+connected
+written: first c0
+written: second c0
+written: first c1
+written: second c1
+written: first c2
+written: second c2
+written: first c3
+written: second c3
+written: first c4
+written: second c4
+written: second r0
+written: first r0
+written: second r1
+written: first r1
+written: second r2
+written: first r2
+written: second r3
+written: first r3
+written: second r4
+written: first r4
+--- instance1 ---
+connect
+service UUID('a5a5a5a5-ffff-9999-1111-5a5a5a5a5a5a')
+characteristic UUID('00000000-1111-2222-3333-444444444444') UUID('00000000-1111-2222-3333-555555555555')
+write c0
+write c1
+write c2
+write c3
+write c4
+write r0
+write r1
+write r2
+write r3
+write r4


### PR DESCRIPTION
On a ble peripheral system with a "significant" number of background asyncio tasks, reception & handling concurrent characteristic writes (eg. a looping task with `await characteristic.written()` can occur out of order.

For some services this can severly impact function, where writes to multiple characteristics to perform functions is critical. For example, in the Object Transfer Service it's common to "set a list filter" on one char, then "send the next list item" on a separate char. If these are handled out of order incorrect results are sent.

Essentially, if the vm / asyncio loop is slowed down by a background task (in this case a `time.sleep()`) while two ble write operations are received by the stack, the asyncio.Event for both characteristics can be set before either aioble characteristic event handler services them.

In this case, the `characteristic.written()` event of which ever task is checked first (whichever one was originally registered first) will be serviced first, regardless of which one came in first.

The first commit in this PR adds a multitest that demonstrates this behavior, failing as some of the messages arrive out of order.

The second commit addresses this issue by re-working the existing `Characteristic(capture=True)` functionality to work through a single shared `deque` which is handled by a background async task. This task pops individual incoming write events from the shared queue and forwards them to the respective characteristic event sequentially. Only once that `characteristic.written()` handles the event does the manager task continue to any other events in the shared queue.

Characteristics configured with `capture=False` (default) still behave the same as previously.

---
This work was funded by Planet Innovation.