### PR TITLE
logging: add call to superclass initialiser; set default formatter

### DIFF
--- a/python-stdlib/logging/logging.py
+++ b/python-stdlib/logging/logging.py
@@ -58,6 +58,8 @@ class Handler:
 
 class StreamHandler(Handler):
     def __init__(self, stream=None):
+        # Not allowing `level` to be set via the initialiser to mirror CPython's implementation
+        super().__init__()
         self.stream = _stream if stream is None else stream
         self.terminator = "\n"
 

--- a/python-stdlib/logging/logging.py
+++ b/python-stdlib/logging/logging.py
@@ -53,7 +53,11 @@ class Handler:
         self.formatter = formatter
 
     def format(self, record):
-        return self.formatter.format(record)
+        if self.formatter:
+            fmt = self.formatter
+        else:
+            fmt = _defaultFormatter
+        return fmt.format(record)
 
 
 class StreamHandler(Handler):
@@ -104,6 +108,12 @@ class Formatter:
             "asctime": record.asctime,
             "levelname": record.levelname,
         }
+
+
+#
+#   The default formatter to use when no other is specified
+#
+_defaultFormatter = Formatter()
 
 
 class Logger:


### PR DESCRIPTION
Addresses minor issues in `logging` module, reported in https://github.com/micropython/micropython-lib/issues/691. 


## Change 1: Makes subclasses of `logging.Handler` call the superclasses' initialiser
CPython:
```
>>> import logging
>>> logger = logging.StreamHandler()
>>> logger.level 
0
```

MicroPython (`master`):
```
>>> logger = logging.StreamHandler()
>>> logger.level
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'StreamHandler' object has no attribute 'level'
```

MicroPython (this branch):
```
>>> logger = logging.StreamHandler()
>>> logger.level
0
```


## Change 2: Sets a default formatter if not set
CPython:
```
>>> record = logging.LogRecord("Test", 20, "/example", 1, "Hello", (), None)
>>> logger.emit(record)
Hello
```

MicroPython (`master` + fix 1):
```
>>> record = logging.LogRecord()
>>> record.set("Test", 20, "Hello")
>>> logger.emit(record)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "logging.py", line 72, in emit
  File "logging.py", line 56, in format
AttributeError: 'NoneType' object has no attribute 'format'
```

MicroPython (this branch):
```
>>> record = logging.LogRecord()
>>> record.set("Test", 20, "Hello")
>>> logger.emit(record)
INFO:Test:Hello
```


The CPython implementation of `logging` can be found here:
https://github.com/python/cpython/blob/main/Lib/logging/__init__.py