### PR TITLE
bisect, json, keyword, types: Add manifest.py.

### DIFF
--- a/python-stdlib/bisect/manifest.py
+++ b/python-stdlib/bisect/manifest.py
@@ -1,0 +1,3 @@
+metadata(description="Port of bisect for micropython")
+
+module("bisect.py")

--- a/python-stdlib/json/manifest.py
+++ b/python-stdlib/json/manifest.py
@@ -1,0 +1,3 @@
+metadata(description="Port of json module for micropython")
+
+package("json")

--- a/python-stdlib/keyword/manifest.py
+++ b/python-stdlib/keyword/manifest.py
@@ -1,0 +1,3 @@
+metadata(description="Port of keyword module for micropython")
+
+module("keyword.py")

--- a/python-stdlib/types/manifest.py
+++ b/python-stdlib/types/manifest.py
@@ -1,0 +1,3 @@
+metadata(description="Port of types module for micropython")
+
+module("types.py")


### PR DESCRIPTION
Add manifest files for bisect, json, keyword, and types since they appeared to have been overlooked.

I ran into trouble when trying to compile Pi Pico firmware with `keyword` as a frozen module after which I found several other modules without manifests. Adding the manifest for `keyword` resolved my compilation issue, so I have assumed that the other manifests are functional as well.
It wasn't readily apparent what the versions of each of these modules are, so I chose not to add anything about that to their metadata. (It's also a little unclear to me what the version is meant to represent -- version of the Python stdlib that it's ported from or the version of the port itself or is it up to the author?).