### PR TITLE
unittest: Convert to a package.

### DIFF
--- a/python-stdlib/unittest-discover/manifest.py
+++ b/python-stdlib/unittest-discover/manifest.py
@@ -1,7 +1,7 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 
 require("argparse")
 require("fnmatch")
 require("unittest")
 
-module("unittest_discover.py")
+package("unittest")

--- a/python-stdlib/unittest-discover/unittest/__main__.py
+++ b/python-stdlib/unittest-discover/unittest/__main__.py
@@ -110,7 +110,6 @@ def _dirname_filename_no_ext(path):
     return dirname, filename.rsplit(".", 1)[0]
 
 
-# This is called from unittest when __name__ == "__main__".
 def discover_main():
     failures = 0
     runner = TestRunner()
@@ -138,3 +137,6 @@ def discover_main():
 
     # Terminate with non zero return code in case of failures.
     sys.exit(failures)
+
+
+discover_main()

--- a/python-stdlib/unittest/manifest.py
+++ b/python-stdlib/unittest/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.10.0")
+metadata(version="0.10.1")
 
-module("unittest.py")
+package("unittest")

--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -460,15 +460,3 @@ def main(module="__main__", testRunner=None):
     suite = TestSuite(module.__name__)
     suite._load_module(module)
     return testRunner.run(suite)
-
-
-# Support `micropython -m unittest` (only useful if unitest-discover is
-# installed).
-if __name__ == "__main__":
-    try:
-        # If unitest-discover is installed, use the main() provided there.
-        from unittest_discover import discover_main
-
-        discover_main()
-    except ImportError:
-        pass


### PR DESCRIPTION
This allows a much more natural way of implementing unitttest-discover:
 - unittest provides `unittest/__init__.py`
 - unittest-discover provides `unittest/__main__.py`

It also fixes an bug where unittest.py previously detected the presence of unittest-discover.py by importing an checking for the ImportError. But that could also be raised by a missing dependency. Now when you run `micropython -m unittest` without unittest-discover, you get `ImportError: no module named 'unittest.__main__'`, and without the required deps, `ImportError: no module named 'argparse'`.

Includes a version bump for both.