### PR TITLE
hashlib: Provide all built-in hash functions.

### DIFF
--- a/python-stdlib/hashlib/hashlib/__init__.py
+++ b/python-stdlib/hashlib/hashlib/__init__.py
@@ -1,19 +1,19 @@
+# Use built-in functions preferentially (on most ports this is just sha256).
 try:
-    import uhashlib
+    from uhashlib import *
 except ImportError:
-    uhashlib = None
+    pass
 
 
-def init():
-    for i in ("sha1", "sha224", "sha256", "sha384", "sha512"):
-        c = getattr(uhashlib, i, None)
-        if not c:
-            c = __import__("_" + i, None, None, (), 1)
-            c = getattr(c, i)
-        globals()[i] = c
-
-
-init()
+# Add missing functions.
+if "sha224" not in globals():
+    from ._sha256 import sha224
+if "sha256" not in globals():
+    from ._sha256 import sha256
+if "sha384" not in globals():
+    from ._sha512 import sha384
+if "sha512" not in globals():
+    from ._sha512 import sha512
 
 
 def new(algo, data=b""):

--- a/python-stdlib/hashlib/hashlib/_sha224.py
+++ b/python-stdlib/hashlib/hashlib/_sha224.py
@@ -1,1 +1,0 @@
-from ._sha256 import sha224

--- a/python-stdlib/hashlib/hashlib/_sha384.py
+++ b/python-stdlib/hashlib/hashlib/_sha384.py
@@ -1,1 +1,0 @@
-from ._sha512 import sha384

--- a/python-stdlib/hashlib/manifest.py
+++ b/python-stdlib/hashlib/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="2.4.0-4")
+metadata(version="2.5.0")
 
 package("hashlib")


### PR DESCRIPTION
If a port had md5 enabled, then it would no longer be available.

Retain the existing logic of using the built-in preferentially.

_This work was funded through GitHub Sponsors._