### PR TITLE
iperf3: macOS server compatibility

### DIFF
--- a/python-ecosys/iperf3/iperf3.py
+++ b/python-ecosys/iperf3/iperf3.py
@@ -147,10 +147,10 @@ class Stats:
 
     def report_receiver(self, stats):
         st = stats["streams"][0]
-        dt = st["end_time"] - st["start_time"]
+        dt = ticks_diff(self.t3, self.t0)
         self.print_line(
-            st["start_time"],
-            st["end_time"],
+            st.get("start_time", 0.0),
+            st.get("end_time", dt * 1e-6),
             st["bytes"],
             st["packets"],
             st["errors"],

--- a/python-ecosys/iperf3/iperf3.py
+++ b/python-ecosys/iperf3/iperf3.py
@@ -147,6 +147,10 @@ class Stats:
 
     def report_receiver(self, stats):
         st = stats["streams"][0]
+
+        # iperf servers pre 3.2 do not transmit start, end time
+        #  so use local as fallback if not available
+
         dt = ticks_diff(self.t3, self.t0)
         self.print_line(
             st.get("start_time", 0.0),


### PR DESCRIPTION
Result message does not appear to encode start, end time, so work around. Probably better fix incoming once I better understand.
    
Fixes micropython/micropython-lib#665