### PR TITLE
datetime: Add default utc tz for now()

### DIFF
--- a/python-stdlib/datetime/datetime.py
+++ b/python-stdlib/datetime/datetime.py
@@ -635,10 +635,10 @@ class datetime:
         else:
             us = 0
         if tz is None:
-            raise NotImplementedError
-        else:
-            dt = cls(*_tmod.gmtime(ts)[:6], microsecond=us, tzinfo=tz)
-            dt = tz.fromutc(dt)
+            tz = timezone.utc
+        
+        dt = cls(*_tmod.gmtime(ts)[:6], microsecond=us, tzinfo=tz)
+        dt = tz.fromutc(dt)
         return dt
 
     @classmethod


### PR DESCRIPTION
The datetime module doesn't support naive datetimes and throws an unimplemented error when calling some of the methods such as datetime.now().

Rather than passing a tz object to these methods on each call I feel it would be best to use a default tz (utc) when a tz isn't provided. This would be more CPython compliant for the end user.

This pr adds a default utc timezone in fromtimestamp() if no tz is supplied.

