### PR TITLE
aioble: Extend BufferedCharacteristic functionality to allow for non-read-only characteristics

### DIFF
--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -293,8 +293,8 @@ class Characteristic(BaseCharacteristic):
 
 
 class BufferedCharacteristic(Characteristic):
-    def __init__(self, service, uuid, max_len=20, append=False):
-        super().__init__(service, uuid, read=True)
+    def __init__(self, service, uuid, max_len=20, append=False, read=True, **kwargs):
+        super().__init__(service, uuid, read=read, **kwargs)
         self._max_len = max_len
         self._append = append
 


### PR DESCRIPTION
`BufferedCharacteristic` is an undocumented characteristic class that merely calls [`bluetooth.BLE.gatts_set_buffer`](https://docs.micropython.org/en/latest/library/bluetooth.html#bluetooth.BLE.gatts_set_buffer), allowing it to extend the internal buffer, which is useful for longer writes to successfully happen.

Oddly enough, `BufferedCharacteristic` currently defaults to read-only characteristics (see `read=True`), and does not allow specifying other characteristic types.

In my own personal testing, I had issues writing data longer than 20 bytes to a characteristic due to this buffer size issue (see [here](https://docs.micropython.org/en/latest/library/bluetooth.html#bluetooth.BLE.gatts_set_buffer) for more info). Calling `gatts_set_buffer` with a longer `max_len` fixes it, but this is not currently exposed to the user in any way through aioble ([there's a TODO to allow user to pass in the BLE object](https://github.com/micropython/micropython-lib/blob/c860319/micropython/bluetooth/aioble/aioble/core.py#L76)).

I tried two different approaches, both porting this `_register` function over to regular `Characteristic`, and extending `BufferedCharacteristic` (this PR). Both function in my case, but doing former defeats the point of `BufferedCharacteristic` and as such PRing the latter felt like it made more sense.

This PR, as such, extends `BufferedCharacteristic` in a backwards-compatible manner (hence the ugly `read=True`+`read=read`) allowing specifying different flags for the characteristic, and hopefully makes it more useful in the process.

If a different approach is desired (i.e. not making this backwards compatible, changing `Characteristic`, exposing BLE object, etc) I can also change the PR to do that.

(Tested and functioning on MicroPython v1.19.1-963-g668a7bd28 of 2023-03-10 on ESP32.)