### PR TITLE
umqtt.robust: When reconnecting, close the previous socket.

### DIFF
--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -21,6 +21,11 @@ class MQTTClient(simple.MQTTClient):
         i = 0
         while 1:
             try:
+                if self.sock:
+                    self.sock.close()
+            except OSError as e:
+                self.log(True, e)
+            try:
                 return super().connect(False)
             except OSError as e:
                 self.log(True, e)


### PR DESCRIPTION
This fixes lengthy reconnection runs (on ESP8266) which at some point started throwing OSErrors (including 23), from which it didn't recover even after server was back.