### PR TITLE
Use content length to avoid http hang

### DIFF
--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -2,10 +2,11 @@ import usocket
 
 
 class Response:
-    def __init__(self, f):
+    def __init__(self, f, length):
         self.raw = f
         self.encoding = "utf-8"
         self._cached = None
+        self.length = length
 
     def close(self):
         if self.raw:
@@ -17,7 +18,10 @@ class Response:
     def content(self):
         if self._cached is None:
             try:
-                self._cached = self.raw.read()
+                if self.length is None:
+                    self._cached = self.raw.read()
+                else:
+                    self._cached = self.raw.read(self.length)
             finally:
                 self.raw.close()
                 self.raw = None
@@ -164,7 +168,7 @@ def request(
         else:
             return request(method, redirect, data, json, headers, stream)
     else:
-        resp = Response(s)
+        resp = Response(s, headers.get("Content-Length"))
         resp.status_code = status
         resp.reason = reason
         if resp_d is not None:


### PR DESCRIPTION
response.content() is hanging on responses that don't end with a final newline.

Issue is in https://github.com/micropython/micropython-lib/issues/546

Here's my actual workaround while waiting for the real fix... reach into the impl and read one character at a time. Stop when reaching "}"

```
    response = urequests.get(url)
    response._cached = response.raw.read(1)
    while True:
        response._cached += response.raw.read(1)
        if response._cached[-1] == 125: break
    json = response.json()