### PR TITLE
Change HTTP/1.0 to HTTP/1.1 in `requests` Python module

### DIFF
--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -93,7 +93,7 @@ def request(
             context = tls.SSLContext(tls.PROTOCOL_TLS_CLIENT)
             context.verify_mode = tls.CERT_NONE
             s = context.wrap_socket(s, server_hostname=host)
-        s.write(b"%s /%s HTTP/1.0\r\n" % (method, path))
+        s.write(b"%s /%s HTTP/1.1\r\n" % (method, path))
         if "Host" not in headers:
             s.write(b"Host: %s\r\n" % host)
         # Iterate over keys to avoid tuple alloc


### PR DESCRIPTION
On the Pico W, I'm suddenly having trouble accessing an API that used to be compatible. The issue seems to be the HTTP version, which I documented at https://github.com/orgs/micropython/discussions/15112. As somewhat of a last try, I copied over https://github.com/micropython/micropython-lib/blob/e025c843b60e93689f0f991d753010bb5bd6a722/python-ecosys/requests/requests/__init__.py into a `urequests_2.py`, used `import urequests_2 as urequests`, and simply replaced `1.0` with `1.1`:
```python
s.write(b"%s /%s HTTP/1.0\r\n" % (method, path))
```
with:
```python
s.write(b"%s /%s HTTP/1.1\r\n" % (method, path))
```
I was able to successfully send data through the API after that. I also wanted to note that I couldn't use the version on `master` due to `ImportError: no module named 'tls'`, hence the pinned version from above. I have tutorials, videos, and a module within a course dependent on this, so it would be great to have this incorporated into a stable version of Pico W MicroPython if it's feasible.