### PR TITLE
all: Enable Ruff lint F541 'f-string without any placeholders'.

### DIFF
--- a/micropython/espflash/espflash.py
+++ b/micropython/espflash/espflash.py
@@ -235,7 +235,7 @@ class ESPFlash:
 
     def flash_attach(self):
         self._command(_CMD_SPI_ATTACH, struct.pack("<II", 0, 0))
-        print(f"Flash attached")
+        print("Flash attached")
 
     def flash_config(self, flash_size=2 * 1024 * 1024):
         self._command(
@@ -288,7 +288,7 @@ class ESPFlash:
     def flash_verify_file(self, path, digest=None, offset=0):
         if digest is None:
             if self.md5sum is None:
-                raise Exception(f"MD5 checksum missing.")
+                raise Exception("MD5 checksum missing.")
             digest = binascii.hexlify(self.md5sum.digest())
 
         size = os.stat(path)[6]
@@ -300,7 +300,7 @@ class ESPFlash:
         if digest == data[0:32]:
             print("Firmware verified.")
         else:
-            raise Exception(f"Firmware verification failed.")
+            raise Exception("Firmware verification failed.")
 
     def reboot(self):
         payload = struct.pack("<I", 0)

--- a/micropython/lora/lora-async/lora/async_modem.py
+++ b/micropython/lora/lora-async/lora/async_modem.py
@@ -109,7 +109,7 @@ class AsyncModem:
             await asyncio.sleep_ms(timeout_ms)
 
         if _DEBUG:
-            print(f"wait complete")
+            print("wait complete")
 
     def _callback(self):
         # IRQ callback from BaseModem._radio_isr. May be in Hard IRQ context.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ ignore = [
   "F403",
   "F405",
   "E501",
-  "F541",
   "ISC001",
   "ISC003",  # micropython does not support implicit concatenation of f-strings
   "PIE810",  # micropython does not support passing tuples to .startswith or .endswith


### PR DESCRIPTION
This is a pretty straightforward lint and fix, should save a small amount of bytecode.