### PR TITLE
typofix in l2cap_file_server.py

### DIFF
--- a/micropython/bluetooth/aioble/examples/l2cap_file_server.py
+++ b/micropython/bluetooth/aioble/examples/l2cap_file_server.py
@@ -97,7 +97,7 @@ async def l2cap_task(connection):
             if list_path:
                 print("List:", list_path)
                 try:
-                    for name, _, _, size in os.ilistdir(list_path):
+                    for name, _, _, size in os.listdir(list_path):
                         await channel.send("{}:{}\n".format(size, name))
                     await channel.send("\n")
                     await channel.flush()


### PR DESCRIPTION
fix a typo. os has `listdir`, not `ilistdir`. `i` prefix seems to be wrong.