### PR TITLE
all: Enable ruff E401,E402 import lints.

### DIFF
--- a/micropython/bluetooth/aioble/examples/l2cap_file_client.py
+++ b/micropython/bluetooth/aioble/examples/l2cap_file_client.py
@@ -5,6 +5,7 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const

--- a/micropython/bluetooth/aioble/examples/l2cap_file_server.py
+++ b/micropython/bluetooth/aioble/examples/l2cap_file_server.py
@@ -16,6 +16,7 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const

--- a/micropython/bluetooth/aioble/examples/temp_client.py
+++ b/micropython/bluetooth/aioble/examples/temp_client.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const

--- a/micropython/bluetooth/aioble/examples/temp_sensor.py
+++ b/micropython/bluetooth/aioble/examples/temp_sensor.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const

--- a/micropython/bluetooth/aioble/multitests/ble_buffered_characteristic.py
+++ b/micropython/bluetooth/aioble/multitests/ble_buffered_characteristic.py
@@ -2,10 +2,12 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/bluetooth/aioble/multitests/ble_characteristic.py
+++ b/micropython/bluetooth/aioble/multitests/ble_characteristic.py
@@ -2,10 +2,12 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/bluetooth/aioble/multitests/ble_descriptor.py
+++ b/micropython/bluetooth/aioble/multitests/ble_descriptor.py
@@ -2,10 +2,12 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/bluetooth/aioble/multitests/ble_notify.py
+++ b/micropython/bluetooth/aioble/multitests/ble_notify.py
@@ -2,10 +2,12 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/bluetooth/aioble/multitests/ble_shutdown.py
+++ b/micropython/bluetooth/aioble/multitests/ble_shutdown.py
@@ -2,10 +2,12 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/bluetooth/aioble/multitests/ble_write_capture.py
+++ b/micropython/bluetooth/aioble/multitests/ble_write_capture.py
@@ -2,10 +2,12 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/bluetooth/aioble/multitests/ble_write_order.py
+++ b/micropython/bluetooth/aioble/multitests/ble_write_order.py
@@ -2,10 +2,12 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/bluetooth/aioble/multitests/perf_gatt_notify.py
+++ b/micropython/bluetooth/aioble/multitests/perf_gatt_notify.py
@@ -2,10 +2,12 @@
 
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/bluetooth/aioble/multitests/perf_l2cap.py
+++ b/micropython/bluetooth/aioble/multitests/perf_l2cap.py
@@ -1,9 +1,11 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.append("")
 
 from micropython import const
-import time, machine
+import machine
+import time
 
 import uasyncio as asyncio
 import aioble

--- a/micropython/drivers/display/lcd160cr/lcd160cr.py
+++ b/micropython/drivers/display/lcd160cr/lcd160cr.py
@@ -2,9 +2,10 @@
 # MIT license; Copyright (c) 2017 Damien P. George
 
 from micropython import const
+import machine
 from utime import sleep_ms
 from ustruct import calcsize, pack_into
-import uerrno, machine
+import uerrno
 
 # for set_orient
 PORTRAIT = const(0)

--- a/micropython/drivers/display/lcd160cr/lcd160cr_test.py
+++ b/micropython/drivers/display/lcd160cr/lcd160cr_test.py
@@ -1,7 +1,10 @@
 # Driver test for official MicroPython LCD160CR display
 # MIT license; Copyright (c) 2017 Damien P. George
 
-import time, math, framebuf, lcd160cr
+import framebuf
+import lcd160cr
+import math
+import time
 
 
 def get_lcd(lcd):

--- a/micropython/drivers/storage/sdcard/sdtest.py
+++ b/micropython/drivers/storage/sdcard/sdtest.py
@@ -1,6 +1,8 @@
 # Test for sdcard block protocol
 # Peter hinch 30th Jan 2016
-import os, sdcard, machine
+import machine
+import os
+import sdcard
 
 
 def sdtest():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,14 +54,12 @@ select = [
   # "UP",   # pyupgrade
 ]
 ignore = [
-  "E401",
-  "E402",
   "E722",
-  "E741",
+  "E741",  # 'l' is currently widely used
   "F401",
   "F403",
   "F405",
-  "E501",
+  "E501",  # line length, recommended to disable
   "ISC001",
   "ISC003",  # micropython does not support implicit concatenation of f-strings
   "PIE810",  # micropython does not support passing tuples to .startswith or .endswith
@@ -74,7 +72,7 @@ ignore = [
   "PLW2901",
   "RUF012",
   "RUF100",
-  "W191",
+  "W191",  # tab-indent, redundant when using formatter
 ]
 line-length = 99
 target-version = "py37"

--- a/python-ecosys/aiohttp/aiohttp/__init__.py
+++ b/python-ecosys/aiohttp/aiohttp/__init__.py
@@ -22,7 +22,8 @@ class ClientResponse:
         c_encoding = self.headers.get("Content-Encoding")
         if c_encoding in ("gzip", "deflate", "gzip,deflate"):
             try:
-                import deflate, io
+                import deflate
+                import io
 
                 if c_encoding == "deflate":
                     with deflate.DeflateIO(io.BytesIO(data), deflate.ZLIB) as d:

--- a/python-ecosys/aiohttp/examples/client.py
+++ b/python-ecosys/aiohttp/examples/client.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.insert(0, ".")
 import aiohttp
 import asyncio

--- a/python-ecosys/aiohttp/examples/compression.py
+++ b/python-ecosys/aiohttp/examples/compression.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.insert(0, ".")
 import aiohttp
 import asyncio

--- a/python-ecosys/aiohttp/examples/get.py
+++ b/python-ecosys/aiohttp/examples/get.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.insert(0, ".")
 import aiohttp
 import asyncio

--- a/python-ecosys/aiohttp/examples/headers.py
+++ b/python-ecosys/aiohttp/examples/headers.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.insert(0, ".")
 import aiohttp
 import asyncio

--- a/python-ecosys/aiohttp/examples/methods.py
+++ b/python-ecosys/aiohttp/examples/methods.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.insert(0, ".")
 import aiohttp
 import asyncio

--- a/python-ecosys/aiohttp/examples/params.py
+++ b/python-ecosys/aiohttp/examples/params.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.insert(0, ".")
 import aiohttp
 import asyncio

--- a/python-ecosys/aiohttp/examples/ws.py
+++ b/python-ecosys/aiohttp/examples/ws.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.insert(0, ".")
 import aiohttp
 import asyncio

--- a/python-ecosys/aiohttp/examples/ws_repl_echo.py
+++ b/python-ecosys/aiohttp/examples/ws_repl_echo.py
@@ -1,5 +1,6 @@
 import sys
 
+# ruff: noqa: E402
 sys.path.insert(0, ".")
 import aiohttp
 import asyncio

--- a/python-ecosys/iperf3/iperf3.py
+++ b/python-ecosys/iperf3/iperf3.py
@@ -12,9 +12,12 @@ Usage:
     iperf3.client('192.168.1.5', udp=True, reverse=True)
 """
 
-import sys, struct
-import time, select, socket
 import json
+import select
+import socket
+import struct
+import sys
+import time
 
 # Provide a urandom() function, supporting devices without os.urandom().
 try:


### PR DESCRIPTION
Mostly small cleanups, and explicit disable for examples/tests which insert the current directory into the path before importing.