### PR TITLE
aiorepl: Use stdin in binary mode and catch windows enter presses

### DIFF
--- a/micropython/aiorepl/aiorepl.py
+++ b/micropython/aiorepl/aiorepl.py
@@ -101,7 +101,7 @@ async def task(g=None, prompt="--> "):
         while True:
             hist_b = 0  # How far back in the history are we currently.
             sys.stdout.write(prompt)
-            cmd = b''
+            cmd = b""
             while True:
                 b = await s.read(1)
                 pc = c  # save previous character


### PR DESCRIPTION
Changed this to use stdin.buffer instead of stdin. Now catches and ignores the consecutive line ending characters within 20ms of the previous.