### PR TITLE
ssl: Use "from tls import *" to be compatible with axtls.

### DIFF
--- a/python-stdlib/ssl/manifest.py
+++ b/python-stdlib/ssl/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.2.0")
+metadata(version="0.2.1")
 
 module("ssl.py", opt=3)

--- a/python-stdlib/ssl/ssl.py
+++ b/python-stdlib/ssl/ssl.py
@@ -1,12 +1,5 @@
 import tls
-from tls import (
-    CERT_NONE,
-    CERT_OPTIONAL,
-    CERT_REQUIRED,
-    MBEDTLS_VERSION,
-    PROTOCOL_TLS_CLIENT,
-    PROTOCOL_TLS_SERVER,
-)
+from tls import *
 
 
 class SSLContext:


### PR DESCRIPTION
axtls doesn't define all the CERT_xxx constants, nor the MBEDTLS_VERSION constant.

This change means that `tls.SSLContext` is imported into the module, but that's subsequently overridden by the class definition in this module.