### PR TITLE
umqtt.simple: Fix MQTTClient publish for connection disruption.

### DIFF
--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -133,7 +133,15 @@ class MQTTClient:
             self.pid += 1
             pid = self.pid
             struct.pack_into("!H", pkt, 0, pid)
-            self.sock.write(pkt, 2)
+            try:
+                self.sock.write(pkt, 2)
+            except OSError as e:
+                if e.args[0] == -1:
+                    print("OSError: -1 occurred. Reconnecting...")
+                    self.connect()
+                    self.sock.write(pkt, 2)
+            else:
+                raise
         self.sock.write(msg)
         if qos == 1:
             while 1:


### PR DESCRIPTION
Method now handles OSError: -1 after many packets, attempting reconnection.

Issue #754

Modified the MQTTClient publish method to gracefully handle connection disruptions. Previously, the method encountered an OSError: -1 after sending a large number of packets, leading to a disconnection from the server. The updated method now includes error handling to detect this situation and attempts to reconnect before retrying the operation. This enhancement ensures that the client can recover from connection disruptions seamlessly, maintaining stable communication with the server.
