### PR TITLE
aioble/client.py: Fix default for the `response` arg to char.write().

### DIFF
--- a/micropython/bluetooth/aioble/aioble/client.py
+++ b/micropython/bluetooth/aioble/aioble/client.py
@@ -269,16 +269,13 @@ class BaseClientCharacteristic:
             characteristic._read_status = status
             characteristic._read_event.set()
 
-    async def write(self, data, response=False, timeout_ms=1000):
+    async def write(self, data, response=None, timeout_ms=1000):
         self._check(_FLAG_WRITE | _FLAG_WRITE_NO_RESPONSE)
 
-        # If we only support write-with-response, then force sensible default.
-        if (
-            response is None
-            and (self.properties & _FLAGS_WRITE)
-            and not (self.properties & _FLAG_WRITE_NO_RESPONSE)
-        ):
-            response = True
+        # If the response arg is unset, then default it to true if we only support write-with-response.
+        if response is None:
+            p = self.properties
+            response = (p & _FLAG_WRITE) and not (p & _FLAG_WRITE_NO_RESPONSE)
 
         if response:
             # Same as read.


### PR DESCRIPTION
- `_FLAG_WRITE` was incorrectly `_FLAGS_WRITE`
- `response` should be defaulted to `None` rather than `False` in order
  to detect that when it is unspecified.

@Enasynco this should fix #563

_This work was funded through GitHub Sponsors._