### PR TITLE
uaiohttpclient: parse port instead of hard code 80

### DIFF
--- a/micropython/uaiohttpclient/example.py
+++ b/micropython/uaiohttpclient/example.py
@@ -1,31 +1,16 @@
 #
 # uaiohttpclient - fetch URL passed as command line argument.
 #
+import sys
 import uasyncio as asyncio
 import uaiohttpclient as aiohttp
 
 
-def print_stream(resp):
-    print((yield from resp.read()))
-    return
-    while True:
-        line = yield from resp.readline()
-        if not line:
-            break
-        print(line.rstrip())
-
-
-def run(url):
-    resp = yield from aiohttp.request("GET", url)
+async def run(url):
+    resp = await aiohttp.request("GET", url)
     print(resp)
-    yield from print_stream(resp)
+    print(await resp.read())
 
 
-import sys
-import logging
-
-logging.basicConfig(level=logging.INFO)
 url = sys.argv[1]
-loop = asyncio.get_event_loop()
-loop.run_until_complete(run(url))
-loop.close()
+asyncio.run(run(url))

--- a/micropython/uaiohttpclient/manifest.py
+++ b/micropython/uaiohttpclient/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="HTTP client module for MicroPython uasyncio module", version="0.5.1")
+metadata(description="HTTP client module for MicroPython uasyncio module", version="0.5.2")
 
 # Originally written by Paul Sokolovsky.
 

--- a/micropython/uaiohttpclient/uaiohttpclient.py
+++ b/micropython/uaiohttpclient/uaiohttpclient.py
@@ -19,10 +19,10 @@ class ChunkedClientResponse(ClientResponse):
 
     def read(self, sz=4 * 1024 * 1024):
         if self.chunk_size == 0:
-            l = yield from self.content.readline()
+            line = yield from self.content.readline()
             # print("chunk line:", l)
-            l = l.split(b";", 1)[0]
-            self.chunk_size = int(l, 16)
+            line = line.split(b";", 1)[0]
+            self.chunk_size = int(line, 16)
             # print("chunk size:", self.chunk_size)
             if self.chunk_size == 0:
                 # End of message
@@ -56,9 +56,10 @@ def request_raw(method, url):
     if proto != "http:":
         raise ValueError("Unsupported protocol: " + proto)
     reader, writer = yield from asyncio.open_connection(host, port)
-    # Use protocol 1.0, because 1.1 always allows to use chunked transfer-encoding
-    # But explicitly set Connection: close, even though this should be default for 1.0,
-    # because some servers misbehave w/o it.
+    # Use protocol 1.0, because 1.1 always allows to use chunked
+    # transfer-encoding But explicitly set Connection: close, even
+    # though this should be default for 1.0, because some servers
+    # misbehave w/o it.
     query = "%s /%s HTTP/1.0\r\nHost: %s\r\nConnection: close\r\nUser-Agent: compat\r\n\r\n" % (
         method,
         path,
@@ -71,7 +72,6 @@ def request_raw(method, url):
 
 def request(method, url):
     redir_cnt = 0
-    redir_url = None
     while redir_cnt < 2:
         reader = yield from request_raw(method, url)
         headers = []

--- a/micropython/uaiohttpclient/uaiohttpclient.py
+++ b/micropython/uaiohttpclient/uaiohttpclient.py
@@ -5,8 +5,8 @@ class ClientResponse:
     def __init__(self, reader):
         self.content = reader
 
-    def read(self, sz=-1):
-        return (yield from self.content.read(sz))
+    async def read(self, sz=-1):
+        return await self.content.read(sz)
 
     def __repr__(self):
         return "<ClientResponse %d %s>" % (self.status, self.headers)
@@ -17,22 +17,22 @@ class ChunkedClientResponse(ClientResponse):
         self.content = reader
         self.chunk_size = 0
 
-    def read(self, sz=4 * 1024 * 1024):
+    async def read(self, sz=4 * 1024 * 1024):
         if self.chunk_size == 0:
-            line = yield from self.content.readline()
+            line = await self.content.readline()
             # print("chunk line:", l)
             line = line.split(b";", 1)[0]
             self.chunk_size = int(line, 16)
             # print("chunk size:", self.chunk_size)
             if self.chunk_size == 0:
                 # End of message
-                sep = yield from self.content.read(2)
+                sep = await self.content.read(2)
                 assert sep == b"\r\n"
                 return b""
-        data = yield from self.content.read(min(sz, self.chunk_size))
+        data = await self.content.read(min(sz, self.chunk_size))
         self.chunk_size -= len(data)
         if self.chunk_size == 0:
-            sep = yield from self.content.read(2)
+            sep = await self.content.read(2)
             assert sep == b"\r\n"
         return data
 
@@ -40,7 +40,7 @@ class ChunkedClientResponse(ClientResponse):
         return "<ChunkedClientResponse %d %s>" % (self.status, self.headers)
 
 
-def request_raw(method, url):
+async def request_raw(method, url):
     try:
         proto, dummy, host, path = url.split("/", 3)
     except ValueError:
@@ -55,7 +55,7 @@ def request_raw(method, url):
 
     if proto != "http:":
         raise ValueError("Unsupported protocol: " + proto)
-    reader, writer = yield from asyncio.open_connection(host, port)
+    reader, writer = await asyncio.open_connection(host, port)
     # Use protocol 1.0, because 1.1 always allows to use chunked
     # transfer-encoding But explicitly set Connection: close, even
     # though this should be default for 1.0, because some servers
@@ -65,22 +65,21 @@ def request_raw(method, url):
         path,
         host,
     )
-    yield from writer.awrite(query.encode("latin-1"))
-    #    yield from writer.aclose()
+    await writer.awrite(query.encode("latin-1"))
     return reader
 
 
-def request(method, url):
+async def request(method, url):
     redir_cnt = 0
     while redir_cnt < 2:
-        reader = yield from request_raw(method, url)
+        reader = await request_raw(method, url)
         headers = []
-        sline = yield from reader.readline()
+        sline = await reader.readline()
         sline = sline.split(None, 2)
         status = int(sline[1])
         chunked = False
         while True:
-            line = yield from reader.readline()
+            line = await reader.readline()
             if not line or line == b"\r\n":
                 break
             headers.append(line)
@@ -92,7 +91,7 @@ def request(method, url):
 
         if 301 <= status <= 303:
             redir_cnt += 1
-            yield from reader.aclose()
+            await reader.aclose()
             continue
         break
 

--- a/micropython/uaiohttpclient/uaiohttpclient.py
+++ b/micropython/uaiohttpclient/uaiohttpclient.py
@@ -46,9 +46,16 @@ def request_raw(method, url):
     except ValueError:
         proto, dummy, host = url.split("/", 2)
         path = ""
+
+    if ":" in host:
+        host, port = host.split(":")
+        port = int(port)
+    else:
+        port = 80
+
     if proto != "http:":
         raise ValueError("Unsupported protocol: " + proto)
-    reader, writer = yield from asyncio.open_connection(host, 80)
+    reader, writer = yield from asyncio.open_connection(host, port)
     # Use protocol 1.0, because 1.1 always allows to use chunked transfer-encoding
     # But explicitly set Connection: close, even though this should be default for 1.0,
     # because some servers misbehave w/o it.


### PR DESCRIPTION
I was getting an error using `uaiohttpclient` and it was due to it hard coding port 80 for the target host. This PR makes a trivial change to split `host:port` if present in the URL. I thought it also sensible to update all the `yield from` to `await` everywhere and of course preface those functions `async`. I made a couple of other minor changes which were suggested by ruff and flake8, i.e. a variable `l` I changed to `ln` and there was a comment > 80 chars which I wrapped.