### PR TITLE
nrf24l01test.py: Add RP2 support, fix ESP32.

### DIFF
--- a/micropython/drivers/radio/nrf24l01/nrf24l01test.py
+++ b/micropython/drivers/radio/nrf24l01/nrf24l01test.py
@@ -93,10 +93,7 @@ def initiator():
         # delay then loop
         utime.sleep_ms(250)
 
-    print(
-        "initiator finished sending; successes=%d, failures=%d"
-        % (num_successes, num_failures)
-    )
+    print("initiator finished sending; successes=%d, failures=%d" % (num_successes, num_failures))
 
 
 def responder():
@@ -148,6 +145,4 @@ print("NRF24L01 pinout for test:")
 print("    CE on", cfg["ce"])
 print("    CSN on", cfg["csn"])
 print("    SPI on", cfg["spi"])
-print(
-    "run nrf24l01test.responder() on responder, then nrf24l01test.initiator() on initiator"
-)
+print("run nrf24l01test.responder() on responder, then nrf24l01test.initiator() on initiator")

--- a/micropython/drivers/radio/nrf24l01/nrf24l01test.py
+++ b/micropython/drivers/radio/nrf24l01/nrf24l01test.py
@@ -20,7 +20,7 @@ elif usys.platform == "esp8266":  # Hardware SPI
     cfg = {"spi": 1, "miso": 12, "mosi": 13, "sck": 14, "csn": 4, "ce": 5}
 elif usys.platform == "esp32":  # Software SPI
     cfg = {"spi": -1, "miso": 32, "mosi": 33, "sck": 25, "csn": 26, "ce": 27}
-elif usys.platform=="rp2":  # Hardware SPI with explicit pin definitions
+elif usys.platform == "rp2":  # Hardware SPI with explicit pin definitions
     cfg = {"spi": -2, "miso": 4, "mosi": 3, "sck": 2, "csn": 5, "ce": 6}
 else:
     raise ValueError("Unsupported platform {}".format(usys.platform))

--- a/micropython/drivers/radio/nrf24l01/nrf24l01test.py
+++ b/micropython/drivers/radio/nrf24l01/nrf24l01test.py
@@ -7,12 +7,12 @@ from machine import Pin, SPI
 from nrf24l01 import NRF24L01
 from micropython import const
 
-# Slave pause between receiving data and checking for further packets.
+# Responder pause between receiving data and checking for further packets.
 _RX_POLL_DELAY = const(15)
-# Slave pauses an additional _SLAVE_SEND_DELAY ms after receiving data and before
-# transmitting to allow the (remote) master time to get into receive mode. The
-# master may be a slow device. Value tested with Pyboard, ESP32 and ESP8266.
-_SLAVE_SEND_DELAY = const(10)
+# Responder pauses an additional _RESPONER_SEND_DELAY ms after receiving data and before
+# transmitting to allow the (remote) initiator time to get into receive mode. The
+# initiator may be a slow device. Value tested with Pyboard, ESP32 and ESP8266.
+_RESPONDER_SEND_DELAY = const(10)
 
 if usys.platform == "pyboard":
     cfg = {"spi": 2, "miso": "Y7", "mosi": "Y8", "sck": "Y6", "csn": "Y5", "ce": "Y4"}
@@ -20,6 +20,8 @@ elif usys.platform == "esp8266":  # Hardware SPI
     cfg = {"spi": 1, "miso": 12, "mosi": 13, "sck": 14, "csn": 4, "ce": 5}
 elif usys.platform == "esp32":  # Software SPI
     cfg = {"spi": -1, "miso": 32, "mosi": 33, "sck": 25, "csn": 26, "ce": 27}
+elif usys.platform=="rp2":  # Hardware SPI with explicit pin definitions
+    cfg = {"spi": -2, "miso": 4, "mosi": 3, "sck": 2, "csn": 5, "ce": 6}
 else:
     raise ValueError("Unsupported platform {}".format(usys.platform))
 
@@ -28,11 +30,14 @@ else:
 pipes = (b"\xe1\xf0\xf0\xf0\xf0", b"\xd2\xf0\xf0\xf0\xf0")
 
 
-def master():
+def initiator():
     csn = Pin(cfg["csn"], mode=Pin.OUT, value=1)
     ce = Pin(cfg["ce"], mode=Pin.OUT, value=0)
     if cfg["spi"] == -1:
-        spi = SPI(-1, sck=Pin(cfg["sck"]), mosi=Pin(cfg["mosi"]), miso=Pin(cfg["miso"]))
+        spi = SoftSPI(sck=Pin(cfg["sck"]), mosi=Pin(cfg["mosi"]), miso=Pin(cfg["miso"]))
+        nrf = NRF24L01(spi, csn, ce, payload_size=8)
+    elif cfg["spi"] == -2:
+        spi = SPI(0, sck=Pin(cfg["sck"]), mosi=Pin(cfg["mosi"]), miso=Pin(cfg["miso"]))
         nrf = NRF24L01(spi, csn, ce, payload_size=8)
     else:
         nrf = NRF24L01(SPI(cfg["spi"]), csn, ce, payload_size=8)
@@ -46,7 +51,7 @@ def master():
     num_failures = 0
     led_state = 0
 
-    print("NRF24L01 master mode, sending %d packets..." % num_needed)
+    print("NRF24L01 initiator mode, sending %d packets..." % num_needed)
 
     while num_successes < num_needed and num_failures < num_needed:
         # stop listening and send packet
@@ -90,14 +95,17 @@ def master():
         # delay then loop
         utime.sleep_ms(250)
 
-    print("master finished sending; successes=%d, failures=%d" % (num_successes, num_failures))
+    print("initiator finished sending; successes=%d, failures=%d" % (num_successes, num_failures))
 
 
-def slave():
+def responder():
     csn = Pin(cfg["csn"], mode=Pin.OUT, value=1)
     ce = Pin(cfg["ce"], mode=Pin.OUT, value=0)
     if cfg["spi"] == -1:
         spi = SPI(-1, sck=Pin(cfg["sck"]), mosi=Pin(cfg["mosi"]), miso=Pin(cfg["miso"]))
+        nrf = NRF24L01(spi, csn, ce, payload_size=8)
+    elif cfg["spi"] == -2:
+        spi = SPI(0, sck=Pin(cfg["sck"]), mosi=Pin(cfg["mosi"]), miso=Pin(cfg["miso"]))
         nrf = NRF24L01(spi, csn, ce, payload_size=8)
     else:
         nrf = NRF24L01(SPI(cfg["spi"]), csn, ce, payload_size=8)
@@ -106,7 +114,7 @@ def slave():
     nrf.open_rx_pipe(1, pipes[0])
     nrf.start_listening()
 
-    print("NRF24L01 slave mode, waiting for packets... (ctrl-C to stop)")
+    print("NRF24L01 responder mode, waiting for packets... (ctrl-C to stop)")
 
     while True:
         if nrf.any():
@@ -122,8 +130,8 @@ def slave():
                     led_state >>= 1
                 utime.sleep_ms(_RX_POLL_DELAY)
 
-            # Give master time to get into receive mode.
-            utime.sleep_ms(_SLAVE_SEND_DELAY)
+            # Give initiator time to get into receive mode.
+            utime.sleep_ms(_RESPONDER_SEND_DELAY)
             nrf.stop_listening()
             try:
                 nrf.send(struct.pack("i", millis))
@@ -147,4 +155,4 @@ print("    CSN on", cfg["csn"])
 print("    SCK on", cfg["sck"])
 print("    MISO on", cfg["miso"])
 print("    MOSI on", cfg["mosi"])
-print("run nrf24l01test.slave() on slave, then nrf24l01test.master() on master")
+print("run nrf24l01test.responder() on responder, then nrf24l01test.initiator() on initiator")


### PR DESCRIPTION
Use explicit pin numbers to instantiate the SPI interface on RP2. On ESP32 use SoftSPI(...) rather than SPI(-1, ...).

Update terminology to initiator/responder.

Tested with two Pico boards.