### PR TITLE
bundle-networking: Include urllib.urequest

### DIFF
--- a/micropython/bundles/bundle-networking/manifest.py
+++ b/micropython/bundles/bundle-networking/manifest.py
@@ -7,6 +7,7 @@ require("mip")
 require("ntptime")
 require("requests")
 require("webrepl")
+require("urllib.urequest")
 
 # Provide urequests (which just forwards to requests) for backwards
 # compatibility.


### PR DESCRIPTION
`urllib.urequest.urlopen` provides an easy way to stream HTTP requests (which urequests can't do), and is seemingly generally recommended over urequests for anything that is more involved than doing a small HTTP request.

it's already [included by default with esp8266](https://github.com/micropython/micropython/blob/65f0cb11afb92cc9c333158ea467667f2127c9a2/ports/esp8266/boards/ESP8266_GENERIC/manifest_2MiB.py#L15) but somehow isn't with the rest of network-capable boards.

this PR changes it so that all boards that install bundle-networking get urllib.urequest too.