### PR TITLE
aioble: add short name support to scan results

### DIFF
--- a/micropython/bluetooth/aioble-central/manifest.py
+++ b/micropython/bluetooth/aioble-central/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.0")
+metadata(version="0.2.1")
 
 require("aioble-core")
 

--- a/micropython/bluetooth/aioble/aioble/central.py
+++ b/micropython/bluetooth/aioble/aioble/central.py
@@ -33,6 +33,7 @@ _SCAN_RSP = const(4)
 
 _ADV_TYPE_FLAGS = const(0x01)
 _ADV_TYPE_NAME = const(0x09)
+_ADV_TYPE_SHORT_NAME = const(0x08)
 _ADV_TYPE_UUID16_INCOMPLETE = const(0x2)
 _ADV_TYPE_UUID16_COMPLETE = const(0x3)
 _ADV_TYPE_UUID32_INCOMPLETE = const(0x4)
@@ -187,9 +188,9 @@ class ScanResult:
                     yield payload[i + 2 : i + payload[i] + 1]
                 i += 1 + payload[i]
 
-    # Returns the value of the advertised name, otherwise empty string.
+    # Returns the value of the complete (or shortened) advertised name, if available.
     def name(self):
-        for n in self._decode_field(_ADV_TYPE_NAME):
+        for n in self._decode_field(_ADV_TYPE_NAME, _ADV_TYPE_SHORT_NAME):
             return str(n, "utf-8") if n else ""
 
     # Generator that enumerates the service UUIDs that are advertised.

--- a/micropython/bluetooth/aioble/manifest.py
+++ b/micropython/bluetooth/aioble/manifest.py
@@ -3,7 +3,7 @@
 # code. This allows (for development purposes) all the files to live in the
 # one directory.
 
-metadata(version="0.2.0")
+metadata(version="0.2.1")
 
 # Default installation gives you everything. Install the individual
 # components (or a combination of them) if you want a more minimal install.


### PR DESCRIPTION
I'm working on using BLE to connect to a Blackmagic Camera and have discovered that in it's advertising packets it will never send it's Complete Local Name (denoted by `0x09`), opting to only send it's Shortened Local Name (denoted by `0x08`).  I've made it so a `ScanResult` will prioritize returning the Complete Local Name, then attempt to fall back to the shortened variant before ultimately returning an empty string.

**Bluetooth Specification Reference**
The [Assigned Numbers Document](https://www.bluetooth.com/specifications/assigned-numbers/) identifies the fields/values for both names as Common Data Types in Section 2.3.  The variants of Local Name are described in Part A, Section 1.2 of the [Core Specification Supplement](https://www.bluetooth.com/specifications/specs/core-specification-supplement-11/).