### PR TITLE
aiohttp: Fix type of `Sec-WebSocket-Key` in `aiohttp_ws.py`

### DIFF
--- a/python-ecosys/aiohttp/aiohttp/aiohttp_ws.py
+++ b/python-ecosys/aiohttp/aiohttp/aiohttp_ws.py
@@ -86,7 +86,7 @@ class WebSocketClient:
 
     def _process_websocket_frame(self, opcode, payload):
         if opcode == self.TEXT:
-            payload = payload.decode()
+            payload = str(payload, "utf-8")
         elif opcode == self.BINARY:
             pass
         elif opcode == self.CLOSE:
@@ -143,7 +143,7 @@ class WebSocketClient:
         headers["Host"] = f"{uri.hostname}:{uri.port}"
         headers["Connection"] = "Upgrade"
         headers["Upgrade"] = "websocket"
-        headers["Sec-WebSocket-Key"] = key
+        headers["Sec-WebSocket-Key"] = str(key, "utf-8")
         headers["Sec-WebSocket-Version"] = "13"
         headers["Origin"] = f"{_http_proto}://{uri.hostname}:{uri.port}"
 

--- a/python-ecosys/aiohttp/manifest.py
+++ b/python-ecosys/aiohttp/manifest.py
@@ -1,6 +1,6 @@
 metadata(
     description="HTTP client module for MicroPython asyncio module",
-    version="0.0.2",
+    version="0.0.3",
     pypi="aiohttp",
 )
 


### PR DESCRIPTION
The function `binascii.b2a_base64()` returns a `bytes`.
Here needs a `string`
Otherwise, the value of `Sec-WebSocket-Key` in the headers will be `b'<BASE64-ENCODED_RANDOM_VALUE>'`.
It means there will be `b'` at the beginning and `'` at the end.