### PR TITLE
micropython/bundles: Add a bundle-networking meta-package.

### DIFF
--- a/micropython/bundles/README.md
+++ b/micropython/bundles/README.md
@@ -1,0 +1,7 @@
+These are "meta packages" designed to make it easy to provide defined
+bundles of related packages.
+
+For example, all deployments of MicroPython with networking support
+(WiFi/Ethernet) should add `require("bundle-networking")` to their
+`manifest.py` to ensure that the the standard set of networking packages
+(including HTTP requests, WebREPL, NTP, package management) are included.

--- a/micropython/bundles/bundle-networking/manifest.py
+++ b/micropython/bundles/bundle-networking/manifest.py
@@ -1,0 +1,9 @@
+metadata(
+    version="0.1.0",
+    metadata="Common networking packages for all network-capable deployments of MicroPython.",
+)
+
+require("mip")
+require("ntptime")
+require("urequests")
+require("webrepl")


### PR DESCRIPTION
This is designed to be a common set of packages that all boards with networking support should include.

Signed-off-by: Jim Mussared <jim.mussared@gmail.com>