### PR TITLE
micropython/drivers/sensors/dht: Fix a regression.

### DIFF
--- a/micropython/drivers/sensor/dht/dht.py
+++ b/micropython/drivers/sensor/dht/dht.py
@@ -8,6 +8,8 @@ if hasattr(machine, "dht_readinto"):
     from machine import dht_readinto
 elif sys.platform.startswith("esp"):
     from esp import dht_readinto
+elif sys.platform == "pyboard":
+    from pyb import dht_readinto
 else:
     dht_readinto = __import__(sys.platform).dht_readinto
 


### PR DESCRIPTION
sys.platform of Pyboard is "pyboard", not "pyb"