### PR TITLE
python-stdlib/copy: Declare dependency on types.

### DIFF
--- a/python-stdlib/copy/manifest.py
+++ b/python-stdlib/copy/manifest.py
@@ -1,3 +1,5 @@
 metadata(version="3.3.3-2")
 
+require("types")
+
 module("copy.py")


### PR DESCRIPTION
`types` module is used here: https://github.com/micropython/micropython-lib/blob/7128d423c2e7c0309ac17a1e6ba873b909b24fcc/python-stdlib/copy/copy.py#L51

Fixes https://github.com/micropython/micropython-lib/issues/679