### PR TITLE
urequests: raise ValueError if terminator isnt CRLF

### DIFF
--- a/python-ecosys/urequests/urequests.py
+++ b/python-ecosys/urequests/urequests.py
@@ -123,6 +123,9 @@ def request(
                 s.write(data)
 
         l = s.readline()
+        if l[:-2] != b"\r\n":
+            # CRLF is required at EOL, as per standard
+            raise ValueError("HTTP error: SeparatorNotCRLF:\n%s" % l)
         # print(l)
         l = l.split(None, 2)
         if len(l) < 2:
@@ -137,6 +140,8 @@ def request(
             if not l or l == b"\r\n":
                 break
             # print(l)
+            if l[:-2] != b"\r\n":  # CRLF is required at EOL, as per standard
+                raise ValueError("HTTP error: SeparatorNotCRLF:\n%s" % l)
             if l.startswith(b"Transfer-Encoding:"):
                 if b"chunked" in l:
                     raise ValueError("Unsupported " + str(l, "utf-8"))


### PR DESCRIPTION
While testing for network connectivity on the PicoW with AP and STA modes active concurrently, I made the mistake of using `\n` as the line terminator (instead of `\r\n` [from the standard](https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1)) as below:
```
echo -e "HTTP/1.0 200 OK\n\nContent-Type: text/html\nContent-Length': 31\n\n<html><body>hello</body></html>\n" |nc -l 8080
```

This leads to the following error:
```
>>> x=urequests.get('http://zero2w:8080')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "urequests.py", line 180, in get
  File "urequests.py", line 152, in request
ValueError: need more than 1 values to unpack
```

This PR adds a check that the terminator for any line should be 'CRLF' instead of 'LF', so that the actual error is now as below:
```
>>> x=urequests.get('http://zero2w:8080')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "urep.py", line 185, in get
  File "urep.py", line 128, in request
ValueError: HTTP error: SeparatorNotCRLF:
b'HTTP/1.0 200 OK\n'
```