### PR TITLE
python-stdlib/hmac/hmac: Fix for hashlib.

### DIFF
--- a/python-stdlib/hmac/hmac.py
+++ b/python-stdlib/hmac/hmac.py
@@ -17,7 +17,7 @@ class HMAC:
             make_hash = digestmod  # A
         elif isinstance(digestmod, str):
             # A hash name suitable for hashlib.new().
-            make_hash = lambda d=b"": hashlib.new(digestmod, d)  # B
+            make_hash = lambda d=b"": getattr(hashlib, digestmod)(d)
         else:
             # A module supporting PEP 247.
             make_hash = digestmod.new  # C

--- a/python-stdlib/hmac/manifest.py
+++ b/python-stdlib/hmac/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="3.4.3")
+metadata(version="3.4.4")
 
 module("hmac.py")

--- a/python-stdlib/hmac/test_hmac.py
+++ b/python-stdlib/hmac/test_hmac.py
@@ -8,7 +8,7 @@ import hashlib
 
 msg = b"zlutoucky kun upel dabelske ody"
 
-dig = hmac.new(b"1234567890", msg=msg, digestmod=hashlib.sha256).hexdigest()
+dig = hmac.new(b"1234567890", msg=msg, digestmod="sha256").hexdigest()
 
 print("c735e751e36b08fb01e25794bdb15e7289b82aecdb652c8f4f72f307b39dad39")
 print(dig)


### PR DESCRIPTION
hashlib has no .new method?