### PR TITLE
umqtt.simple: add ping_response_received for ping handling

### DIFF
--- a/micropython/umqtt.simple/README.rst
+++ b/micropython/umqtt.simple/README.rst
@@ -51,6 +51,7 @@ follows MQTT control operations, and maps them to class methods:
   clean_session=True argument is used (default)).
 * ``disconnect()`` - Disconnect from a server, release resources.
 * ``ping()`` - Ping server (response is processed automatically by wait_msg()).
+  * ``ping_response_received`` - True once ping has been responded to, False if not. Set by wait_msg() and reset upon next ping().
 * ``publish()`` - Publish a message.
 * ``subscribe()`` - Subscribe to a topic.
 * ``set_callback()`` - Set callback for received subscription messages.

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -34,6 +34,7 @@ class MQTTClient:
         self.lw_msg = None
         self.lw_qos = 0
         self.lw_retain = False
+        self.ping_response_received = False
 
     def _send_str(self, s):
         self.sock.write(struct.pack("!H", len(s)))
@@ -112,6 +113,7 @@ class MQTTClient:
 
     def ping(self):
         self.sock.write(b"\xc0\0")
+        self.ping_response_received = False
 
     def publish(self, topic, msg, retain=False, qos=0):
         pkt = bytearray(b"\x30\0\0\0")
@@ -181,6 +183,7 @@ class MQTTClient:
         if res == b"\xd0":  # PINGRESP
             sz = self.sock.read(1)[0]
             assert sz == 0
+            self.ping_response_received = True
             return None
         op = res[0]
         if op & 0xF0 != 0x30:


### PR DESCRIPTION
Currently when using `ping` the response is swallowed which makes it not particularly useful. This PR adds a flag `ping_response_received` to the client which is set to `True` if a response has been received in `wait_msg`. I've been using this approach in a personal project without any issues and it's not particularly invasive so I wanted to propose it as a solution to #332.

Another possible approach is to actually respond in `wait_msg` with an actual ping response however I'm not certain how that would interact with subscriptions and those currently using `wait_msg` so this approach was taken in order to not be breaking while still being useful.