### PR TITLE
lcd160cr: Remove support for options in manifest.

### DIFF
--- a/micropython/drivers/display/lcd160cr/manifest.py
+++ b/micropython/drivers/display/lcd160cr/manifest.py
@@ -1,8 +1,3 @@
 metadata(description="LCD160CR driver.", version="0.1.0")
 
-options.defaults(test=False)
-
 module("lcd160cr.py", opt=3)
-
-if options.test:
-    module("lcd160cr_test.py", opt=3)


### PR DESCRIPTION
This is the last remaining use of the "options" feature. Nothing in the main repo which `require()`'s this package sets it.

_This work was funded through GitHub Sponsors._