### PR TITLE
Add bare-minimum manifest.py files to bisect, json, keyword, and types.

### DIFF
--- a/python-stdlib/bisect/manifest.py
+++ b/python-stdlib/bisect/manifest.py
@@ -1,0 +1,1 @@
+module("bisect.py")

--- a/python-stdlib/json/manifest.py
+++ b/python-stdlib/json/manifest.py
@@ -1,0 +1,1 @@
+package("json")

--- a/python-stdlib/keyword/manifest.py
+++ b/python-stdlib/keyword/manifest.py
@@ -1,0 +1,1 @@
+module("keyword.py")

--- a/python-stdlib/types/manifest.py
+++ b/python-stdlib/types/manifest.py
@@ -1,0 +1,1 @@
+module("types.py")


### PR DESCRIPTION
These four modules (bisect, json, keyword, and types) seem to have been missing manifest files; I'm unsureif it's just been an oversight or if there is a reason for it.

I didn't have much success finding what the versions of these modules may be, nor did I put too much effort into finding the details commented in some other manifests (original author, other metadata), but I think that info should also be covered in the code itself. As in the summary, this is the bare minimum necessary to be able to use a custom manifest that requires `keyword`, or example. In fact, I've tested this by successfully compiling Pi Pico firmware with a custom manifest that requires `keyword`.
