### PR TITLE
micropython/mip/mip/__init__.py: Implement install from gitlab.

### DIFF
--- a/micropython/mip/mip/__init__.py
+++ b/micropython/mip/mip/__init__.py
@@ -73,6 +73,18 @@ def _rewrite_url(url, branch=None):
             + "/"
             + "/".join(url[2:])
         )
+    elif url.startswith("gitlab:"):
+        url = url[7:].split("/")
+        url = (
+            "https://gitlab.com/"
+            + url[0]
+            + "/"
+            + url[1]
+            + "/-/raw/"
+            + branch
+            + "/"
+            + "/".join(url[2:])
+        )
     return url
 
 
@@ -128,6 +140,7 @@ def _install_package(package, index, target, version, mpy):
         package.startswith("http://")
         or package.startswith("https://")
         or package.startswith("github:")
+        or package.startswith("gitlab:")
     ):
         if package.endswith(".py") or package.endswith(".mpy"):
             print("Downloading {} to {}".format(package, target))


### PR DESCRIPTION
Modify _rewrite_url() to allow mip install from `gitlab:` repository.

Signed-off-by: Olivier Lenoir <olivier.len02@gmail.com>