### PR TITLE
gzip: Fix recursion error in open() function.

### DIFF
--- a/python-stdlib/gzip/gzip.py
+++ b/python-stdlib/gzip/gzip.py
@@ -3,15 +3,15 @@
 
 _WBITS = const(15)
 
-import io, deflate
+import builtins, io, deflate
 
 
 def GzipFile(fileobj):
     return deflate.DeflateIO(fileobj, deflate.GZIP, _WBITS)
 
 
-def open(filename, mode):
-    return deflate.DeflateIO(open(filename, mode), deflate.GZIP, _WBITS, True)
+def open(filename, mode="rb"):
+    return deflate.DeflateIO(builtins.open(filename, mode), deflate.GZIP, _WBITS, True)
 
 
 if hasattr(deflate.DeflateIO, "write"):

--- a/python-stdlib/gzip/manifest.py
+++ b/python-stdlib/gzip/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="1.0.0")
+metadata(version="1.0.1")
 
 module("gzip.py")


### PR DESCRIPTION
And give the `mode` parameter a default, matching CPython.