### PR TITLE
drivers/display/lcd160cr: Use isinstance() for type checking.

### DIFF
--- a/micropython/drivers/display/lcd160cr/lcd160cr_test.py
+++ b/micropython/drivers/display/lcd160cr/lcd160cr_test.py
@@ -5,7 +5,7 @@ import time, math, framebuf, lcd160cr
 
 
 def get_lcd(lcd):
-    if type(lcd) is str:
+    if isinstance(lcd, str):
         lcd = lcd160cr.LCD160CR(lcd)
     return lcd
 


### PR DESCRIPTION
Fixes linter warning [E721](https://beta.ruff.rs/docs/rules/type-comparison/), which was expanded in Ruff 823 to include direct comparison against built-in types.

This is the micropython-lib version of https://github.com/micropython/micropython/pull/12196

---

This work was funded by GitHub sponsors.