### PR TITLE
python-stdlib/pathlib: Add __rtruediv__ magic method to pathlib.Path

### DIFF
--- a/python-stdlib/pathlib/pathlib.py
+++ b/python-stdlib/pathlib/pathlib.py
@@ -47,6 +47,9 @@ class Path:
     def __truediv__(self, other):
         return Path(self._path, str(other))
 
+    def __rtruediv__(self, other):
+        return Path(other, self._path)
+
     def __repr__(self):
         return f'{type(self).__name__}("{self._path}")'
 

--- a/python-stdlib/pathlib/tests/test_pathlib.py
+++ b/python-stdlib/pathlib/tests/test_pathlib.py
@@ -322,3 +322,14 @@ class TestPathlib(unittest.TestCase):
         self.assertTrue(Path("foo/test").with_suffix(".tar") == Path("foo/test.tar"))
         self.assertTrue(Path("foo/bar.bin").with_suffix(".txt") == Path("foo/bar.txt"))
         self.assertTrue(Path("bar.txt").with_suffix("") == Path("bar"))
+
+    def test_rtruediv(self):
+        """Works as of micropython ea7031f"""
+        res = "foo" / Path("bar")
+        self.assertTrue(res == Path("foo/bar"))
+
+    def test_rtruediv_inplace(self):
+        """Works as of micropython ea7031f"""
+        res = "foo"
+        res /= Path("bar")
+        self.assertTrue(res == Path("foo/bar"))


### PR DESCRIPTION
Now works due to https://github.com/micropython/micropython/pull/10844#issuecomment-1554135154.

Code is still valid with older versions of micropython, just the actual rtruediv operations won't work (they previously still didn't work, so no change in functionality).