### PR TITLE
Add pre-commit support for micropython-lib.

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: pip install --user ruff
-    - run: ruff --format=github .
     - uses: actions/setup-python@v4
     - name: Install packages
       run: source tools/ci.sh && ci_code_formatting_setup

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+name: Python code lint with ruff
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: pip install --user ruff
+    - run: ruff --format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: local
+    hooks:
+      - id: codeformat
+        name: MicroPython codeformat.py for changed files
+        entry: tools/codeformat.py -v -f
+        language: python
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.280
+    hooks:
+      - id: ruff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,21 @@ or packages from micropython-lib, please post at the
 ### Pull requests
 
 The same rules for commit messages, signing-off commits, and commit structure
-apply as for the main MicroPython repository. All Python code is formatted
-using `black`. See [`tools/codeformat.py`](tools/codeformat.py) to apply
-`black` automatically before submitting a PR.
+apply [as for the main MicroPython repository](https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md).
 
-There are some specific conventions and guidelines for micropython-lib:
+All Python code is formatted using the [black](https://github.com/psf/black)
+tool. You can run [`tools/codeformat.py`](tools/codeformat.py) to apply
+`black` automatically before submitting a PR. The GitHub CI will also run the
+[ruff](https://github.com/astral-sh/ruff) tool to apply further "linting"
+checks.
+
+Similar to the main repository, a configuration is provided for the
+[pre-commit](https://pre-commit.com/) tool to apply `black` code formatting
+rules and run `ruff` automatically. See the documentation for using pre-commit
+in [the code conventions document](https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md#automatic-pre-commit-hooks)
+
+In addition to the conventions from the main repository, there are some
+specific conventions and guidelines for micropython-lib:
 
 * The first line of the commit message should start with the name of the
   package, followed by a short description of the commit. Package names are

--- a/tools/codeformat.py
+++ b/tools/codeformat.py
@@ -76,7 +76,7 @@ def main():
             # Filter against the default list of files. This is a little fiddly
             # because we need to apply both the inclusion globs given in PATHS
             # as well as the EXCLUSIONS, and use absolute paths
-            files = set(os.path.abspath(f) for f in files)
+            files = {os.path.abspath(f) for f in files}
             all_files = set(list_files(PATHS, EXCLUSIONS, TOP))
             if args.v:  # In verbose mode, log any files we're skipping
                 for f in files - all_files:


### PR DESCRIPTION
1. Simplify codeformat.py back to be the same as the main repo version, but without .c/.h support. (It's pretty much just a wrapper around `black` now)
2. Add pre-commit support (same as main repo).
3. Split the ruff action into its own CI action (same as main repo).

_This work was funded through GitHub Sponsors._