### PR TITLE
drivers/led/neopixel: Add brightness control.

### DIFF
--- a/micropython/drivers/led/neopixel/manifest.py
+++ b/micropython/drivers/led/neopixel/manifest.py
@@ -1,3 +1,3 @@
-metadata(description="WS2812/NeoPixel driver.", version="0.1.0")
+metadata(description="WS2812/NeoPixel driver.", version="0.2.0")
 
 module("neopixel.py", opt=3)

--- a/micropython/drivers/led/neopixel/neopixel.py
+++ b/micropython/drivers/led/neopixel/neopixel.py
@@ -31,8 +31,8 @@ class NeoPixel:
 
     def __setitem__(self, i, v):
         offset = i * self.bpp
+        adjusted_v = tuple(self._calculate_brightness(c) for c in v)
         for i in range(self.bpp):
-            adjusted_v = tuple(self._calculate_brightness(c) for c in v)
             self.buf[offset + self.ORDER[i]] = adjusted_v[i]
 
     def __getitem__(self, i):

--- a/micropython/drivers/led/neopixel/neopixel.py
+++ b/micropython/drivers/led/neopixel/neopixel.py
@@ -43,6 +43,11 @@ class NeoPixel:
         for i in range(self.n):
             self[i] = v
 
+    def set_brightness(self, b: float):
+        self.brightness = b
+        for i in range(self.n):
+            self[i] = self[i]
+
     def write(self):
         # BITSTREAM_TYPE_HIGH_LOW = 0
         bitstream(self.pin, 0, self.timing, self.buf)

--- a/micropython/drivers/led/neopixel/neopixel.py
+++ b/micropython/drivers/led/neopixel/neopixel.py
@@ -44,8 +44,8 @@ class NeoPixel:
             self[i] = v
 
     def set_brightness(self, b: float):
-        self.brightness = b
-        for i in range(self.n):
+        self.brightness = min(max(b, 0.0), 1.0)
+        for i in range(self.n)
             self[i] = self[i]
 
     def write(self):

--- a/micropython/drivers/led/neopixel/neopixel.py
+++ b/micropython/drivers/led/neopixel/neopixel.py
@@ -12,7 +12,7 @@ class NeoPixel:
         self.pin = pin
         self.n = n
         self.bpp = bpp
-        self.brightness = brightness
+        self.brightness = min(max(brightness, 0.0), 1.0)
         self.buf = bytearray(n * bpp)
         self.pin.init(pin.OUT)
         # Timing arg can either be 1 for 800kHz or 0 for 400kHz,
@@ -45,7 +45,7 @@ class NeoPixel:
 
     def set_brightness(self, b: float):
         self.brightness = min(max(b, 0.0), 1.0)
-        for i in range(self.n)
+        for i in range(self.n):
             self[i] = self[i]
 
     def write(self):

--- a/micropython/drivers/led/neopixel/neopixel.py
+++ b/micropython/drivers/led/neopixel/neopixel.py
@@ -8,10 +8,11 @@ class NeoPixel:
     # G R B W
     ORDER = (1, 0, 2, 3)
 
-    def __init__(self, pin, n, bpp=3, timing=1):
+    def __init__(self, pin, n, bpp=3, timing=1, brightness: float = 1.0):
         self.pin = pin
         self.n = n
         self.bpp = bpp
+        self.brightness = brightness
         self.buf = bytearray(n * bpp)
         self.pin.init(pin.OUT)
         # Timing arg can either be 1 for 800kHz or 0 for 400kHz,
@@ -22,28 +23,25 @@ class NeoPixel:
             else timing
         )
 
+    def _calculate_brightness(self, v):
+        return round(v * self.brightness)
+
     def __len__(self):
         return self.n
 
     def __setitem__(self, i, v):
         offset = i * self.bpp
         for i in range(self.bpp):
-            self.buf[offset + self.ORDER[i]] = v[i]
+            adjusted_v = tuple(self._calculate_brightness(c) for c in v)
+            self.buf[offset + self.ORDER[i]] = adjusted_v[i]
 
     def __getitem__(self, i):
         offset = i * self.bpp
         return tuple(self.buf[offset + self.ORDER[i]] for i in range(self.bpp))
 
     def fill(self, v):
-        b = self.buf
-        l = len(self.buf)
-        bpp = self.bpp
-        for i in range(bpp):
-            c = v[i]
-            j = self.ORDER[i]
-            while j < l:
-                b[j] = c
-                j += bpp
+        for i in range(self.n):
+            self[i] = v
 
     def write(self):
         # BITSTREAM_TYPE_HIGH_LOW = 0


### PR DESCRIPTION
New functionality to specify a brightness for the strip when creating the instance, and also via `set_brightness`. Also refactored the `fill()` method to avoid duplicating the logic used in `__setitem__`. Existing functionality is that the `write()` method must be called to see the changes, so while `set_brightness` does change the values for all the pixels in the instance, it does not write that back out to the strip immediately.

This should be completely backwards-compatible with the previous version in that the brightness is by default 100%.