### PR TITLE
lora: Remove the pin parameter from IRQ callback.

### DIFF
--- a/micropython/lora/README.md
+++ b/micropython/lora/README.md
@@ -1028,12 +1028,12 @@ following different approaches:
   `poll_send()` now?" check function if there's no easy way to determine
   which interrupt has woken the board up.
 * Implement a custom interrupt callback function and call
-  `modem.set_irq_callback()` to install it. The function will be called with a
-  single argument, which is either the `Pin` that triggered a hardware interrupt
-  or `None` for a soft interrupt. Refer to the documentation about [writing interrupt
-  handlers](https://docs.micropython.org/en/latest/reference/isr_rules.html) for
-  more information. The `lora-async` modem classes install their own callback here,
-  so it's not possible to mix this approach with the provided asynchronous API.
+  `modem.set_irq_callback()` to install it. The function will be called if a
+  hardware interrupt occurs, possibly in hard interrupt context. Refer to the
+  documentation about [writing interrupt handlers][isr_rules] for more
+  information. It may also be called if the driver triggers a soft interrupt.
+  The `lora-async` modem classes install their own callback here, so it's not
+  possible to mix this approach with the provided asynchronous API.
 * Call `modem.poll_recv()` or `modem.poll_send()`. This takes more time
   and uses more power as it reads the modem IRQ status directly from the modem
   via SPI, but it also give the most definite result.
@@ -1154,3 +1154,5 @@ Usually, this means the constructor parameter `dio3_tcxo_millivolts` (see above)
 must be set as the SX126x chip DIO3 output pin is the power source for the TCXO
 connected to the modem.  Often this parameter should be set to `3300` (3.3V) but
 it may be another value, consult the documentation for your LoRa modem module.
+
+[isr_rules]: https://docs.micropython.org/en/latest/reference/isr_rules.html

--- a/micropython/lora/lora-async/lora/async_modem.py
+++ b/micropython/lora/lora-async/lora/async_modem.py
@@ -111,9 +111,8 @@ class AsyncModem:
         if _DEBUG:
             print(f"wait complete")
 
-    def _callback(self, _):
-        # IRQ callback from BaseModem._radio_isr. Hard IRQ context unless _DEBUG
-        # is on.
+    def _callback(self):
+        # IRQ callback from BaseModem._radio_isr. May be in Hard IRQ context.
         #
         # Set both RX & TX flag. This isn't necessary for "real" interrupts, but may be necessary
         # to wake both for the case of a "soft" interrupt triggered by sleep() or standby(), where

--- a/micropython/lora/lora-async/manifest.py
+++ b/micropython/lora/lora-async/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 require("lora")
 package("lora")

--- a/micropython/lora/lora/lora/modem.py
+++ b/micropython/lora/lora/lora/modem.py
@@ -233,25 +233,16 @@ class BaseModem:
     #
     # ISR implementation is relatively simple, just exists to signal an optional
     # callback, record a timestamp, and wake up the hardware if
-    # needed. ppplication code is expected to call poll_send() or
+    # needed. Application code is expected to call poll_send() or
     # poll_recv() as applicable in order to confirm the modem state.
     #
-    # This is a MP hard irq in some configurations, meaning no memory allocation is possible.
-    #
-    # 'pin' may also be None if this is a "soft" IRQ triggered after a receive
-    # timed out during a send (meaning no receive IRQ will fire, but the
-    # receiver should wake up and move on anyhow.)
-    def _radio_isr(self, pin):
+    # This is a MP hard irq in some configurations.
+    def _radio_isr(self, _):
         self._last_irq = time.ticks_ms()
         if self._irq_callback:
-            self._irq_callback(pin)
+            self._irq_callback()
         if _DEBUG:
-            # Note: this may cause a MemoryError and fail if _DEBUG is enabled in this base class
-            # but disabled in the subclass, meaning this is a hard irq handler
-            try:
-                print("_radio_isr pin={}".format(pin))
-            except MemoryError:
-                pass
+            print("_radio_isr")
 
     def irq_triggered(self):
         # Returns True if the ISR has executed since the last time a send or a receive
@@ -264,8 +255,7 @@ class BaseModem:
         # This is used by the AsyncModem implementation, but can be called in
         # other circumstances to implement custom ISR logic.
         #
-        # Note that callback may be called in hard ISR context, meaning no
-        # memory allocation is possible.
+        # Note that callback may be called in hard ISR context.
         self._irq_callback = callback
 
     def _get_last_irq(self):

--- a/micropython/lora/lora/manifest.py
+++ b/micropython/lora/lora/manifest.py
@@ -1,2 +1,2 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 package("lora")


### PR DESCRIPTION
It's not necessary to know which pin triggered the IRQ, and it saves some code size.

Noticed while making changes for #572, but is actually an unrelated change.

---

This work was funded through GitHub Sponsors.