### PR TITLE
Implement the utop module

### DIFF
--- a/micropython/utop/README.md
+++ b/micropython/utop/README.md
@@ -1,0 +1,12 @@
+# utop
+
+Provides a top-like live overview of the running system.
+
+On the `esp32` port this depends on the `esp32.idf_task_info()` function, which
+can be enabled by adding the following lines to the board `sdkconfig`:
+
+```ini
+CONFIG_FREERTOS_USE_TRACE_FACILITY=y
+CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID=y
+CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y
+```

--- a/micropython/utop/manifest.py
+++ b/micropython/utop/manifest.py
@@ -1,0 +1,6 @@
+metadata(
+    version="0.1.0",
+    description="Provides a top-like live overview of the running system.",
+)
+
+module("utop.py")

--- a/micropython/utop/utop.py
+++ b/micropython/utop/utop.py
@@ -1,3 +1,4 @@
+import micropython
 import time
 
 try:
@@ -71,6 +72,12 @@ def top(update_interval_ms=1000, timeout_ms=None, thread_names={}):
         else:
             print("INFO: Platform does not support listing active tasks.\x1b[K")
             line_count += 1
+
+        print("\x1b[K")
+        line_count += 1
+        print("MicroPython ", end="")
+        micropython.mem_info()
+        line_count += 3
 
         if previous_line_count > line_count:
             for _ in range(previous_line_count - line_count):

--- a/micropython/utop/utop.py
+++ b/micropython/utop/utop.py
@@ -79,6 +79,23 @@ def top(update_interval_ms=1000, timeout_ms=None, thread_names={}):
         micropython.mem_info()
         line_count += 3
 
+        if esp32 is not None:
+            print("\x1b[K")
+            line_count += 1
+            for name, cap in (("data", esp32.HEAP_DATA), ("exec", esp32.HEAP_EXEC)):
+                heaps = esp32.idf_heap_info(cap)
+                print(
+                    "IDF heap ({}): {} regions, {} total, {} free, {} largest contiguous, {} min free watermark\x1b[K".format(
+                        name,
+                        len(heaps),
+                        sum((h[0] for h in heaps)),
+                        sum((h[1] for h in heaps)),
+                        max((h[2] for h in heaps)),
+                        sum((h[3] for h in heaps)),
+                    )
+                )
+                line_count += 1
+
         if previous_line_count > line_count:
             for _ in range(previous_line_count - line_count):
                 print("\x1b[K")

--- a/micropython/utop/utop.py
+++ b/micropython/utop/utop.py
@@ -1,0 +1,85 @@
+import time
+
+try:
+    import esp32
+    import _thread
+except ImportError:
+    esp32 = None
+
+
+def top(update_interval_ms=1000, timeout_ms=None, thread_names={}):
+    time_start = time.ticks_ms()
+    previous_total_runtime = None
+    previous_task_runtimes = {}
+    previous_line_count = 0
+    esp32_task_state_names = dict(
+        enumerate(("running", "ready", "blocked", "suspended", "deleted", "invalid"))
+    )
+
+    while timeout_ms is None or abs(time.ticks_diff(time.ticks_ms(), time_start)) < timeout_ms:
+        if previous_line_count > 0:
+            print("\x1b[{}A".format(previous_line_count), end="")
+        line_count = 0
+
+        if esp32 is not None:
+            if not hasattr(esp32, "idf_task_info"):
+                print(
+                    "INFO: esp32.idf_task_info() is not available, cannot list active tasks.\x1b[K"
+                )
+                line_count += 1
+            else:
+                print("   CPU%  CORE  PRIORITY  STATE      STACKWATERMARK  NAME\x1b[K")
+                line_count += 1
+
+                total_runtime, tasks = esp32.idf_task_info()
+                current_thread_id = _thread.get_ident()
+                tasks.sort(key=lambda t: t[0])
+                for (
+                    task_id,
+                    task_name,
+                    task_state,
+                    task_priority,
+                    task_runtime,
+                    task_stackhighwatermark,
+                    task_coreid,
+                ) in tasks:
+                    task_runtime_percentage = "-"
+                    if (
+                        total_runtime != previous_total_runtime
+                        and task_id in previous_task_runtimes
+                    ):
+                        task_runtime_percentage = "{:.2f}%".format(
+                            100
+                            * ((task_runtime - previous_task_runtimes[task_id]) & (2**32 - 1))
+                            / ((total_runtime - previous_total_runtime) & (2**32 - 1))
+                        )
+                    print(
+                        "{:>7}  {:>4}  {:>8d}  {:<9}  {:<14d}  {}{}\x1b[K".format(
+                            task_runtime_percentage,
+                            "-" if task_coreid is None else task_coreid,
+                            task_priority,
+                            esp32_task_state_names.get(task_state, "unknown"),
+                            task_stackhighwatermark,
+                            thread_names.get(task_id, task_name),
+                            " (*)" if task_id == current_thread_id else "",
+                        )
+                    )
+                    line_count += 1
+
+                    previous_task_runtimes[task_id] = task_runtime
+                previous_total_runtime = total_runtime
+        else:
+            print("INFO: Platform does not support listing active tasks.\x1b[K")
+            line_count += 1
+
+        if previous_line_count > line_count:
+            for _ in range(previous_line_count - line_count):
+                print("\x1b[K")
+            print("\x1b[{}A".format(previous_line_count - line_count), end="")
+
+        previous_line_count = line_count
+
+        try:
+            time.sleep_ms(update_interval_ms)
+        except KeyboardInterrupt:
+            break


### PR DESCRIPTION
Implements a new module, `utop`, as suggested in https://github.com/micropython/micropython/pull/12732#issuecomment-1790040708.

Currently only works on the `esp32` port, and requires https://github.com/micropython/micropython/pull/12732.

An animated GIF to demonstrate what the output looks like:

![utop](https://github.com/micropython/micropython-lib/assets/954385/5b16b50a-3d21-4132-9844-1a97e26fe55a)

Opted to give it a generic name instead of ESP32-specific, as there was mention of other platforms also having options to retrieve runtime performance data, which might be nice to support at a later time.

Compared to the version posted in that `esp32` MR ([here](https://github.com/micropython/micropython/blob/e2316bd17741dd74e49faa1efdea89712695657b/docs/library/esp32.rst#functions)) this version is a few lines longer to make it a bit easier to read and expand later. For example it includes an optional argument for renaming threads, useful to distinguish multiple `mp_thread` instances.

First commit implements the functionality as demo'd in the other MR. The second commit adds two lines of information about the current state of the ESP-IDF heap, as an example of how we could expand this later to be a more useful development utility.