### PR TITLE
Pathlib Support

### DIFF
--- a/python-stdlib/pathlib/pathlib.py
+++ b/python-stdlib/pathlib/pathlib.py
@@ -1,0 +1,115 @@
+import os
+
+
+def _try(ok, f, *args, **kwargs):
+    if ok:
+        try:
+            f(*args, **kwargs)
+        except OSError:
+            pass
+    else:
+        f(*args, **kwargs)
+
+
+class Path:
+    def __init__(self, *segments):
+        self._path = "/".join(segments)
+        # self._path will never end in "/"
+        while self._path[-1] == "/":
+            self._path = self._path[:-1]
+
+    def __truediv__(self, other):
+        return self._path + "/" + other
+
+    def open(self, mode='r', encoding=None):
+        with open(self._path, mode) as f:
+            yield f
+
+    def exists(self):
+        try:
+            os.stat(self._path)
+        except OSError:
+            return False
+        return True
+
+    def mkdir(self, parents=False, exist_ok=False):
+        if parents:
+            segments = self._path.split("/")
+            if segments[0] == "":
+                segments = segments[1:]
+                progressive_path = "/"
+            else:
+                progressive_path = ""
+            for segment in segments:
+                progressive_path += "/" + segment
+                _try(
+                    not (progressive_path == self._path and not exist_ok),
+                    os.mkdir,
+                    progressive_path
+                )
+        else:
+            _try(exist_ok, os.mkdir, self._path)
+
+    def glob(self):
+        raise NotImplementedError
+
+    def rglob(self):
+        raise NotImplementedError
+
+    def stat(self):
+        return os.stat(self._path)
+
+    def read_bytes(self):
+        with open(self._path, "rb") as f:
+            return f.read()
+
+    def read_text(self, encoding=None):
+        with open(self._path, "r") as f:
+            return f.read()
+
+    def rename(self, target):
+        os.rename(self._path, target)
+
+    def rmdir(self):
+        os.rmdir(self._path)
+
+    def touch(self, exist_ok=True):
+        try:
+            os.stat(self._path)
+        except OSError:
+            if not exist_ok:
+                return
+
+        with open(self._path):
+            pass
+
+    def unlink(self, missing_ok=False):
+        _try(missing_ok, os.unlink, self._path)
+
+    def write_bytes(self, data):
+        with open(self._path, "wb") as f:
+            f.write(data)
+
+    def write_text(self, data, encoding=None):
+        with open(self._path, "w") as f:
+            f.write(data)
+
+    @property
+    def stem(self):
+        return self.name.rsplit(".", 1)[0]
+
+    @property
+    def parent(self):
+        return Path(*self._path.split("/"))
+
+    @property
+    def name(self):
+        return self._path.rsplit("/", 1)[-1]
+
+    @property
+    def suffix(self):
+        elems = self._path.rsplit(".", 1)
+        if len(elems) == 1:
+            return ""
+        else:
+            return "." + elems[-1]

--- a/python-stdlib/pathlib/tests/test_pathlib.py
+++ b/python-stdlib/pathlib/tests/test_pathlib.py
@@ -15,6 +15,7 @@ def ilistdir(x):
 
 os.ilistdir = ilistdir
 
+
 @pytest.fixture
 def mock_os_getcwd(mocker):
     return mocker.patch("upathlib.os.getcwd", return_value="/")
@@ -120,11 +121,11 @@ def test_is_file(tmp_path):
 
 
 def test_glob(tmp_path):
-    foo_txt = (tmp_path / "foo.txt")
+    foo_txt = tmp_path / "foo.txt"
     foo_txt.touch()
-    bar_txt = (tmp_path / "bar.txt")
+    bar_txt = tmp_path / "bar.txt"
     bar_txt.touch()
-    baz_bin = (tmp_path / "baz.bin")
+    baz_bin = tmp_path / "baz.bin"
     baz_bin.touch()
 
     path = Path(str(tmp_path))
@@ -138,15 +139,15 @@ def test_glob(tmp_path):
 
 
 def test_rglob(tmp_path):
-    foo_txt = (tmp_path / "foo.txt")
+    foo_txt = tmp_path / "foo.txt"
     foo_txt.touch()
-    bar_txt = (tmp_path / "bar.txt")
+    bar_txt = tmp_path / "bar.txt"
     bar_txt.touch()
-    baz_bin = (tmp_path / "baz.bin")
+    baz_bin = tmp_path / "baz.bin"
     baz_bin.touch()
-    boop_folder = (tmp_path / "boop")
+    boop_folder = tmp_path / "boop"
     boop_folder.mkdir()
-    bap_txt = (tmp_path / "boop" / "bap.txt")
+    bap_txt = tmp_path / "boop" / "bap.txt"
     bap_txt.touch()
 
     path = Path(str(tmp_path))
@@ -282,4 +283,3 @@ def test_with_suffix():
     assert Path("foo/test").with_suffix(".tar") == Path("foo/test.tar")
     assert Path("foo/bar.bin").with_suffix(".txt") == Path("foo/bar.txt")
     assert Path("bar.txt").with_suffix("") == Path("bar")
-

--- a/python-stdlib/pathlib/tests/test_pathlib.py
+++ b/python-stdlib/pathlib/tests/test_pathlib.py
@@ -1,0 +1,104 @@
+import os
+from importlib.machinery import SourceFileLoader
+
+import pytest
+
+from upathlib import Path
+
+
+def ilistdir(x):
+    for name in os.listdir(x):
+        stat = os.stat(x + "/" + name)  # noqa: PL116
+        yield (name, stat.st_mode, stat.st_ino)
+
+
+os.ilistdir = ilistdir
+
+@pytest.fixture
+def tmp_path_str_str(tmp_path_str):
+    return tmp_path_str_str
+
+
+def test_init_single_segment():
+    path = Path("foo")
+    assert path._path == "foo"
+
+    path = Path("foo/")
+    assert path._path == "foo"
+
+    path = Path("/foo")
+    assert path._path == "/foo"
+
+
+def test_init_multiple_segment():
+    path = Path("foo", "bar")
+    assert path._path == "foo/bar"
+
+    path = Path("foo/", "bar")
+    assert path._path == "foo/bar"
+
+    path = Path("/foo", "bar")
+    assert path._path == "/foo/bar"
+
+
+def test_truediv_join():
+    pass
+
+
+def test_open():
+    pass
+
+
+def test_exists(tmp_path_str):
+    pass
+
+
+def test_mkdir(tmp_path_str):
+    pass
+
+
+def test_glob(tmp_path_strl):
+    pass
+
+
+def test_rglob(tmp_path_str):
+    pass
+
+
+def test_stat(tmp_path_str):
+    pass
+
+
+def test_rmdir(tmp_path_str):
+    pass
+
+
+def test_touch(tmp_path_str):
+    pass
+
+def test_unlink(tmp_path_str):
+    pass
+
+def test_write_bytes(tmp_path_str):
+    pass
+
+def test_write_text(tmp_path_str):
+    pass
+
+def test_read_bytes(tmp_path_str):
+    pass
+
+def test_read_text(tmp_path_str):
+    pass
+
+def test_stem():
+    pass
+
+def test_name():
+    pass
+
+def test_parent():
+    pass
+
+def test_suffix():
+    pass

--- a/python-stdlib/pathlib/tests/test_pathlib.py
+++ b/python-stdlib/pathlib/tests/test_pathlib.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 from importlib.machinery import SourceFileLoader
 
@@ -15,90 +16,263 @@ def ilistdir(x):
 os.ilistdir = ilistdir
 
 @pytest.fixture
-def tmp_path_str_str(tmp_path_str):
-    return tmp_path_str_str
+def mock_os_getcwd(mocker):
+    return mocker.patch("upathlib.os.getcwd", return_value="/")
 
 
-def test_init_single_segment():
+def test_init_single_segment(mock_os_getcwd):
     path = Path("foo")
-    assert path._path == "foo"
+    assert path._abs_path == "/foo"
 
     path = Path("foo/")
-    assert path._path == "foo"
+    assert path._abs_path == "/foo"
 
     path = Path("/foo")
-    assert path._path == "/foo"
+    assert path._abs_path == "/foo"
 
 
-def test_init_multiple_segment():
+def test_init_multiple_segment(mock_os_getcwd):
     path = Path("foo", "bar")
-    assert path._path == "foo/bar"
+    assert path._abs_path == "/foo/bar"
 
     path = Path("foo/", "bar")
-    assert path._path == "foo/bar"
+    assert path._abs_path == "/foo/bar"
 
     path = Path("/foo", "bar")
-    assert path._path == "/foo/bar"
+    assert path._abs_path == "/foo/bar"
 
 
 def test_truediv_join():
     pass
 
 
-def test_open():
-    pass
+def test_open(tmp_path):
+    fn = tmp_path / "foo.txt"
+    path = Path(str(fn))
+
+    with path.open("w") as f:
+        f.write("file contents")
+
+    with path.open("r") as f:
+        actual = f.read()
+
+    assert actual == "file contents"
 
 
-def test_exists(tmp_path_str):
-    pass
+def test_exists(tmp_path):
+    fn = tmp_path / "foo.txt"
+
+    path = Path(str(fn))
+    assert not path.exists()
+
+    fn.touch()
+
+    assert path.exists()
 
 
-def test_mkdir(tmp_path_str):
-    pass
+def test_mkdir(tmp_path):
+    target = tmp_path / "foo" / "bar" / "baz"
+    path = Path(str(target))
+
+    with pytest.raises(OSError):
+        path.mkdir()
+
+    with pytest.raises(OSError):
+        path.mkdir(exist_ok=True)
+
+    path.mkdir(parents=True)
+    assert target.is_dir()
+
+    with pytest.raises(OSError):
+        path.mkdir(exist_ok=False)
+
+    path.mkdir(exist_ok=True)
 
 
-def test_glob(tmp_path_strl):
-    pass
+def test_is_dir(tmp_path):
+    target = tmp_path
+    path = Path(str(target))
+    assert path.is_dir()
+
+    target = tmp_path / "foo"
+    path = Path(str(target))
+    assert not path.is_dir()
+    target.mkdir()
+    assert path.is_dir()
+
+    target = tmp_path / "bar.txt"
+    path = Path(str(target))
+    assert not path.is_dir()
+    target.touch()
+    assert not path.is_dir()
 
 
-def test_rglob(tmp_path_str):
-    pass
+def test_is_file(tmp_path):
+    target = tmp_path
+    path = Path(str(target))
+    assert not path.is_file()
+
+    target = tmp_path / "bar.txt"
+    path = Path(str(target))
+    assert not path.is_file()
+    target.touch()
+    assert path.is_file()
 
 
-def test_stat(tmp_path_str):
-    pass
+def test_glob(tmp_path):
+    foo_txt = (tmp_path / "foo.txt")
+    foo_txt.touch()
+    bar_txt = (tmp_path / "bar.txt")
+    bar_txt.touch()
+    baz_bin = (tmp_path / "baz.bin")
+    baz_bin.touch()
+
+    path = Path(str(tmp_path))
+    res = path.glob("*.txt")
+    assert inspect.isgenerator(res)
+
+    res = [str(x) for x in res]
+    assert len(res) == 2
+    assert str(foo_txt) in res
+    assert str(bar_txt) in res
 
 
-def test_rmdir(tmp_path_str):
-    pass
+def test_rglob(tmp_path):
+    foo_txt = (tmp_path / "foo.txt")
+    foo_txt.touch()
+    bar_txt = (tmp_path / "bar.txt")
+    bar_txt.touch()
+    baz_bin = (tmp_path / "baz.bin")
+    baz_bin.touch()
+    boop_folder = (tmp_path / "boop")
+    boop_folder.mkdir()
+    bap_txt = (tmp_path / "boop" / "bap.txt")
+    bap_txt.touch()
+
+    path = Path(str(tmp_path))
+    res = path.rglob("*.txt")
+    assert inspect.isgenerator(res)
+
+    res = [str(x) for x in res]
+    assert len(res) == 3
+    assert str(foo_txt) in res
+    assert str(bar_txt) in res
+    assert str(bap_txt) in res
 
 
-def test_touch(tmp_path_str):
-    pass
+def test_stat(tmp_path):
+    expected = os.stat(tmp_path)
+    path = Path(str(tmp_path))
+    actual = path.stat()
+    assert expected == actual
 
-def test_unlink(tmp_path_str):
-    pass
 
-def test_write_bytes(tmp_path_str):
-    pass
+def test_rmdir(tmp_path):
+    target = tmp_path / "foo"
 
-def test_write_text(tmp_path_str):
-    pass
+    path = Path(str(target))
 
-def test_read_bytes(tmp_path_str):
-    pass
+    with pytest.raises(OSError):
+        # Doesn't exist
+        path.rmdir()
 
-def test_read_text(tmp_path_str):
-    pass
+    target.mkdir()
+    assert target.exists()
+    path.rmdir()
+    assert not target.exists()
 
-def test_stem():
-    pass
+    target.mkdir()
+    (target / "bar.txt").touch()
+    with pytest.raises(OSError):
+        # Cannot rmdir; contains file.
+        path.rmdir()
+
+
+def test_touch(tmp_path):
+    target = tmp_path / "foo.txt"
+    assert not target.exists()
+
+    path = Path(str(target))
+    path.touch()
+    assert target.exists()
+
+    path = Path(str(tmp_path / "bar" / "baz.txt"))
+    with pytest.raises(OSError):
+        # Parent directory does not exist
+        path.touch()
+
+
+def test_unlink(tmp_path):
+    target = tmp_path / "foo.txt"
+
+    path = Path(str(target))
+    with pytest.raises(OSError):
+        # File does not exist
+        path.unlink()
+
+    target.touch()
+    assert target.exists()
+    path.unlink()
+    assert not target.exists()
+
+    path = Path(str(tmp_path))
+    with pytest.raises(OSError):
+        # File does not exist
+        path.unlink()
+
+
+def test_write_bytes(tmp_path):
+    target = tmp_path / "foo.bin"
+    path = Path(str(target))
+    path.write_bytes(b"test byte data")
+    actual = target.read_bytes()
+    assert actual == b"test byte data"
+
+
+def test_write_text(tmp_path):
+    target = tmp_path / "foo.txt"
+    path = Path(str(target))
+    path.write_text("test string")
+    actual = target.read_text()
+    assert actual == "test string"
+
+
+def test_read_bytes(tmp_path):
+    target = tmp_path / "foo.bin"
+    target.write_bytes(b"test byte data")
+
+    path = Path(str(target))
+    actual = path.read_bytes()
+    assert actual == b"test byte data"
+
+
+def test_read_text(tmp_path):
+    target = tmp_path / "foo.txt"
+    target.write_text("test string")
+
+    path = Path(str(target))
+    actual = path.read_text()
+    assert actual == "test string"
+
+
+def test_stem(mock_os_getcwd):
+    assert Path("foo/test").stem == "test"
+    assert Path("foo/bar.bin").stem == "bar"
+    assert Path("").stem == ""
+
 
 def test_name():
-    pass
+    assert Path("foo/test").name == "test"
+    assert Path("foo/bar.bin").name == "bar.bin"
+
 
 def test_parent():
-    pass
+    assert Path("foo/test").parent == Path("foo")
+    assert Path("foo/bar.bin").parent == Path("foo")
+    assert Path("bar.bin").parent == Path(".")
+
 
 def test_suffix():
-    pass
+    assert Path("foo/test").suffix == ""
+    assert Path("foo/bar.bin").suffix == ".bin"
+    assert Path("bar.txt").suffix == ".txt"

--- a/python-stdlib/pathlib/tests/test_pathlib.py
+++ b/python-stdlib/pathlib/tests/test_pathlib.py
@@ -276,3 +276,10 @@ def test_suffix():
     assert Path("foo/test").suffix == ""
     assert Path("foo/bar.bin").suffix == ".bin"
     assert Path("bar.txt").suffix == ".txt"
+
+
+def test_with_suffix():
+    assert Path("foo/test").with_suffix(".tar") == Path("foo/test.tar")
+    assert Path("foo/bar.bin").with_suffix(".txt") == Path("foo/bar.txt")
+    assert Path("bar.txt").with_suffix("") == Path("bar")
+

--- a/python-stdlib/pathlib/upathlib.py
+++ b/python-stdlib/pathlib/upathlib.py
@@ -178,6 +178,13 @@ class Path:
         with open(self._abs_path, "w") as f:
             f.write(data)
 
+    def with_suffix(self, suffix):
+        old_suffix = self.suffix
+        if old_suffix:
+            return Path(self._abs_path[:-len(old_suffix)] + suffix)
+        else:
+            return Path(self._abs_path + suffix)
+
     @property
     def stem(self):
         return self.name.rsplit(".", 1)[0]

--- a/python-stdlib/pathlib/upathlib.py
+++ b/python-stdlib/pathlib/upathlib.py
@@ -13,7 +13,17 @@ def _try(ok, f, *args, **kwargs):
 
 class Path:
     def __init__(self, *segments):
-        self._path = "/".join(segments)
+        segments_stripped = []
+        for segment in segments:
+            if not segments_stripped and segment[0] == "/":
+                segments_stripped.append("")
+            while segment[-1] == "/":
+                segment = segment[:-1]
+            while segment[0] == "/":
+                segment = segment[1:]
+            segments_stripped.append(segment)
+
+        self._path = "/".join(segments_stripped)
         # self._path will never end in "/"
         while self._path[-1] == "/":
             self._path = self._path[:-1]

--- a/python-stdlib/pathlib/upathlib.py
+++ b/python-stdlib/pathlib/upathlib.py
@@ -38,8 +38,6 @@ class Path:
         return self._abs_path
 
     def __eq__(self, other):
-        # TODO: this doesn't handle the case of comparing
-        # relative vs absolute path.
         return self._abs_path == str(other)
 
 

--- a/python-stdlib/pathlib/upathlib.py
+++ b/python-stdlib/pathlib/upathlib.py
@@ -32,7 +32,7 @@ class Path:
         return self._abs_path + "/" + other
 
     def __repr__(self):
-        return f"{type(self).__name__}(\"{self._abs_path}\")"
+        return f'{type(self).__name__}("{self._abs_path}")'
 
     def __str__(self):
         return self._abs_path
@@ -40,8 +40,7 @@ class Path:
     def __eq__(self, other):
         return self._abs_path == str(other)
 
-
-    def open(self, mode='r', encoding=None):
+    def open(self, mode="r", encoding=None):
         return open(self._abs_path, mode, encoding=encoding)
 
     def exists(self):
@@ -179,7 +178,7 @@ class Path:
     def with_suffix(self, suffix):
         old_suffix = self.suffix
         if old_suffix:
-            return Path(self._abs_path[:-len(old_suffix)] + suffix)
+            return Path(self._abs_path[: -len(old_suffix)] + suffix)
         else:
             return Path(self._abs_path + suffix)
 


### PR DESCRIPTION
Here's my first stab at adding most of the common functionality of `pathlib.Path`. I'd say that 99% of the common use-case support is there. The `glob` functionality could use some work; currently it only supports a single `"*"` wildcard; however, this is the vast majority of common use-cases and it won't fail silently if non-supported glob patterns are provided.

Currently the module is named `upathlib`; this was just so that I could get it working with pytest. If someone could help me import it in tests without colliding with the builtin `pathlib`, that would be greatly appreciated!

Unit tests require `pytest-mock` to be installed.