### PR TITLE
mip: Raise exception if installs fail

### DIFF
--- a/micropython/mip/mip/__init__.py
+++ b/micropython/mip/mip/__init__.py
@@ -153,6 +153,12 @@ def _install_package(package, index, target, version, mpy):
     return _install_json(package, index, target, version, mpy)
 
 
+class InstallError(RuntimeError):
+    """
+    Raised when an installation fails.
+    """
+
+
 def install(package, index=None, target=None, version=None, mpy=True):
     if not target:
         for p in sys.path:
@@ -160,8 +166,7 @@ def install(package, index=None, target=None, version=None, mpy=True):
                 target = p
                 break
         else:
-            print("Unable to find lib dir in sys.path")
-            return
+            raise InstallError("Unable to find lib dir in sys.path")
 
     if not index:
         index = _PACKAGE_INDEX
@@ -169,4 +174,4 @@ def install(package, index=None, target=None, version=None, mpy=True):
     if _install_package(package, index.rstrip("/"), target, version, mpy):
         print("Done")
     else:
-        print("Package may be partially installed")
+        raise InstallError("Package may be partially installed")


### PR DESCRIPTION
Currently, the only way to know if `mip.install` has failed is to interpret the final line emitted to stdout. This makes it difficult to use `mip` in scripts. To better support this use case, this change introduces an `InstallError` that is raised if the installation is not successful.

Install failures after this PR:
```
>>> mip.install("does-not-exist")
Installing does-not-exist (latest) from https://micropython.org/pi/v2 to /home/colin/.micropython/lib
Package not found: https://micropython.org/pi/v2/package/6/does-not-exist/latest.json
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mip/__init__.py", line 185, in install
InstallError: Package may be partially installed
```

```
>>> sys.path = []
>>> mip.install("logging")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mip/__init__.py", line 177, in install
InstallError: Unable to find lib dir in sys.path
```