### PR TITLE
Add "Content-Type: application/octet-stream" to header

### DIFF
--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -114,7 +114,6 @@ def request(
         s.write(b"Connection: close\r\n\r\n")
         if data:
             s.write(b"Content-Type: application/octet-stream\r\n")
-            
             if chunked_data:
                 for chunk in data:
                     s.write(b"%x\r\n" % len(chunk))

--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -113,6 +113,8 @@ def request(
                 s.write(b"Content-Length: %d\r\n" % len(data))
         s.write(b"Connection: close\r\n\r\n")
         if data:
+            s.write(b"Content-Type: application/octet-stream\r\n")
+            
             if chunked_data:
                 for chunk in data:
                     s.write(b"%x\r\n" % len(chunk))


### PR DESCRIPTION
 for when sending binary data

example usage on my ESP32-CAM module:

```python
# capture and upload
import camera
import urequests

camera.init(0, format=camera.JPEG, fb_location=camera.PSRAM)
buf = camera.capture()
response = urequests.post("https://.............", data=buf)
print(response.text)
response.close()
```