### PR TITLE
tarfile-write: fix TarInfo mode in add() method. Set permissions to 644 instead of 000 (fixes #797)

### DIFF
--- a/python-stdlib/tarfile-write/tarfile/write.py
+++ b/python-stdlib/tarfile-write/tarfile/write.py
@@ -99,7 +99,7 @@ def add(self, name, recursive=True):
     tarinfo = TarInfo(name)
     try:
         stat = os.stat(name)
-        tarinfo.mode = stat[0]
+        tarinfo.mode = 0x1a4
         tarinfo.uid = stat[4]
         tarinfo.gid = stat[5]
         tarinfo.size = stat[6]


### PR DESCRIPTION
This change fixes issue #797 which I opened a bit earlier.

I'm not sure how to go about this PR because the suggested change doesn't require a lot of the code linting and other requests from the contributing guidelines, but maybe I'm missing something.
I didn't even clone the repository but did everything in GitHub to avoid VS Code applying weirdness to the file format, 
hope it works out.

thanks
ubi