### PR TITLE
unix-ffi: Isolate packages from python-stdlib version of `os`

### DIFF
--- a/unix-ffi/email.message/manifest.py
+++ b/unix-ffi/email.message/manifest.py
@@ -1,7 +1,7 @@
 metadata(version="0.5.3")
 
 require("re", unix_ffi=True)
-require("uu")
+require("uu", unix_ffi=True)
 require("base64")
 require("binascii")
 require("email.utils", unix_ffi=True)

--- a/unix-ffi/glob/manifest.py
+++ b/unix-ffi/glob/manifest.py
@@ -1,7 +1,7 @@
 metadata(version="0.5.2")
 
 require("os", unix_ffi=True)
-require("os-path")
+require("os-path", unix_ffi=True)
 require("re", unix_ffi=True)
 require("fnmatch")
 

--- a/unix-ffi/os-path/manifest.py
+++ b/unix-ffi/os-path/manifest.py
@@ -1,0 +1,6 @@
+metadata(version="0.1.4")
+
+# Originally written by Paul Sokolovsky.
+
+require("os", unix_ffi=True)
+package("os", base_path="../../python-stdlib/os-path")

--- a/unix-ffi/os/os/__init__.py
+++ b/unix-ffi/os/os/__init__.py
@@ -5,6 +5,12 @@ import stat as stat_
 import ffilib
 import uos
 
+# Provide optional dependencies (which may be installed separately).
+try:
+    from . import path
+except ImportError:
+    pass
+
 R_OK = const(4)
 W_OK = const(2)
 X_OK = const(1)

--- a/unix-ffi/uu/manifest.py
+++ b/unix-ffi/uu/manifest.py
@@ -1,0 +1,6 @@
+metadata(version="0.5.1")
+
+require("binascii")
+require("os-path", unix_ffi=True)
+
+module("uu.py", base_path="../../python-stdlib/uu")


### PR DESCRIPTION
Currently, installing `email.message` (or any package that requires it, i.e. `email.feedparser`, `email.parser`, `http.client`) or `glob` causes the python-stdlib version of `os` to be installed instead of the unix-ffi version.

This adds unix-ffi versions of `os-path` and `uu` so that the unix-ffi version of `os` is installed in these cases.