### PR TITLE
umqtt.simple and umqtt.robust improvements

### DIFF
--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -52,3 +52,11 @@ class MQTTClient(simple.MQTTClient):
                 self.log(False, e)
             self.reconnect()
             attempts -= 1
+    
+    def ping(self):
+        while 1:
+            try:
+                return super().ping()
+            except simple.MQTTException as e:
+                self.log(False, e)
+            self.reconnect()

--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -52,7 +52,7 @@ class MQTTClient(simple.MQTTClient):
                 self.log(False, e)
             self.reconnect()
             attempts -= 1
-    
+
     def ping(self):
         while 1:
             try:

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -36,6 +36,7 @@ class MQTTClient:
         self.lw_msg = None
         self.lw_qos = 0
         self.lw_retain = False
+        self.pingresp_pending = False
 
     def _send_str(self, s):
         self.sock.write(struct.pack("!H", len(s)))
@@ -63,6 +64,10 @@ class MQTTClient:
         self.lw_retain = retain
 
     def connect(self, clean_session=True):
+        try:
+            self.sock.close()
+        except:
+            pass
         self.sock = socket.socket()
         addr = socket.getaddrinfo(self.server, self.port)[0][-1]
         self.sock.connect(addr)
@@ -108,13 +113,18 @@ class MQTTClient:
         assert resp[0] == 0x20 and resp[1] == 0x02
         if resp[3] != 0:
             raise MQTTException(resp[3])
+        self.pingresp_pending = False
         return resp[2] & 1
 
     def disconnect(self):
         self.sock.write(b"\xe0\0")
         self.sock.close()
+        self.pingresp_pending = False
 
     def ping(self):
+        if self.pingresp_pending:
+            raise MQTTException('No response for previous ping')
+        self.pingresp_pending = True
         self.sock.write(b"\xc0\0")
 
     def publish(self, topic, msg, retain=False, qos=0):
@@ -185,6 +195,7 @@ class MQTTClient:
         if res == b"\xd0":  # PINGRESP
             sz = self.sock.read(1)[0]
             assert sz == 0
+            self.pingresp_pending = False
             return None
         op = res[0]
         if op & 0xF0 != 0x30:

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -123,7 +123,7 @@ class MQTTClient:
 
     def ping(self):
         if self.pingresp_pending:
-            raise MQTTException('No response for previous ping')
+            raise MQTTException("No response for previous ping")
         self.pingresp_pending = True
         self.sock.write(b"\xc0\0")
 


### PR DESCRIPTION
- Keep track of MQTT ping responses (PINGRESP) via MQTTClient.pingresp_pending attribute
- An attempt to send PINGREQ (by calling ping()) when we haven’t yet received a PINGRESP for our previous one will raise an exception
- MQTTClient.ping superclassed in mqtt.robust to make use of the  pingresp_pending attribute. Reconnect will be performed on 'No response for previous ping’ exception
- MQTTClient.connect() will always try to close the previous socket (if any) first. Otherwise the reconnect() function from mqtt.robust might fail on trying to re-instantiate the socket with OSerr=23