### PR TITLE
aiorepl: Ignore second linefeed immediately after first

### DIFF
--- a/micropython/aiorepl/aiorepl.py
+++ b/micropython/aiorepl/aiorepl.py
@@ -104,8 +104,8 @@ async def task(g=None, prompt="--> "):
             cmd = ""
             while True:
                 b = await s.read(1)
-                c = ord(b)
                 pc = c  # save previous character
+                c = ord(b)
                 pt = t  # save previous time
                 t = time.ticks_ms()
                 if c < 0x20 or c > 0x7E:

--- a/micropython/aiorepl/aiorepl.py
+++ b/micropython/aiorepl/aiorepl.py
@@ -110,7 +110,10 @@ async def task(g=None, prompt="--> "):
                 t = time.ticks_ms()
                 if c < 0x20 or c > 0x7E:
                     if c == 0x0A:
-                        # CR
+                        # LF
+                        # If the previous character was also linefeed, and was less than 20 ms ago, ignore this linefeed
+                        if pc == 0x0A and time.ticks_diff(t, pt) < 20:
+                            continue
                         sys.stdout.write("\n")
                         if cmd:
                             # Push current command.


### PR DESCRIPTION
Pressing Enter or Return in a windows client will send two characters. Both will received because aiorepl reads characters one-by-one, both will be a linefeed after universal newline conversion.

This change means the second linefeed is ignored