### PR TITLE
urequests: close socket on delete of resp. object

### DIFF
--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -12,6 +12,9 @@ class Response:
             self.raw.close()
             self.raw = None
         self._cached = None
+        
+    def __del__(self):
+        self.close()
 
     @property
     def content(self):

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -12,7 +12,7 @@ class Response:
             self.raw.close()
             self.raw = None
         self._cached = None
-        
+
     def __del__(self):
         self.close()
 


### PR DESCRIPTION
The .close() should be called if response object is not in use / can not be reached anymore. 
This should automatically call the close() method if the object is delected by the garbage collector.