### PR TITLE
micropython/mip: Add command-line functionality for the Unix port.

### DIFF
--- a/micropython/mip-cmdline/manifest.py
+++ b/micropython/mip-cmdline/manifest.py
@@ -1,0 +1,6 @@
+metadata(version="0.1.0", description="Optional support for running `micropython -m mip`")
+
+require("argparse")
+require("mip")
+
+package("mip")

--- a/micropython/mip-cmdline/mip/__main__.py
+++ b/micropython/mip-cmdline/mip/__main__.py
@@ -1,0 +1,46 @@
+# MicroPython package installer command line
+# MIT license; Copyright (c) 2022 Jim Mussared
+
+import argparse
+import sys
+
+
+def do_install():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-t",
+        "--target",
+        help="Directory to start discovery",
+    )
+    parser.add_argument(
+        "-i",
+        "--index",
+        help="Pattern to match test files",
+    )
+    parser.add_argument(
+        "--mpy",
+        action="store_true",
+        help="download as compiled .mpy files (default)",
+    )
+    parser.add_argument(
+        "--no-mpy",
+        action="store_true",
+        help="download as .py source files",
+    )
+    parser.add_argument("package", nargs="+")
+    args = parser.parse_args(args=sys.argv[2:])
+
+    from . import install
+
+    for package in args.package:
+        version = None
+        if "@" in package:
+            package, version = package.split("@")
+        install(package, args.index, args.target, version, not args.no_mpy)
+
+
+if len(sys.argv) >= 2:
+    if sys.argv[1] == "install":
+        do_install()
+    else:
+        print('mip: Unknown command "{}"'.format(sys.argv[1]))

--- a/micropython/mip/manifest.py
+++ b/micropython/mip/manifest.py
@@ -2,4 +2,4 @@ metadata(version="0.2.0", description="On-device package installer for network-c
 
 require("urequests")
 
-package("mip")
+package("mip", opt=3)

--- a/micropython/mip/manifest.py
+++ b/micropython/mip/manifest.py
@@ -1,5 +1,5 @@
-metadata(version="0.1.0", description="On-device package installer for network-capable boards")
+metadata(version="0.2.0", description="On-device package installer for network-capable boards")
 
 require("urequests")
 
-module("mip.py")
+package("mip")

--- a/micropython/mip/mip/__init__.py
+++ b/micropython/mip/mip/__init__.py
@@ -153,7 +153,7 @@ def _install_package(package, index, target, version, mpy):
     return _install_json(package, index, target, version, mpy)
 
 
-def install(package, index=_PACKAGE_INDEX, target=None, version=None, mpy=True):
+def install(package, index=None, target=None, version=None, mpy=True):
     if not target:
         for p in sys.path:
             if p.endswith("/lib"):
@@ -162,6 +162,9 @@ def install(package, index=_PACKAGE_INDEX, target=None, version=None, mpy=True):
         else:
             print("Unable to find lib dir in sys.path")
             return
+
+    if not index:
+        index = _PACKAGE_INDEX
 
     if _install_package(package, index.rstrip("/"), target, version, mpy):
         print("Done")


### PR DESCRIPTION
Moves mip.py to mip/__init__.py, so that the optional (added in this commit) mip/__main__.py can exist to support:

`micropython -m mip install [--target,--index,--no-mpy] package@version`

"install" works by forwarding the arguments directly to mip.install.

Also makes mip opt=3 by default because it's going to be frozen-by-default on many boards.

@mattytrentini I think this is something you've expressed an interest in previously?

_This work was funded through GitHub Sponsors._