### PR TITLE
added timezone support in ntptime library

### DIFF
--- a/micropython/net/ntptime/ntptime.py
+++ b/micropython/net/ntptime/ntptime.py
@@ -44,7 +44,7 @@ def time():
 
 def get_tz_offset(tz: str) -> int:
     tz = tz.strip()
-    if '/' not in tz or len(tz) < 3:
+    if "/" not in tz or len(tz) < 3:
         raise Exception("Unsupported timezone: {}. Example: asia/kolkata".format(tz))
 
     tz_offset = 0
@@ -60,11 +60,11 @@ def get_tz_offset(tz: str) -> int:
         response = response.decode()
 
         from json import loads
-        response = loads(response[response.find('{'):])
+        response = loads(response[response.find("{"):])
 
-        tokens = response['utc_offset'].split(':')
+        tokens = response["utc_offset"].split(":")
         tz_offset = (int(tokens[0][1:]) * 3600) + (int(tokens[1]) * 60)
-        if tokens[0][0] != '+':
+        if tokens[0][0] != "+":
             tz_offset *= -1
     except Exception:
         pass

--- a/micropython/net/ntptime/ntptime.py
+++ b/micropython/net/ntptime/ntptime.py
@@ -1,5 +1,4 @@
 import utime
-
 try:
     import usocket as socket
 except:
@@ -50,31 +49,15 @@ def get_tz_offset(tz: str) -> int:
 
     tz_offset = 0
     try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            sock.connect((TZ_HOST, 80))
-            request = bytes(f"GET /api/timezone/{tz} HTTP/1.1\nHost: {TZ_HOST}\n\n", "UTF-8")
-            sock.send(request)
-            response = sock.recv(4096)
-        finally:
-            sock.close()
-        response = response.decode()
-
-        from json import loads
-
-        response = loads(response[response.find("{") :])
-
-        tokens = response["utc_offset"].split(":")
-        tz_offset = (int(tokens[0][1:]) * 3600) + (int(tokens[1]) * 60)
-        if tokens[0][0] != "+":
-            tz_offset *= -1
+        from urequests import get
+        response = get("http://{}/api/timezone/{}".format(TZ_HOST, tz))
+        tz_offset = response.json()["raw_offset"]
     except Exception:
         pass
 
     return tz_offset
 
 
-# There's currently no timezone support in MicroPython, and the RTC is set in UTC time.
 def settime(tz: str = None):
     t = time()
     if tz:

--- a/micropython/net/ntptime/ntptime.py
+++ b/micropython/net/ntptime/ntptime.py
@@ -66,8 +66,10 @@ def get_tz_offset(tz: str) -> int:
         tz_offset = (int(tokens[0][1:]) * 3600) + (int(tokens[1]) * 60)
         if tokens[0][0] != '+':
             tz_offset *= -1
-    finally:
-        return tz_offset
+    except Exception:
+        pass
+        
+    return tz_offset
 
 
 # There's currently no timezone support in MicroPython, and the RTC is set in UTC time.

--- a/micropython/net/ntptime/ntptime.py
+++ b/micropython/net/ntptime/ntptime.py
@@ -1,4 +1,5 @@
 import utime
+
 try:
     import usocket as socket
 except:
@@ -50,11 +51,11 @@ def get_tz_offset(tz: str) -> int:
     tz_offset = 0
     try:
         from urequests import get
+
         response = get("http://{}/api/timezone/{}".format(TZ_HOST, tz))
         tz_offset = response.json()["raw_offset"]
     except Exception:
         pass
-
     return tz_offset
 
 

--- a/micropython/net/ntptime/ntptime.py
+++ b/micropython/net/ntptime/ntptime.py
@@ -16,6 +16,7 @@ timeout = 1
 
 TZ_HOST = "worldtimeapi.org"
 
+
 def time():
     NTP_QUERY = bytearray(48)
     NTP_QUERY[0] = 0x1B
@@ -60,7 +61,8 @@ def get_tz_offset(tz: str) -> int:
         response = response.decode()
 
         from json import loads
-        response = loads(response[response.find("{"):])
+
+        response = loads(response[response.find("{") :])
 
         tokens = response["utc_offset"].split(":")
         tz_offset = (int(tokens[0][1:]) * 3600) + (int(tokens[1]) * 60)
@@ -68,7 +70,7 @@ def get_tz_offset(tz: str) -> int:
             tz_offset *= -1
     except Exception:
         pass
-        
+
     return tz_offset
 
 


### PR DESCRIPTION
ntptime library doesn't support timezone while setting time via NTP server.
This PR is to address that limitation, now the `settime()` takes an optional timezone parameter as string (example asia/kolkata).

Then it uses `wordtimeapi.org` to get the time offset and sets the time.