### PR TITLE
tempfile module and shutil.rmtree fix

### DIFF
--- a/python-stdlib/shutil/shutil.py
+++ b/python-stdlib/shutil/shutil.py
@@ -5,11 +5,14 @@ from collections import namedtuple
 _ntuple_diskusage = namedtuple("usage", ("total", "used", "free"))
 
 
-def rmtree(top):
-    for path, dirs, files in os.walk(top, False):
-        for f in files:
-            os.unlink(path + "/" + f)
-        os.rmdir(path)
+def rmtree(d):
+    for name, type, *_ in os.ilistdir(d):
+        path = d + "/" + name
+        if type & 0x4000:  # dir
+            rmtree(path)
+        else:  # file
+            os.unlink(path)
+    os.rmdir(d)
 
 
 def copyfileobj(src, dest, length=512):

--- a/python-stdlib/shutil/shutil.py
+++ b/python-stdlib/shutil/shutil.py
@@ -6,6 +6,9 @@ _ntuple_diskusage = namedtuple("usage", ("total", "used", "free"))
 
 
 def rmtree(d):
+    if not d:
+        raise ValueError
+
     for name, type, *_ in os.ilistdir(d):
         path = d + "/" + name
         if type & 0x4000:  # dir

--- a/python-stdlib/shutil/test_shutil.py
+++ b/python-stdlib/shutil/test_shutil.py
@@ -1,0 +1,56 @@
+"""
+Don't use ``tempfile`` in these tests, as ``tempfile`` relies on ``shutil``.
+"""
+
+import os
+import shutil
+import unittest
+
+
+class TestRmtree(unittest.TestCase):
+    def test_dir_dne(self):
+        with self.assertRaises(OSError):
+            os.stat("foo")
+
+        with self.assertRaises(OSError):
+            shutil.rmtree("foo")
+
+    def test_file(self):
+        fn = "foo"
+        with open(fn, "w"):
+            pass
+
+        with self.assertRaises(OSError):
+            shutil.rmtree(fn)
+
+        os.remove(fn)
+
+    def test_empty_dir(self):
+        with self.assertRaises(OSError):
+            # If this triggers, a previous test didn't clean up.
+            # bit of a chicken/egg situation with ``tempfile``
+            os.stat("foo")
+
+        os.mkdir("foo")
+        shutil.rmtree("foo")
+
+        with self.assertRaises(OSError):
+            os.stat("foo")
+
+    def test_dir(self):
+        with self.assertRaises(OSError):
+            # If this triggers, a previous test didn't clean up.
+            # bit of a chicken/egg situation with ``tempfile``
+            os.stat("foo")
+
+        os.mkdir("foo")
+        os.mkdir("foo/bar")
+        with open("foo/bar/baz1.txt", "w"):
+            pass
+        with open("foo/bar/baz2.txt", "w"):
+            pass
+
+        shutil.rmtree("foo")
+
+        with self.assertRaises(OSError):
+            os.stat("foo")

--- a/python-stdlib/tempfile/tempfile.py
+++ b/python-stdlib/tempfile/tempfile.py
@@ -1,0 +1,59 @@
+import errno
+import os
+import random
+import shutil
+
+_ascii_letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _get_candidate_name(size=8):
+    return "".join(random.choice(_ascii_letters) for _ in range(size))
+
+
+def _sanitize_inputs(suffix, prefix, dir):
+    if dir is None:
+        dir = "/tmp"
+    if suffix is None:
+        suffix = ""
+    if prefix is None:
+        prefix = ""
+    return suffix, prefix, dir
+
+
+def _try(action, *args, **kwargs):
+    try:
+        action(*args, **kwargs)
+        return True
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise e
+    return False
+
+
+def mkdtemp(suffix=None, prefix=None, dir=None):
+    suffix, prefix, dir = _sanitize_inputs(suffix, prefix, dir)
+
+    _try(os.mkdir, dir)
+
+    while True:
+        name = _get_candidate_name()
+        file = os.path.join(dir, prefix + name + suffix)
+        if _try(os.mkdir, file):
+            return file
+
+
+class TemporaryDirectory:
+    def __init__(self, suffix=None, prefix=None, dir=None):
+        self.name = mkdtemp(suffix, prefix, dir)
+
+    def __repr__(self):
+        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+    def __enter__(self):
+        return self.name
+
+    def __exit__(self, exc, value, tb):
+        self.cleanup()
+
+    def cleanup(self):
+        _try(shutil.rmtree, self.name)

--- a/python-stdlib/tempfile/tempfile.py
+++ b/python-stdlib/tempfile/tempfile.py
@@ -37,7 +37,7 @@ def mkdtemp(suffix=None, prefix=None, dir=None):
 
     while True:
         name = _get_candidate_name()
-        file = os.path.join(dir, prefix + name + suffix)
+        file = dir + "/" + prefix + name + suffix
         if _try(os.mkdir, file):
             return file
 

--- a/python-stdlib/tempfile/test_tempfile.py
+++ b/python-stdlib/tempfile/test_tempfile.py
@@ -1,0 +1,50 @@
+import os
+import tempfile
+import unittest
+
+
+class Base(unittest.TestCase):
+    def assertExists(self, fn):
+        os.stat(fn)
+
+    def assertNotExists(self, fn):
+        with self.assertRaises(OSError):
+            os.stat(fn)
+
+
+class TestMkdtemp(Base):
+    def test_no_args(self):
+        fn = tempfile.mkdtemp()
+        self.assertTrue(fn.startswith("/tmp"))
+        self.assertExists(fn)
+        os.rmdir(fn)
+
+    def test_prefix(self):
+        fn = tempfile.mkdtemp(prefix="foo")
+        self.assertTrue(fn.startswith("/tmp"))
+        self.assertTrue("foo" in fn)
+        self.assertFalse(fn.endswith("foo"))
+        self.assertExists(fn)
+        os.rmdir(fn)
+
+    def test_suffix(self):
+        fn = tempfile.mkdtemp(suffix="foo")
+        self.assertTrue(fn.startswith("/tmp"))
+        self.assertTrue(fn.endswith("foo"))
+        self.assertExists(fn)
+        os.rmdir(fn)
+
+    def test_dir(self):
+        fn = tempfile.mkdtemp(dir="tmp_micropython")
+        self.assertTrue(fn.startswith("tmp_micropython"))
+        self.assertExists(fn)
+        os.rmdir(fn)
+
+
+class TestTemporaryDirectory(Base):
+    def test_context_manager_no_args(self):
+        with tempfile.TemporaryDirectory() as fn:
+            self.assertTrue(isinstance(fn, str))
+            self.assertTrue(fn.startswith("/tmp"))
+            self.assertExists(fn)
+        self.assertNotExists(fn)


### PR DESCRIPTION
`shutil.rmtree` had a reference to `os.walk`, which isn't in micropython. I updated it to use `os.ilistdir` and added unittests for it.

Initial implementation of the `tempfile` module. It currently has the following implemented:

* `mkdtemp`
* `TemporaryDirectory`

I only ever use `TemporaryDirectory`, and I assume others may have similar experience.

This is to make it much easier for me to update my pathlib unittests to be micropython-compatible.