### PR TITLE
all: Remove __version__ from .py files.

### DIFF
--- a/python-stdlib/datetime/datetime.py
+++ b/python-stdlib/datetime/datetime.py
@@ -2,8 +2,6 @@
 
 import time as _tmod
 
-__version__ = "2.0.0"
-
 _DBM = (0, 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334)
 _DIM = (0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
 _TIME_SPEC = ("auto", "hours", "minutes", "seconds", "milliseconds", "microseconds")

--- a/python-stdlib/json/json/__init__.py
+++ b/python-stdlib/json/json/__init__.py
@@ -99,7 +99,7 @@ Using json.tool from the shell to validate and pretty-print::
     $ echo '{ 1.2:3.4}' | python -m json.tool
     Expecting property name enclosed in double quotes: line 1 column 3 (char 2)
 """
-__version__ = "2.0.9"
+
 __all__ = [
     "dump",
     "dumps",

--- a/unix-ffi/cgi/cgi.py
+++ b/unix-ffi/cgi/cgi.py
@@ -25,9 +25,6 @@ written in Python.
 # responsible for its maintenance.
 #
 
-__version__ = "2.6"
-
-
 # Imports
 # =======
 


### PR DESCRIPTION
It is inserted automatically during publish/freezing and having this here prevents the automatic process from happening.

See https://github.com/orgs/micropython/discussions/11838