### PR TITLE
os.path: Remove ffi os.access usage in exists().

### DIFF
--- a/python-stdlib/os-path/manifest.py
+++ b/python-stdlib/os-path/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.1.3")
+metadata(version="0.1.4")
 
 # Originally written by Paul Sokolovsky.
 

--- a/python-stdlib/os-path/os/path.py
+++ b/python-stdlib/os-path/os/path.py
@@ -47,7 +47,11 @@ def basename(path):
 
 
 def exists(path):
-    return os.access(path, os.F_OK)
+    try:
+        os.stat(path)
+        return True
+    except OSError:
+        return False
 
 
 # TODO
@@ -55,11 +59,9 @@ lexists = exists
 
 
 def isdir(path):
-    import stat
-
     try:
         mode = os.stat(path)[0]
-        return stat.S_ISDIR(mode)
+        return mode & 0o040000
     except OSError:
         return False
 


### PR DESCRIPTION
The current `os.path.exists()` function uses `os.access()` which is only provided in the ffi os module, not in `uos`.

```
anl@STEP: ~ $ micropython
MicroPython v1.18-305-g587339022 on 2022-04-11; linux [GCC 9.4.0] version
Use Ctrl-D to exit, Ctrl-E for paste mode
>>> import os
>>> os.access
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'access'
>>>
```

Also, `is_dir` requries the stat module from micropython-lib