### PR TITLE
aiohttp_ws: convert Sec-WebSocket-Key from bytes to str

### DIFF
--- a/python-ecosys/aiohttp/aiohttp/aiohttp_ws.py
+++ b/python-ecosys/aiohttp/aiohttp/aiohttp_ws.py
@@ -143,7 +143,7 @@ class WebSocketClient:
         headers["Host"] = f"{uri.hostname}:{uri.port}"
         headers["Connection"] = "Upgrade"
         headers["Upgrade"] = "websocket"
-        headers["Sec-WebSocket-Key"] = key
+        headers["Sec-WebSocket-Key"] = key.decode()
         headers["Sec-WebSocket-Version"] = "13"
         headers["Origin"] = f"{_http_proto}://{uri.hostname}:{uri.port}"
 


### PR DESCRIPTION
Without the fix, the client submits a header formatted as bytes:

```
Sec-WebSocket-Key     b'aaaaaaaaaaaaa'
```

resulting in the server rejecting the connection (I use the python websocket module in the server for checking). This PR decodes the key, and thus correctly formats the header:

```
Sec-WebSocket-Key     aaaaaaaaaaaaa
```
