### PR TITLE
.github/workflows/ruff.yml: Pin to 0.1.0.

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,6 +5,6 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - run: pip install --user ruff
-    - run: ruff --format=github .
+    - uses: actions/checkout@v4
+    - run: pip install --user ruff==0.1.0
+    - run: ruff check --output-format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,6 @@ repos:
         entry: tools/codeformat.py -v -f
         language: python
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.280
+    rev: v0.1.0
     hooks:
       - id: ruff


### PR DESCRIPTION
The `--format` flag was changed to `--output-format` in the recent update.

Pin to this version to prevent further updates from breaking (e.g. through new rules or other changes).

_This work was funded through GitHub Sponsors._