### PR TITLE
ci: Add unix-ffi library when building unix-ffi subdirectory.

### DIFF
--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -30,7 +30,11 @@ function ci_build_packages_check_manifest {
     for file in $(find -name manifest.py); do
         echo "##################################################"
         echo "# Testing $file"
-        python3 /tmp/micropython/tools/manifestfile.py --lib . --compile $file
+        extra_args=
+        if [[ "$file" =~ "/unix-ffi/" ]]; then
+            extra_args="--unix-ffi"
+        fi
+        python3 /tmp/micropython/tools/manifestfile.py $extra_args --lib . --compile $file
     done
 }
 


### PR DESCRIPTION
Attempt to un-break the manifest build. Depends on https://github.com/micropython/micropython/pull/13655
