### PR TITLE
aioble: Fix descriptor flag handling.

### DIFF
--- a/micropython/bluetooth/aioble-client/manifest.py
+++ b/micropython/bluetooth/aioble-client/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.0")
+metadata(version="0.3.0")
 
 require("aioble-core")
 

--- a/micropython/bluetooth/aioble-server/manifest.py
+++ b/micropython/bluetooth/aioble-server/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.0")
+metadata(version="0.3.0")
 
 require("aioble-core")
 

--- a/micropython/bluetooth/aioble/aioble/client.py
+++ b/micropython/bluetooth/aioble/aioble/client.py
@@ -439,7 +439,7 @@ class ClientDescriptor(BaseClientCharacteristic):
     def __init__(self, characteristic, dsc_handle, uuid):
         self.characteristic = characteristic
 
-        super().__init__(dsc_handle, _FLAG_READ | _FLAG_WRITE_NO_RESPONSE, uuid)
+        super().__init__(dsc_handle, _FLAG_READ | _FLAG_WRITE, uuid)
 
     def __str__(self):
         return "Descriptor: {} {} {}".format(self._value_handle, self.properties, self.uuid)

--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -38,9 +38,6 @@ _FLAG_WRITE_AUTHORIZED = const(0x4000)
 
 _FLAG_WRITE_CAPTURE = const(0x10000)
 
-_FLAG_DESC_READ = const(1)
-_FLAG_DESC_WRITE = const(2)
-
 
 _WRITE_CAPTURE_QUEUE_LIMIT = const(10)
 
@@ -307,14 +304,13 @@ class Descriptor(BaseCharacteristic):
     def __init__(self, characteristic, uuid, read=False, write=False, initial=None):
         characteristic.descriptors.append(self)
 
-        # Workaround for https://github.com/micropython/micropython/issues/6864
         flags = 0
         if read:
-            flags |= _FLAG_DESC_READ
+            flags |= _FLAG_READ
         if write:
+            flags |= _FLAG_WRITE
             self._write_event = asyncio.ThreadSafeFlag()
             self._write_data = None
-            flags |= _FLAG_DESC_WRITE
 
         self.uuid = uuid
         self.flags = flags

--- a/micropython/bluetooth/aioble/manifest.py
+++ b/micropython/bluetooth/aioble/manifest.py
@@ -3,7 +3,7 @@
 # code. This allows (for development purposes) all the files to live in the
 # one directory.
 
-metadata(version="0.2.1")
+metadata(version="0.3.1")
 
 # Default installation gives you everything. Install the individual
 # components (or a combination of them) if you want a more minimal install.


### PR DESCRIPTION
Follow up to https://github.com/micropython/micropython/pull/11239

- Removes the workaround for https://github.com/micropython/micropython/issues/6864.

- Sets the default flags for discovered descriptors to be WRITE, so that d.write() will implicitly set response=True.

_This work was funded through GitHub Sponsors._