### PR TITLE
Fix chunked_data requests in urequests.py

### DIFF
--- a/python-ecosys/requests/manifest.py
+++ b/python-ecosys/requests/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.8.0", pypi="requests")
+metadata(version="0.8.1", pypi="requests")
 
 package("requests")

--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -45,7 +45,7 @@ def request(
     parse_headers=True,
 ):
     redirect = None  # redirection url, None means no redirection
-    chunked_data = data and getattr(data, "__iter__", None) and not getattr(data, "__len__", None)
+    chunked_data = data and getattr(data, "__next__", None) and not getattr(data, "__len__", None)
 
     if auth is not None:
         import ubinascii


### PR DESCRIPTION
Chunked detection does not work on current Micropython as it never has an `__iter__` attribute to a generator. It does add `__next__` to them, so this test in `urequests` for chunked detection did not work. I've changed it to `__next__`. I can post a failing example in the PR.