### PR TITLE
umqtt.robust: let reconnect() call the connect() method of the top class

### DIFF
--- a/micropython/umqtt.robust/example_lwt_robust.py
+++ b/micropython/umqtt.robust/example_lwt_robust.py
@@ -1,0 +1,29 @@
+import umqtt.robust
+import time
+
+# Last will and testament (LWT) is commonly used to signal a device as being
+# online or offline. This example builds on umqtt.robust to provide a more
+# reliable connection with the MQTT broker and signal its status as being
+# either Online or Offline. This feature adds to code size and isn't required
+# in all circumstances, so hasn't been included by default.
+
+
+class MyMQTTClient(umqtt.robust.MQTTClient):
+    def connect(self, clean_session=True):
+        self.set_last_will(b"tele/test/LWT", b"Offline", retain=True)
+        try:
+            return super().connect(clean_session)
+        finally:
+            self.publish(b"tele/test/LWT", b"Online", retain=True)
+
+
+# Change the server to test on your MQTT broker
+c = MyMQTTClient("test_client", "localhost", keepalive=5)
+c.DEBUG = True
+
+c.connect()
+
+# wait_msg() only returns when a message is received, so this example
+# highlights the LWT feature. In practical applications, the broker keeps
+# the connection alive only if there is traffic from the client (ping(), etc.)
+c.wait_msg()

--- a/micropython/umqtt.robust/example_resubscribe_robust.py
+++ b/micropython/umqtt.robust/example_resubscribe_robust.py
@@ -1,0 +1,52 @@
+import umqtt.robust
+import time
+
+# A common expectation of the robust client is that it should re-subscribe to
+# topics after a reconnect(). This feature adds to code size and isn't required
+# in all circumstances, so hasn't been included by default.
+
+# You can easily inherit from umqtt.robust.MQTTClient to add this feature...
+
+
+class MyMQTTClient(umqtt.robust.MQTTClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.topics = []
+
+    def connect(self, clean_session=True):
+        if not super().connect(clean_session):
+            # Session was not restored - need to resubscribe
+            for topic in self.topics:
+                self.subscribe(topic)
+
+            return False  # Session was not restored
+
+        return True  # Session was restored
+
+    def subscribe(self, topic):
+        print("Subscribing to", topic)
+        super().subscribe(topic)
+        if topic not in self.topics:
+            self.topics.append(topic)
+
+
+# Change the server to test on your MQTT broker
+c = MyMQTTClient("test_client", "localhost", keepalive=5)
+c.DEBUG = True
+
+c.set_callback(print)
+
+c.connect()
+c.subscribe(b"test/topic/a")
+
+c.publish(b"test/topic/a", b"message 1")
+c.wait_msg()
+
+# Connection breaks once keepalive expires
+time.sleep(8)
+
+c.publish(b"test/topic/a", b"message 2")  # publish() doesn't detect OSError, message 2 is lost
+c.check_msg()  # check_msg() detects OSError and will reconnect()
+
+c.publish(b"test/topic/a", b"message 3")
+c.wait_msg()

--- a/micropython/umqtt.robust/manifest.py
+++ b/micropython/umqtt.robust/manifest.py
@@ -1,5 +1,5 @@
 metadata(
-    description='Lightweight MQTT client for MicroPython ("robust" version).', version="1.0.2"
+    description='Lightweight MQTT client for MicroPython ("robust" version).', version="1.0.3"
 )
 
 # Originally written by Paul Sokolovsky.

--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -20,6 +20,8 @@ class MQTTClient(simple.MQTTClient):
         i = 0
         while 1:
             try:
+                # self.connect will call a subclass definition (if any)
+                # else fall back to parent class definition
                 return self.connect(False)
             except OSError as e:
                 self.log(True, e)


### PR DESCRIPTION
This allows overriding of the `connect()` method by a subclass as per the included examples: `example_lwt_robust.py` and `example_resubscribe_robust.py`.

Fixes #186, #321 (by enabling `example_resubscribe_robust.py`)
Supersedes PR #195 (original source file moved, examples added)