### PR TITLE
Add upip.py and pip.py dummy modules for reverse "compatibility"

### DIFF
--- a/micropython/mip/manifest.py
+++ b/micropython/mip/manifest.py
@@ -2,4 +2,9 @@ metadata(version="0.2.0", description="On-device package installer for network-c
 
 require("requests")
 
+#dummy packages for pre-v1.20.0
+module("pip.py", opt=3)
+module("upip.py", opt=3)
+
+
 package("mip", opt=3)

--- a/micropython/mip/pip.py
+++ b/micropython/mip/pip.py
@@ -1,0 +1,4 @@
+# Dummy module for upip and pip to redirect user to mip
+raise ImportError("""This module has been deprecated, please instead use mip.
+https://docs.micropython.org/en/latest/reference/packages.html
+""")

--- a/micropython/mip/upip.py
+++ b/micropython/mip/upip.py
@@ -1,0 +1,4 @@
+# Dummy module for upip and pip to redirect user to mip
+raise ImportError("""This module has been deprecated, please instead use mip.
+https://docs.micropython.org/en/latest/reference/packages.html
+""")


### PR DESCRIPTION
Hi all, first PR here. Let me know if I did something wrong.
I noticed many packages in various places (github, Python package index, blogs/guide websites, etc) still guide users to install either from a custom index like PyPi or micropython-lib using upip. As of v1.20.0 these are both deprecated by mip and removed, leaving users confused with a module not found error.
My simple fix is 2 dummy packages bundled with mip that when imported throw an ImportError with an explanation and link to the [Micropython page on package management](https://docs.micropython.org/en/latest/reference/packages.html#packages) with mip, which for me was surprisingly difficult to find without knowing the new name "mip" (which doesn't follow the old pattern of "u"+package name many are familiar with.) It certainly would have saved me a bit of time.
Assuming my fork has no formatting issues (functionality is fine, tested on ESP32 w/ mip) I can't see why it would be a problem - it's a lightweight fix and other deprecated/renamed modules have done this or similar so there's precedent.
Thanks for reviewing!