### PR TITLE
types: Add manifest file.

### DIFF
--- a/python-stdlib/bisect/manifest.py
+++ b/python-stdlib/bisect/manifest.py
@@ -1,0 +1,3 @@
+metadata(version="0.5")
+
+module("bisect.py")

--- a/python-stdlib/json/manifest.py
+++ b/python-stdlib/json/manifest.py
@@ -1,0 +1,3 @@
+metadata(version="0.1")
+
+package("json")

--- a/python-stdlib/keyword/manifest.py
+++ b/python-stdlib/keyword/manifest.py
@@ -1,0 +1,3 @@
+metadata(version="0.0.1")
+
+module("keyword.py")

--- a/python-stdlib/types/manifest.py
+++ b/python-stdlib/types/manifest.py
@@ -1,0 +1,3 @@
+metadata(version="0.0.1")
+
+module("types.py")


### PR DESCRIPTION
Curiously the stdlib/types module missed getting a manifest file in the big migration from [setup.py](https://github.com/micropython/micropython-lib/commit/ecef7a506ccbf31bbbdc0369d17f1d09543e0442#diff-d230118eba5a373e8601695ff1152c9c938687d82cf42cf214ac14ec78432082) to [manifest.py](https://github.com/micropython/micropython-lib/commit/ce66e701) perhaps because it was missing the metadata.txt and only had [setup.py](https://github.com/micropython/micropython-lib/blob/a18d49cda7a5d615298e8bb65fb24208036befff/python-stdlib/types/setup.py)