### PR TITLE
unix-ffi: Remove "unix_ffi" argument from require().

### DIFF
--- a/unix-ffi/README.md
+++ b/unix-ffi/README.md
@@ -19,9 +19,13 @@ replacement for CPython.
 
 ### Usage
 
-To use a unix-specific library, pass `unix_ffi=True` to `require()` in your
-manifest file.
+To use a unix-specific library, a manifest file must add the `unix-ffi`
+library to the library search path using `add_library()`:
 
 ```py
-require("os", unix_ffi=True) # Use the unix-ffi version instead of python-stdlib.
+add_library("unix-ffi", "$(MPY_LIB_DIR)/unix-ffi", prepend=True)
 ```
+
+Prepending the `unix-ffi` library to the path will make it so that the
+`unix-ffi` version of a package will be preferred if that package appears in
+both `unix-ffi` and another library (eg `python-stdlib`).

--- a/unix-ffi/_markupbase/manifest.py
+++ b/unix-ffi/_markupbase/manifest.py
@@ -1,5 +1,5 @@
 metadata(version="3.3.4")
 
-require("re", unix_ffi=True)
+require("re")
 
 module("_markupbase.py")

--- a/unix-ffi/email.charset/manifest.py
+++ b/unix-ffi/email.charset/manifest.py
@@ -1,7 +1,7 @@
 metadata(version="0.5.1")
 
 require("functools")
-require("email.encoders", unix_ffi=True)
-require("email.errors", unix_ffi=True)
+require("email.encoders")
+require("email.errors")
 
 package("email")

--- a/unix-ffi/email.encoders/manifest.py
+++ b/unix-ffi/email.encoders/manifest.py
@@ -3,7 +3,7 @@ metadata(version="0.5.1")
 require("base64")
 require("binascii")
 require("quopri")
-require("re", unix_ffi=True)
+require("re")
 require("string")
 
 package("email")

--- a/unix-ffi/email.feedparser/manifest.py
+++ b/unix-ffi/email.feedparser/manifest.py
@@ -1,8 +1,8 @@
 metadata(version="0.5.1")
 
-require("re", unix_ffi=True)
-require("email.errors", unix_ffi=True)
-require("email.message", unix_ffi=True)
-require("email.internal", unix_ffi=True)
+require("re")
+require("email.errors")
+require("email.message")
+require("email.internal")
 
 package("email")

--- a/unix-ffi/email.header/manifest.py
+++ b/unix-ffi/email.header/manifest.py
@@ -1,9 +1,9 @@
 metadata(version="0.5.2")
 
-require("re", unix_ffi=True)
+require("re")
 require("binascii")
-require("email.encoders", unix_ffi=True)
-require("email.errors", unix_ffi=True)
-require("email.charset", unix_ffi=True)
+require("email.encoders")
+require("email.errors")
+require("email.charset")
 
 package("email")

--- a/unix-ffi/email.internal/manifest.py
+++ b/unix-ffi/email.internal/manifest.py
@@ -1,15 +1,15 @@
 metadata(version="0.5.1")
 
-require("re", unix_ffi=True)
+require("re")
 require("base64")
 require("binascii")
 require("functools")
 require("string")
 # require("calendar") TODO
 require("abc")
-require("email.errors", unix_ffi=True)
-require("email.header", unix_ffi=True)
-require("email.charset", unix_ffi=True)
-require("email.utils", unix_ffi=True)
+require("email.errors")
+require("email.header")
+require("email.charset")
+require("email.utils")
 
 package("email")

--- a/unix-ffi/email.message/manifest.py
+++ b/unix-ffi/email.message/manifest.py
@@ -1,11 +1,11 @@
 metadata(version="0.5.3")
 
-require("re", unix_ffi=True)
+require("re")
 require("uu")
 require("base64")
 require("binascii")
-require("email.utils", unix_ffi=True)
-require("email.errors", unix_ffi=True)
-require("email.charset", unix_ffi=True)
+require("email.utils")
+require("email.errors")
+require("email.charset")
 
 package("email")

--- a/unix-ffi/email.parser/manifest.py
+++ b/unix-ffi/email.parser/manifest.py
@@ -1,8 +1,8 @@
 metadata(version="0.5.1")
 
 require("warnings")
-require("email.feedparser", unix_ffi=True)
-require("email.message", unix_ffi=True)
-require("email.internal", unix_ffi=True)
+require("email.feedparser")
+require("email.message")
+require("email.internal")
 
 package("email")

--- a/unix-ffi/email.utils/manifest.py
+++ b/unix-ffi/email.utils/manifest.py
@@ -1,13 +1,13 @@
 metadata(version="3.3.4")
 
-require("os", unix_ffi=True)
-require("re", unix_ffi=True)
+require("os")
+require("re")
 require("base64")
 require("random")
 require("datetime")
-require("urllib.parse", unix_ffi=True)
+require("urllib.parse")
 require("warnings")
 require("quopri")
-require("email.charset", unix_ffi=True)
+require("email.charset")
 
 package("email")

--- a/unix-ffi/fcntl/manifest.py
+++ b/unix-ffi/fcntl/manifest.py
@@ -2,6 +2,6 @@ metadata(version="0.0.4")
 
 # Originally written by Paul Sokolovsky.
 
-require("ffilib", unix_ffi=True)
+require("ffilib")
 
 module("fcntl.py")

--- a/unix-ffi/getopt/manifest.py
+++ b/unix-ffi/getopt/manifest.py
@@ -1,5 +1,5 @@
 metadata(version="3.3.4")
 
-require("os", unix_ffi=True)
+require("os")
 
 module("getopt.py")

--- a/unix-ffi/gettext/manifest.py
+++ b/unix-ffi/gettext/manifest.py
@@ -2,6 +2,6 @@ metadata(version="0.1.0")
 
 # Originally written by Riccardo Magliocchetti.
 
-require("ffilib", unix_ffi=True)
+require("ffilib")
 
 module("gettext.py")

--- a/unix-ffi/glob/manifest.py
+++ b/unix-ffi/glob/manifest.py
@@ -1,8 +1,8 @@
 metadata(version="0.5.2")
 
-require("os", unix_ffi=True)
+require("os")
 require("os-path")
-require("re", unix_ffi=True)
+require("re")
 require("fnmatch")
 
 module("glob.py")

--- a/unix-ffi/html.parser/manifest.py
+++ b/unix-ffi/html.parser/manifest.py
@@ -1,8 +1,8 @@
 metadata(version="3.3.4")
 
-require("_markupbase", unix_ffi=True)
+require("_markupbase")
 require("warnings")
-require("html.entities", unix_ffi=True)
-require("re", unix_ffi=True)
+require("html.entities")
+require("re")
 
 package("html")

--- a/unix-ffi/http.client/manifest.py
+++ b/unix-ffi/http.client/manifest.py
@@ -1,10 +1,10 @@
 metadata(version="0.5.1")
 
-require("email.parser", unix_ffi=True)
-require("email.message", unix_ffi=True)
-require("socket", unix_ffi=True)
+require("email.parser")
+require("email.message")
+require("socket")
 require("collections")
-require("urllib.parse", unix_ffi=True)
+require("urllib.parse")
 require("warnings")
 
 package("http")

--- a/unix-ffi/machine/manifest.py
+++ b/unix-ffi/machine/manifest.py
@@ -2,8 +2,8 @@ metadata(version="0.2.1")
 
 # Originally written by Paul Sokolovsky.
 
-require("ffilib", unix_ffi=True)
-require("os", unix_ffi=True)
-require("signal", unix_ffi=True)
+require("ffilib")
+require("os")
+require("signal")
 
 package("machine")

--- a/unix-ffi/multiprocessing/manifest.py
+++ b/unix-ffi/multiprocessing/manifest.py
@@ -2,8 +2,8 @@ metadata(version="0.1.2")
 
 # Originally written by Paul Sokolovsky.
 
-require("os", unix_ffi=True)
-require("select", unix_ffi=True)
+require("os")
+require("select")
 require("pickle")
 
 module("multiprocessing.py")

--- a/unix-ffi/os/manifest.py
+++ b/unix-ffi/os/manifest.py
@@ -2,7 +2,7 @@ metadata(version="0.6.0")
 
 # Originally written by Paul Sokolovsky.
 
-require("ffilib", unix_ffi=True)
+require("ffilib")
 require("errno")
 require("stat")
 

--- a/unix-ffi/pwd/manifest.py
+++ b/unix-ffi/pwd/manifest.py
@@ -2,6 +2,6 @@ metadata(version="0.1.0")
 
 # Originally written by Riccardo Magliocchetti.
 
-require("ffilib", unix_ffi=True)
+require("ffilib")
 
 module("pwd.py")

--- a/unix-ffi/re/manifest.py
+++ b/unix-ffi/re/manifest.py
@@ -2,6 +2,6 @@ metadata(version="0.2.5")
 
 # Originally written by Paul Sokolovsky.
 
-require("ffilib", unix_ffi=True)
+require("ffilib")
 
 module("re.py")

--- a/unix-ffi/select/manifest.py
+++ b/unix-ffi/select/manifest.py
@@ -2,7 +2,7 @@ metadata(version="0.3.0")
 
 # Originally written by Paul Sokolovsky.
 
-require("os", unix_ffi=True)
-require("ffilib", unix_ffi=True)
+require("os")
+require("ffilib")
 
 module("select.py")

--- a/unix-ffi/signal/manifest.py
+++ b/unix-ffi/signal/manifest.py
@@ -2,6 +2,6 @@ metadata(version="0.3.2")
 
 # Originally written by Paul Sokolovsky.
 
-require("ffilib", unix_ffi=True)
+require("ffilib")
 
 module("signal.py")

--- a/unix-ffi/sqlite3/manifest.py
+++ b/unix-ffi/sqlite3/manifest.py
@@ -2,6 +2,6 @@ metadata(version="0.2.4")
 
 # Originally written by Paul Sokolovsky.
 
-require("ffilib", unix_ffi=True)
+require("ffilib")
 
 module("sqlite3.py")

--- a/unix-ffi/time/manifest.py
+++ b/unix-ffi/time/manifest.py
@@ -1,5 +1,5 @@
 metadata(version="0.5.0")
 
-require("ffilib", unix_ffi=True)
+require("ffilib")
 
 module("time.py")

--- a/unix-ffi/timeit/manifest.py
+++ b/unix-ffi/timeit/manifest.py
@@ -1,9 +1,9 @@
 metadata(version="3.3.4")
 
-require("getopt", unix_ffi=True)
+require("getopt")
 require("itertools")
 # require("linecache") TODO
-require("time", unix_ffi=True)
+require("time")
 require("traceback")
 
 module("timeit.py")

--- a/unix-ffi/ucurses/manifest.py
+++ b/unix-ffi/ucurses/manifest.py
@@ -2,8 +2,8 @@ metadata(version="0.1.2")
 
 # Originally written by Paul Sokolovsky.
 
-require("os", unix_ffi=True)
-require("tty", unix_ffi=True)
-require("select", unix_ffi=True)
+require("os")
+require("tty")
+require("select")
 
 package("ucurses")

--- a/unix-ffi/urllib.parse/manifest.py
+++ b/unix-ffi/urllib.parse/manifest.py
@@ -1,6 +1,6 @@
 metadata(version="0.5.2")
 
-require("re", unix_ffi=True)
+require("re")
 require("collections")
 require("collections-defaultdict")
 


### PR DESCRIPTION
And describe how to use `add_library()` instead.