### PR TITLE
unittest-discover: Print results when no tests are found/run.

### DIFF
--- a/python-stdlib/unittest-discover/manifest.py
+++ b/python-stdlib/unittest-discover/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.1.1")
+metadata(version="0.1.2")
 
 require("argparse")
 require("fnmatch")

--- a/python-stdlib/unittest/manifest.py
+++ b/python-stdlib/unittest/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.10.2")
+metadata(version="0.10.3")
 
 package("unittest")

--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -300,9 +300,10 @@ class TestResult:
         return self.errorsNum == 0 and self.failuresNum == 0
 
     def printErrors(self):
-        print()
-        self.printErrorList(self.errors)
-        self.printErrorList(self.failures)
+        if self.errors or self.failures:
+            print()
+            self.printErrorList(self.errors)
+            self.printErrorList(self.failures)
 
     def printErrorList(self, lst):
         sep = "----------------------------------------------------------------------"


### PR DESCRIPTION
Currently if no tests are found when running `unittest discover` then nothing at all is written to stdout, leading you to think it's not working at all.

cpython unittest does display a `0 tests run` sort of output in this scenareo, this PR ensures our package does the same.