### PR TITLE
stdlib/fnmatch: Fix compatibility with ure -> re.

### DIFF
--- a/python-stdlib/fnmatch/fnmatch.py
+++ b/python-stdlib/fnmatch/fnmatch.py
@@ -27,8 +27,6 @@ except ImportError:
 
 __all__ = ["filter", "fnmatch", "fnmatchcase", "translate"]
 
-COMPAT = re.__name__ == "ure"
-
 
 def fnmatch(name, pat):
     """Test whether FILENAME matches PATTERN.
@@ -58,12 +56,18 @@ def _compile_pattern(pat):
         res = bytes(res_str, "ISO-8859-1")
     else:
         res = translate(pat)
-    if COMPAT:
+
+    try:
+        ptn = re.compile(res)
+    except ValueError:
+        # re1.5 doesn't support all regex features
         if res.startswith("(?ms)"):
             res = res[5:]
         if res.endswith("\\Z"):
             res = res[:-2] + "$"
-    return re.compile(res).match
+        ptn = re.compile(res)
+
+    return ptn.match
 
 
 def filter(names, pat):

--- a/python-stdlib/fnmatch/manifest.py
+++ b/python-stdlib/fnmatch/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.6.0")
+metadata(version="0.6.1")
 
 module("fnmatch.py")


### PR DESCRIPTION
With the recent micropython change to remove the `u` prefix by default on builtins (https://github.com/micropython/micropython/pull/11740) the format checker in fnmatch which was detecting `ure` no longer works. 

The MR updates the module to filter the regex automatically as needed.