### PR TITLE
all: Apply semver versioning to all packages.

### DIFF
--- a/micropython/aioespnow/manifest.py
+++ b/micropython/aioespnow/manifest.py
@@ -1,6 +1,6 @@
 metadata(
     description="Extends the micropython espnow module with methods to support asyncio.",
-    version="0.1",
+    version="0.1.0",
 )
 
 module("aioespnow.py")

--- a/micropython/aiorepl/manifest.py
+++ b/micropython/aiorepl/manifest.py
@@ -1,5 +1,5 @@
 metadata(
-    version="0.1",
+    version="0.1.1",
     description="Provides an asynchronous REPL that can run concurrently with an asyncio, also allowing await expressions.",
 )
 

--- a/micropython/espflash/manifest.py
+++ b/micropython/espflash/manifest.py
@@ -1,5 +1,5 @@
 metadata(
-    version="0.1",
+    version="0.1.0",
     description="Provides a minimal ESP32 bootloader protocol implementation.",
 )
 

--- a/micropython/lora/lora-async/manifest.py
+++ b/micropython/lora/lora-async/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 require("lora")
 package("lora")

--- a/micropython/lora/lora-sx126x/manifest.py
+++ b/micropython/lora/lora-sx126x/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 require("lora")
 package("lora")

--- a/micropython/lora/lora-sx127x/manifest.py
+++ b/micropython/lora/lora-sx127x/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 require("lora")
 package("lora")

--- a/micropython/lora/lora-sync/manifest.py
+++ b/micropython/lora/lora-sync/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 require("lora")
 package("lora")

--- a/micropython/lora/lora/manifest.py
+++ b/micropython/lora/lora/manifest.py
@@ -1,2 +1,2 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 package("lora")

--- a/micropython/udnspkt/manifest.py
+++ b/micropython/udnspkt/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="Make and parse DNS packets (Sans I/O approach).", version="0.1")
+metadata(description="Make and parse DNS packets (Sans I/O approach).", version="0.1.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/micropython/urllib.urequest/manifest.py
+++ b/micropython/urllib.urequest/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.6")
+metadata(version="0.6.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/micropython/xmltok/manifest.py
+++ b/micropython/xmltok/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="Simple XML tokenizer", version="0.2")
+metadata(description="Simple XML tokenizer", version="0.2.1")
 
 # Originally written by Paul Sokolovsky.
 

--- a/python-ecosys/pyjwt/manifest.py
+++ b/python-ecosys/pyjwt/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.1", pypi="pyjwt")
+metadata(version="0.1.0", pypi="pyjwt")
 
 require("hmac")
 

--- a/python-stdlib/argparse/manifest.py
+++ b/python-stdlib/argparse/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.4")
+metadata(version="0.4.0")
 
 # Originally written by Damien George.
 

--- a/python-stdlib/base64/manifest.py
+++ b/python-stdlib/base64/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="3.3.3-4")
+metadata(version="3.3.4")
 
 require("binascii")
 require("struct")

--- a/python-stdlib/binascii/manifest.py
+++ b/python-stdlib/binascii/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="2.4.0-5")
+metadata(version="2.4.1")
 
 module("binascii.py")

--- a/python-stdlib/bisect/manifest.py
+++ b/python-stdlib/bisect/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.5")
+metadata(version="0.5.0")
 
 module("bisect.py")

--- a/python-stdlib/cmd/manifest.py
+++ b/python-stdlib/cmd/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="3.4.0-2")
+metadata(version="3.4.1")
 
 module("cmd.py")

--- a/python-stdlib/collections-defaultdict/manifest.py
+++ b/python-stdlib/collections-defaultdict/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.3")
+metadata(version="0.3.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/python-stdlib/contextlib/manifest.py
+++ b/python-stdlib/contextlib/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="Port of contextlib for micropython", version="3.4.2-4")
+metadata(description="Port of contextlib for micropython", version="3.4.3")
 
 require("ucontextlib")
 require("collections")

--- a/python-stdlib/copy/manifest.py
+++ b/python-stdlib/copy/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="3.3.3-2")
+metadata(version="3.3.4")
 
 require("types")
 

--- a/python-stdlib/curses.ascii/manifest.py
+++ b/python-stdlib/curses.ascii/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="3.4.2-1")
+metadata(version="3.4.3")
 
 package("curses")

--- a/python-stdlib/hashlib-core/manifest.py
+++ b/python-stdlib/hashlib-core/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="1.0")
+metadata(version="1.0.0")
 
 package("hashlib")

--- a/python-stdlib/hashlib-sha224/manifest.py
+++ b/python-stdlib/hashlib-sha224/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="1.0", description="Adds the SHA224 hash algorithm to hashlib.")
+metadata(version="1.0.0", description="Adds the SHA224 hash algorithm to hashlib.")
 
 require("hashlib-sha256")
 package("hashlib")

--- a/python-stdlib/hashlib-sha256/manifest.py
+++ b/python-stdlib/hashlib-sha256/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="1.0", description="Adds the SHA256 hash algorithm to hashlib.")
+metadata(version="1.0.0", description="Adds the SHA256 hash algorithm to hashlib.")
 
 require("hashlib-core")
 package("hashlib")

--- a/python-stdlib/hashlib-sha384/manifest.py
+++ b/python-stdlib/hashlib-sha384/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="1.0", description="Adds the SHA384 hash algorithm to hashlib.")
+metadata(version="1.0.0", description="Adds the SHA384 hash algorithm to hashlib.")
 
 require("hashlib-sha512")
 package("hashlib")

--- a/python-stdlib/hashlib-sha512/manifest.py
+++ b/python-stdlib/hashlib-sha512/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="1.0", description="Adds the SHA512 hash algorithm to hashlib.")
+metadata(version="1.0.0", description="Adds the SHA512 hash algorithm to hashlib.")
 
 require("hashlib-core")
 package("hashlib")

--- a/python-stdlib/hmac/manifest.py
+++ b/python-stdlib/hmac/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="3.4.2-3")
+metadata(version="3.4.3")
 
 module("hmac.py")

--- a/python-stdlib/html/manifest.py
+++ b/python-stdlib/html/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="3.3.3-2")
+metadata(version="3.3.4")
 
 require("string")
 

--- a/python-stdlib/io/manifest.py
+++ b/python-stdlib/io/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 
 module("io.py")

--- a/python-stdlib/json/manifest.py
+++ b/python-stdlib/json/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 
 package("json")

--- a/python-stdlib/logging/manifest.py
+++ b/python-stdlib/logging/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.5")
+metadata(version="0.6.0")
 
 module("logging.py")

--- a/python-stdlib/os/manifest.py
+++ b/python-stdlib/os/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.6")
+metadata(version="0.6.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/python-stdlib/pickle/manifest.py
+++ b/python-stdlib/pickle/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 
 module("pickle.py")

--- a/python-stdlib/random/manifest.py
+++ b/python-stdlib/random/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.2")
+metadata(version="0.2.0")
 
 module("random.py")

--- a/python-stdlib/ssl/manifest.py
+++ b/python-stdlib/ssl/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 
 module("ssl.py")

--- a/python-stdlib/textwrap/manifest.py
+++ b/python-stdlib/textwrap/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="3.4.2-1")
+metadata(version="3.4.3")
 
 module("textwrap.py")

--- a/python-stdlib/threading/manifest.py
+++ b/python-stdlib/threading/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 
 module("threading.py")

--- a/python-stdlib/time/manifest.py
+++ b/python-stdlib/time/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 
 module("time.py")

--- a/python-stdlib/traceback/manifest.py
+++ b/python-stdlib/traceback/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.3")
+metadata(version="0.3.0")
 
 module("traceback.py")

--- a/unix-ffi/_markupbase/manifest.py
+++ b/unix-ffi/_markupbase/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="3.3.3-1")
+metadata(version="3.3.4")
 
 require("re", unix_ffi=True)
 

--- a/unix-ffi/cgi/manifest.py
+++ b/unix-ffi/cgi/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="3.3.3-2")
+metadata(version="3.3.4")
 
 module("cgi.py")

--- a/unix-ffi/email.utils/manifest.py
+++ b/unix-ffi/email.utils/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="3.3.3-2")
+metadata(version="3.3.4")
 
 require("os", unix_ffi=True)
 require("re", unix_ffi=True)

--- a/unix-ffi/getopt/manifest.py
+++ b/unix-ffi/getopt/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="3.3.3-1")
+metadata(version="3.3.4")
 
 require("os", unix_ffi=True)
 

--- a/unix-ffi/gettext/manifest.py
+++ b/unix-ffi/gettext/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 
 # Originally written by Riccardo Magliocchetti.
 

--- a/unix-ffi/html.entities/manifest.py
+++ b/unix-ffi/html.entities/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="3.3.3-1")
+metadata(version="3.3.4")
 
 package("html")

--- a/unix-ffi/html.parser/manifest.py
+++ b/unix-ffi/html.parser/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="3.3.3-2")
+metadata(version="3.3.4")
 
 require("_markupbase", unix_ffi=True)
 require("warnings")

--- a/unix-ffi/os/manifest.py
+++ b/unix-ffi/os/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.6")
+metadata(version="0.6.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/unix-ffi/pwd/manifest.py
+++ b/unix-ffi/pwd/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.1")
+metadata(version="0.1.0")
 
 # Originally written by Riccardo Magliocchetti.
 

--- a/unix-ffi/select/manifest.py
+++ b/unix-ffi/select/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.3")
+metadata(version="0.3.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/unix-ffi/time/manifest.py
+++ b/unix-ffi/time/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.5")
+metadata(version="0.5.0")
 
 require("ffilib", unix_ffi=True)
 

--- a/unix-ffi/timeit/manifest.py
+++ b/unix-ffi/timeit/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="3.3.3-3")
+metadata(version="3.3.4")
 
 require("getopt", unix_ffi=True)
 require("itertools")


### PR DESCRIPTION
- For packages that were just x.y, update to x.y.0.
- For that were x.y.z-N, update to x.y.(z+1)

From now on we'll apply semver rules:
- MAJOR version when you make incompatible API changes
- MINOR version when you add functionality in a backward compatible manner
- PATCH version when you make backward compatible bug fixes

In a separate PR we should consider moving some of our 0.y.z packages to 1.0.0 in order to establish the initial "major" version.

Some more background here: https://github.com/orgs/micropython/discussions/11838#discussioncomment-6247638