### PR TITLE
webrepl: Changes for more webrepl features while making it smaller.

### DIFF
--- a/micropython/net/webrepl/legacy_file_transfer.py
+++ b/micropython/net/webrepl/legacy_file_transfer.py
@@ -1,0 +1,53 @@
+class LegacyFileTransfer:
+    def __init__(self):
+        self.opbuf = bytearray(82)
+        self.opptr = 0
+        self.op = 0
+
+    def handle(self, buf, sock):
+        if self.op == 2:
+            import struct
+
+            ret = self.file.readinto(memoryview(self.filebuf)[2:])
+            memoryview(self.filebuf)[0:2] = struct.pack("<h", ret)
+            sock.ioctl(9, 2)
+            sock.write(memoryview(self.filebuf)[0 : (2 + ret)])
+            if ret == 0:
+                sock.write(b"WB\x00\x00")
+                self.op = 0
+                self.filebuf = None
+            sock.ioctl(9, 1)
+            return
+        self.opbuf[self.opptr] = buf[0]
+        self.opptr += 1
+        if self.opptr != 82:  # or bytes(buf[0:2]) != b"WA":
+            return
+        self.opptr = 0
+        sock.ioctl(9, 2)
+        sock.write(b"WB\x00\x00")
+        sock.ioctl(9, 1)
+        type = self.opbuf[2]
+        if type == 2:  # GET_FILE
+            self.op = type
+            name = self.opbuf[18:82].rstrip(b"\x00")
+            self.filebuf = bytearray(2 + 256)
+            self.file = open(name.decode(), "rb")
+        elif type == 1:  # PUT_FILE
+            import struct
+
+            name = self.opbuf[18:82].rstrip(b"\x00")
+            size = struct.unpack("<I", self.opbuf[12:16])[0]
+            filebuf = bytearray(512)
+            with open(name.decode(), "wb") as file:
+                while size > 0:
+                    ret = sock.readinto(filebuf)
+                    if ret is None:
+                        continue
+                    if ret > 0:
+                        file.write(memoryview(filebuf)[0:ret])
+                        size -= ret
+                    elif ret < 0:
+                        break
+            sock.ioctl(9, 2)
+            sock.write(b"WB\x00\x00")
+            sock.ioctl(9, 1)

--- a/micropython/net/webrepl/manifest.py
+++ b/micropython/net/webrepl/manifest.py
@@ -1,4 +1,5 @@
 metadata(description="WebREPL server.", version="1.0.0")
 
 module("webrepl.py", opt=3)
+module("legacy_file_transfer.py", opt=3)
 module("webrepl_setup.py", opt=3)


### PR DESCRIPTION
This change:
- Moves the password checking to python
- Removes the special file transfer protocol (This changes allows to extend `mpremote` to support webrepl just like a serial port)
- Moves the REPL data to websocket binary packages

The change should be compatible with the current micropython version, however a new webrepl client needs to be deployed under https://micropython.org/webrepl/

Currently, to help you testing, I've adjusted the default URL to https://felix.dogcraft.de/webrepl/, where I host the corresponding draft "new" webrepl client. I've pushed the modified js code here, if you want to take a look: https://github.com/felixdoerre/webreplv2. I'm not completely sure, if I should open a PR in https://github.com/micropython/webrepl, as this seems to be the authoritative source of the client, but the repo seems to be abandoned for some time now.

The new webrepl client currently features (See also [#13540](https://github.com/micropython/micropython/issues/13540)):
- A file browser, allowing directory listings, downloads and uploads. This uses the same injected code as `mpremote`.
- An implementation of the `mount`-feature from `mpremote` that works with the same injected code. It allows mounting files from the browser's local storage (which can host some python scripts that one wants to bring for debugging), or from a local folder, that is drag-and-dropped into the webrepl (read-only), this is useful for rapid development/testing.
- An implementation of mip with a package browser to list and download packages directly from https://micropython.org/pi/

Currently the "mount" feature has to be activated "manually" (by calling `hookme()` from the developer tools, and then executing `__mount()` in the repl manually). Also the UI for the file browser might not be super intuitive yet (the + for upload and mounting a local folder might be too small and not clear enough). So I'm hoping for UI improvement suggestions.

If you want, I can split the `mount` and the `mip` implementation into separate PRs, but the file-browser and this PR are dependent on each other.

With this change the `_webrepl` module from micropython is not needed anymore and can be removed.