### PR TITLE
lora: Multiple small fixes (including syncword, sx126x minimum config)

### DIFF
--- a/micropython/lora/lora-sx126x/lora/sx126x.py
+++ b/micropython/lora/lora-sx126x/lora/sx126x.py
@@ -386,7 +386,7 @@ class _SX126x(BaseModem):
                 # see
                 # https://www.thethingsnetwork.org/forum/t/should-private-lorawan-networks-use-a-different-sync-word/34496/15
                 syncword = 0x0404 + ((syncword & 0x0F) << 4) + ((syncword & 0xF0) << 8)
-            self._cmd(">BBH", _CMD_WRITE_REGISTER, _REG_LSYNCRH, syncword)
+            self._cmd(">BHH", _CMD_WRITE_REGISTER, _REG_LSYNCRH, syncword)
 
         if not self._configured or any(
             key in lora_cfg for key in ("output_power", "pa_ramp_us", "tx_ant")

--- a/micropython/lora/lora-sx126x/lora/sx126x.py
+++ b/micropython/lora/lora-sx126x/lora/sx126x.py
@@ -469,7 +469,7 @@ class _SX126x(BaseModem):
         # See DS 13.1.12 Calibrate Function
 
         # calibParam 0xFE means to calibrate all blocks.
-        self._cmd("<BB", _CMD_CALIBRATE, 0xFE)
+        self._cmd("BB", _CMD_CALIBRATE, 0xFE)
 
         time.sleep_us(_CALIBRATE_TYPICAL_TIME_US)
 
@@ -545,7 +545,7 @@ class _SX126x(BaseModem):
         else:
             timeout = 0  # Single receive mode, no timeout
 
-        self._cmd(">BBH", _CMD_SET_RX, timeout >> 16, timeout)
+        self._cmd(">BBH", _CMD_SET_RX, timeout >> 16, timeout)  # 24 bits
 
         return self._dio1
 
@@ -729,10 +729,10 @@ class _SX126x(BaseModem):
             return res
 
     def _reg_read(self, addr):
-        return self._cmd("BBBB", _CMD_READ_REGISTER, addr >> 8, addr & 0xFF, n_read=1)[0]
+        return self._cmd(">BHB", _CMD_READ_REGISTER, addr, 0, n_read=1)[0]
 
     def _reg_write(self, addr, val):
-        return self._cmd("BBBB", _CMD_WRITE_REGISTER, addr >> 8, addr & 0xFF, val & 0xFF)
+        return self._cmd(">BHB", _CMD_WRITE_REGISTER, addr, val & 0xFF)
 
 
 class _SX1262(_SX126x):

--- a/micropython/lora/lora-sx126x/manifest.py
+++ b/micropython/lora/lora-sx126x/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.1")
+metadata(version="0.1.2")
 require("lora")
 package("lora")

--- a/micropython/lora/lora-sx127x/lora/sx127x.py
+++ b/micropython/lora/lora-sx127x/lora/sx127x.py
@@ -519,6 +519,9 @@ class _SX127x(BaseModem):
 
         self._reg_update(_REG_MODEM_CONFIG3, update_mask, modem_config3)
 
+        if "syncword" in lora_cfg:
+            self._reg_write(_REG_SYNC_WORD, lora_cfg["syncword"])
+
     def _reg_write(self, reg, value):
         self._cs(0)
         if isinstance(value, int):

--- a/micropython/lora/lora-sx127x/manifest.py
+++ b/micropython/lora/lora-sx127x/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 require("lora")
 package("lora")

--- a/micropython/lora/lora-sync/lora/sync_modem.py
+++ b/micropython/lora/lora-sync/lora/sync_modem.py
@@ -42,8 +42,8 @@ class SyncModem:
 
         tx = True
         while tx is True:
-            tx = self.poll_send()
             self._sync_wait(will_irq)
+            tx = self.poll_send()
         return tx
 
     def recv(self, timeout_ms=None, rx_length=0xFF, rx_packet=None):

--- a/micropython/lora/lora-sync/manifest.py
+++ b/micropython/lora/lora-sync/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 require("lora")
 package("lora")

--- a/micropython/lora/lora/lora/modem.py
+++ b/micropython/lora/lora/lora/modem.py
@@ -37,10 +37,11 @@ class BaseModem:
         self._ant_sw = ant_sw
         self._irq_callback = None
 
-        # Common configuration settings that need to be tracked by all modem drivers
-        # (Note that subclasses may set these to other values in their constructors, to match
-        # the power-on-reset configuration of a particular modem.)
+        # Common configuration settings that need to be tracked by all modem drivers.
         #
+        # Where modem hardware sets different values after reset, the driver should
+        # set them back to these defaults (if not provided by the user), so that
+        # behaviour remains consistent between different modems using the same driver.
         self._rf_freq_hz = 0  # Needs to be set via configure()
         self._sf = 7  # Spreading factor
         self._bw_hz = 125000  # Reset value


### PR DESCRIPTION
Collection of small LoRa fixes in individual commits. See commit messages for more details.

* SX126x: Fix invalid configuration after reset. Configuring with the documented minimal `lora_cfg` didn't produce the documented results, some configuration keys always needed to be set.
* SX126x: Fix syncword setting. Closes #796.
* SX127x: Fix syncword setting. Implementation was simply missing. :facepalm: 
* lora-sync: Fix a possible race where a send which failed immediately (or completed very quickly) would not return immediately.
* SX126x: Cosmetic clean up of some struct formatting.

Test on SX1276, SX1262, STM32WL55.