### PR TITLE
requests: Added support for some non-standard URLs

### DIFF
--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -68,6 +68,14 @@ def request(
         port = 443
     else:
         raise ValueError("Unsupported protocol: " + proto)
+    
+    if "?" in host:
+        host, _path = host.split("?", 1)
+        path = "?" + _path + path
+
+    if "#" in host:
+        host, _path = host.split("#", 1)
+        path = "#" + _path + path
 
     if ":" in host:
         host, port = host.split(":", 1)


### PR DESCRIPTION
In some cases, servers may return non-standard URLs like `https://ecard.v.zzu.edu.cn?tid=xxxx` in "Location" line, which could not be properly treated since there are no slashes between hostname and remote path. So I added my code to separate remote path from hostname. 