### PR TITLE
typing: Add typing module

### DIFF
--- a/python-stdlib/typing/manifest.py
+++ b/python-stdlib/typing/manifest.py
@@ -1,0 +1,3 @@
+metadata(version="0.1")
+
+module("typing.py")

--- a/python-stdlib/typing/test_typing.py
+++ b/python-stdlib/typing/test_typing.py
@@ -1,0 +1,24 @@
+# This doesn't quite test everything but just serves to verify that basic syntax works,
+# which for MicroPython means everything typing-related should be ignored.
+
+from typing import *
+
+MyAlias = str
+Vector = List[float]
+Nested = Iterable[Tuple[int, ...]]
+UserId = NewType("UserId", int)
+T = TypeVar("T", int, float, complex)
+
+hintedGlobal: Any = None
+
+
+def func_with_hints(c: int, b: MyAlias, a: Union[int, None], lst: List[float] = [0.0]) -> Any:
+    pass
+
+
+class ClassWithHints(Generic[T]):
+
+    a: int = 0
+
+    def foo(self, other: int) -> None:
+        pass

--- a/python-stdlib/typing/typing.py
+++ b/python-stdlib/typing/typing.py
@@ -1,0 +1,154 @@
+def cast(type, val):
+    return val
+
+
+def get_origin(type):
+    return None
+
+
+def get_args(type):
+    return ()
+
+
+def no_type_check(arg):
+    return arg
+
+
+def overload(func):
+    return None
+
+
+class _AnyCall:
+    def __init__(*args, **kwargs):
+        pass
+
+    def __call__(*args, **kwargs):
+        pass
+
+
+_anyCall = _AnyCall()
+
+
+class _SubscriptableType:
+    def __getitem__(self, arg):
+        return _anyCall
+
+
+_Subscriptable = _SubscriptableType()
+
+
+def TypeVar(type, *types):
+    return None
+
+
+def NewType(name, type):
+    return type
+
+
+class Any:
+    pass
+
+
+class BinaryIO:
+    pass
+
+
+class ClassVar:
+    pass
+
+
+class Final:
+    pass
+
+
+class Hashable:
+    pass
+
+
+class IO:
+    pass
+
+
+class NoReturn:
+    pass
+
+
+class Sized:
+    pass
+
+
+class SupportsInt:
+    pass
+
+
+class SupportsFloat:
+    pass
+
+
+class SupportsComplex:
+    pass
+
+
+class SupportsBytes:
+    pass
+
+
+class SupportsIndex:
+    pass
+
+
+class SupportsAbs:
+    pass
+
+
+class SupportsRound:
+    pass
+
+
+class TextIO:
+    pass
+
+
+AnyStr = str
+Text = str
+Pattern = str
+Match = str
+TypedDict = dict
+
+AbstractSet = _Subscriptable
+AsyncContextManager = _Subscriptable
+AsyncGenerator = _Subscriptable
+AsyncIterable = _Subscriptable
+AsyncIterator = _Subscriptable
+Awaitable = _Subscriptable
+Callable = _Subscriptable
+ChainMap = _Subscriptable
+Collection = _Subscriptable
+Container = _Subscriptable
+ContextManager = _Subscriptable
+Coroutine = _Subscriptable
+Counter = _Subscriptable
+DefaultDict = _Subscriptable
+Deque = _Subscriptable
+Dict = _Subscriptable
+FrozenSet = _Subscriptable
+Generator = _Subscriptable
+Generic = _Subscriptable
+Iterable = _Subscriptable
+Iterator = _Subscriptable
+List = _Subscriptable
+Literal = _Subscriptable
+Mapping = _Subscriptable
+MutableMapping = _Subscriptable
+MutableSequence = _Subscriptable
+MutableSet = _Subscriptable
+NamedTuple = _Subscriptable
+Optional = _Subscriptable
+OrderedDict = _Subscriptable
+Sequence = _Subscriptable
+Set = _Subscriptable
+Tuple = _Subscriptable
+Type = _Subscriptable
+Union = _Subscriptable
+
+TYPE_CHECKING = False


### PR DESCRIPTION
Brought up a couple of times here and on the forums.

To implement this I just took most things from `dir(typing)` in CPython 3.8, removed what looked too esoteric and kept the rest. Alphabetically so it's easier to find things. Probably still too much, but I really cannot guess what is used and what is not.

Closes #190.