### PR TITLE
urequests support for user-provided http versions

### DIFF
--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -43,9 +43,12 @@ def request(
     auth=None,
     timeout=None,
     parse_headers=True,
+    http_version="1.0",
 ):
     redirect = None  # redirection url, None means no redirection
-    chunked_data = data and getattr(data, "__iter__", None) and not getattr(data, "__len__", None)
+    chunked_data = (
+        data and getattr(data, "__iter__", None) and not getattr(data, "__len__", None)
+    )
 
     if auth is not None:
         import ubinascii
@@ -91,7 +94,11 @@ def request(
         s.connect(ai[-1])
         if proto == "https:":
             s = ussl.wrap_socket(s, server_hostname=host)
-        s.write(b"%s /%s HTTP/1.0\r\n" % (method, path))
+
+        method_path = f"{method} /{path} HTTP/{http_version}\r\n"
+        # example string for method_path:
+        # POST /api/v1/rooms/1/samples HTTP/1.1
+        s.write(b"%s" % method_path)
         if not "Host" in headers:
             s.write(b"Host: %s\r\n" % host)
         # Iterate over keys to avoid tuple alloc


### PR DESCRIPTION
## About
Hi there! :)
This pull request implements a simple update to the urequests's request function. This implementation includes an argument to allow for modifcation of the socket's written http version. 

## Why this was done?
I made this change in my own fork because I had scrapped together an API in FastAPI, and this did not accept my microcontroller's HTTP 1.0 post requests. 


Please let me know if there is a reason the HTTP 1.1 version remains in the code - despite possible need for it to be http 1.0. I am new to learning about HTTP and related topics :)

Cheers!