### PR TITLE
ntptime: Allows manual timezone setting.

### DIFF
--- a/micropython/net/ntptime/ntptime.py
+++ b/micropython/net/ntptime/ntptime.py
@@ -41,9 +41,9 @@ def time():
     return val - NTP_DELTA
 
 
-# There's currently no timezone support in MicroPython, and the RTC is set in UTC time.
-def settime():
-    t = time()
+# Set the zone to fit timezone, default zone=0, and the RTC is set in UTC time.
+def settime(zone=0):
+    t = time() + zone * 3600
     import machine
 
     tm = utime.gmtime(t)


### PR DESCRIPTION
Adds only a minimal amount of code, allowing manual setting of the timezone.

Similar to this PR, but it's closed. https://github.com/micropython/micropython-lib/pull/634