### PR TITLE
aiorepl features: cursor, paste and raw mode.

### DIFF
--- a/micropython/aiorepl/README.md
+++ b/micropython/aiorepl/README.md
@@ -21,7 +21,7 @@ To use this library, you need to import the library and then start the REPL task
 For example, in main.py:
 
 ```py
-import uasyncio as asyncio
+import asyncio
 import aiorepl
 
 async def demo():

--- a/micropython/aiorepl/aiorepl.py
+++ b/micropython/aiorepl/aiorepl.py
@@ -5,7 +5,7 @@ from micropython import const
 import re
 import sys
 import time
-import uasyncio as asyncio
+import asyncio
 
 # Import statement (needs to be global, and does not return).
 _RE_IMPORT = re.compile("^import ([^ ]+)( as ([^ ]+))?")

--- a/micropython/aiorepl/manifest.py
+++ b/micropython/aiorepl/manifest.py
@@ -1,5 +1,5 @@
 metadata(
-    version="0.1.1",
+    version="0.2.0",
     description="Provides an asynchronous REPL that can run concurrently with an asyncio, also allowing await expressions.",
 )
 


### PR DESCRIPTION
I've been using aiorepl daily on my work project and could no longer live without it. I have however been missing some features of the built in repl, so worked to add them here!

The most regular issue I run into is needing to update / fix the line I've just typed! So this PR adds left/right cursor support with character insertion / deletion. This includes the redraw-to-end-of line stuff needed to keep the terminal looking correct.

I considered adding some python functions to the existing readline functionality in micropython, however I think trying to break out a suitable api of readline / repl interface parts suitable for use in something like this would take some effort and and code bulk not used by many users.

Another limitation I've found quite difficult lately is the inability to handle multi-line input, particularly for defining functions etc inline, or pasting a few lines of list creation.  Rather than implementing full mulitline handling by detection when an "open" command is interered, I thought just adding paste mode would be simpler - it was quite clean really, though I don't print the `==` prompt on each line like the builtin repl does.

Lastly, I really wanted more mpremote support for my running instrument with aiorepl active, so reimplemented raw / raw-paste mode from pyexec.c. Again it'd be more efficient to expose some of the underlying c functions for this but they'd need to be refactored to allow passing in received characters which would be very messy. So, pure-python versions have been written and seem to "just work" for the current master branch mpremote for file copy and mount functionality!

@jimmo would you prefer some/all of this in an extension module? it does make the module a reasonable bit bigger....

---
This work was funded by Planet Innovation.