### PR TITLE
sdcard: Set MISO high before readblocks/writeblocks.

### DIFF
--- a/micropython/drivers/storage/sdcard/sdcard.py
+++ b/micropython/drivers/storage/sdcard/sdcard.py
@@ -243,6 +243,10 @@ class SDCard:
         self.spi.write(b"\xff")
 
     def readblocks(self, block_num, buf):
+        # workaround for shared bus, required for (at least) some Kingston
+        # devices, ensure MOSI is high before starting transaction
+        self.spi.write(b"\xff")
+
         nblocks = len(buf) // 512
         assert nblocks and not len(buf) % 512, "Buffer length is invalid"
         if nblocks == 1:
@@ -270,6 +274,10 @@ class SDCard:
                 raise OSError(5)  # EIO
 
     def writeblocks(self, block_num, buf):
+        # workaround for shared bus, required for (at least) some Kingston
+        # devices, ensure MOSI is high before starting transaction
+        self.spi.write(b"\xff")
+
         nblocks, err = divmod(len(buf), 512)
         assert nblocks and not err, "Buffer length is invalid"
         if nblocks == 1:


### PR DESCRIPTION
Originally by @peterhinch.
See https://github.com/micropython/micropython/pull/6007 for discussion.

The summary is that on some cards (especially older Kingston ones) if the bus is shared with other SPI devices, then it seems to require that MISO is high for a few cycles before the transaction is initiated.

Because CS is high, this change should otherwise be a no-op.