### PR TITLE
stdlib/os: Provide namedtuple response for os.stat().

### DIFF
--- a/python-stdlib/os/manifest.py
+++ b/python-stdlib/os/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.6.0")
+metadata(version="0.7.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/python-stdlib/os/os/__init__.py
+++ b/python-stdlib/os/os/__init__.py
@@ -6,3 +6,28 @@ try:
     from . import path
 except ImportError:
     pass
+
+from collections import namedtuple
+
+# https://docs.python.org/3/library/os.html#os.stat_result
+stat_result = namedtuple(
+    "stat_result",
+    (
+        "st_mode",
+        "st_ino",
+        "st_dev",
+        "st_nlink",
+        "st_uid",
+        "st_gid",
+        "st_size",
+        "st_atime",
+        "st_mtime",
+        "st_ctime",
+    ),
+)
+
+__os_stat = stat
+
+
+def stat(path):
+    return stat_result(*__os_stat(path))


### PR DESCRIPTION
Having the option to wrap / return os.stat() with the cpython standard format can greatly aid in porting third party libraries.