### PR TITLE
stdlib/logging: Add full support for logging exception tracebacks.

### DIFF
--- a/python-stdlib/logging/logging.py
+++ b/python-stdlib/logging/logging.py
@@ -1,5 +1,5 @@
 from micropython import const
-
+import io
 import sys
 import time
 
@@ -148,10 +148,17 @@ class Logger:
     def critical(self, msg, *args):
         self.log(CRITICAL, msg, *args)
 
-    def exception(self, msg, *args):
+    def exception(self, msg, *args, exc_info=True):
         self.log(ERROR, msg, *args)
-        if hasattr(sys, "exc_info"):
-            sys.print_exception(sys.exc_info()[1], _stream)
+        tb = None
+        if isinstance(exc_info, BaseException):
+            tb = exc_info
+        elif hasattr(sys, "exc_info"):
+            tb = sys.exc_info()[1]
+        if tb:
+            buf = io.StringIO()
+            sys.print_exception(tb, buf)
+            self.log(ERROR, buf.getvalue())
 
     def addHandler(self, handler):
         self.handlers.append(handler)


### PR DESCRIPTION
I noticed recently that the current `log.exception()` function doesn't always print the tracebacks of the exception.

The current handling requires your build to be compiled with `MICROPY_PY_SYS_EXC_INFO` which is not always on by default.

This PR allows you to pass an exception object in as the `exc_info` kwarg (cpython allows this) so the following works regarless of the above build setting.

``` python
try:
    run_func()
except Exception as ex:
  log.exception("run_func failed", exc_info=ex)
```

Separately to that, currently even when `sys.exc_info()` is enabled, it's only printing the traceback to `_stream` = `sys.stderr` - not to the configured logging handlers. This means for instance if you've got a file log handler, it misses out on the tracebacks.
This PR also addresses this.