### PR TITLE
Fix AttributeError when unittests tries to handle exceptions

### DIFF
--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -402,9 +402,7 @@ def _run_suite(c, test_result: TestResult, suite_name=""):
             test_result.skipped.append((name, c, reason))
         except Exception as ex:
             _handle_test_exception(
-                current_test=(name, c),
-                test_result=test_result,
-                exc_info=(type(exc), exc, None)
+                current_test=(name, c), test_result=test_result, exc_info=(type(exc), exc, None)
             )
             # Uncomment to investigate failure in detail
             # raise

--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -332,12 +332,12 @@ class TestResult:
         return self
 
 
-def _capture_exc(exc, traceback):
+def _capture_exc(exc, exc_traceback):
     buf = io.StringIO()
     if hasattr(sys, "print_exception"):
         sys.print_exception(exc, buf)
     elif traceback is not None:
-        traceback.print_exception(None, exc, traceback, file=buf)
+        traceback.print_exception(None, exc, exc_traceback, file=buf)
     return buf.getvalue()
 
 
@@ -401,12 +401,10 @@ def _run_suite(c, test_result: TestResult, suite_name=""):
             test_result.skippedNum += 1
             test_result.skipped.append((name, c, reason))
         except Exception as ex:
-            if hasattr(sys, 'exc_info'):
-                exc_info = sys.exc_info()
-            else:
-                exc_info = (ex.__class__, ex, None)
             _handle_test_exception(
-                current_test=(name, c), test_result=test_result, exc_info=exc_info
+                current_test=(name, c),
+                test_result=test_result,
+                exc_info=(type(exc), exc, None)
             )
             # Uncomment to investigate failure in detail
             # raise

--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -401,8 +401,12 @@ def _run_suite(c, test_result: TestResult, suite_name=""):
             test_result.skippedNum += 1
             test_result.skipped.append((name, c, reason))
         except Exception as ex:
+            if hasattr(sys, 'exc_info'):
+                exc_info = sys.exc_info()
+            else:
+                exc_info = (ex.__class__, ex, None)
             _handle_test_exception(
-                current_test=(name, c), test_result=test_result, exc_info=sys.exc_info()
+                current_test=(name, c), test_result=test_result, exc_info=exc_info
             )
             # Uncomment to investigate failure in detail
             # raise


### PR DESCRIPTION
without path: 
```python
test__clock_draw__minimal_dimentions__correct_fbuf_values (__main__.SegClockTestCase) ...Traceback (most recent call last):
  File "<stdin>", line 35, in <module>
  File "unittest/__init__.py", line 462, in main
  File "unittest/__init__.py", line 269, in run
  File "unittest/__init__.py", line 254, in run
  File "unittest/__init__.py", line 430, in _run_suite
  File "unittest/__init__.py", line 405, in run_one
AttributeError: 'module' object has no attribute 'exc_info'
```

with patch: 
```python 
test__clock_draw__minimal_dimentions__correct_fbuf_values (__main__.SegClockTestCase) ... ERROR

======================================================================
FAIL: test__clock_draw__minimal_dimentions__correct_fbuf_values <class 'SegClockTestCase'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "unittest.py", line 390, in run_one
  File "<stdin>", line 26, in test__clock_draw__minimal_dimentions__correct_fbuf_values
AttributeError: 'SegClockTestCase' object has no attribute 'assertEquals'
```
