### PR TITLE
aioble: fix `ScanResult.services` decoding of UUIDs, and add/improve multitests

### DIFF
--- a/micropython/bluetooth/aioble-central/manifest.py
+++ b/micropython/bluetooth/aioble-central/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.1")
+metadata(version="0.2.2")
 
 require("aioble-core")
 

--- a/micropython/bluetooth/aioble/aioble/central.py
+++ b/micropython/bluetooth/aioble/aioble/central.py
@@ -195,12 +195,14 @@ class ScanResult:
 
     # Generator that enumerates the service UUIDs that are advertised.
     def services(self):
-        for u in self._decode_field(_ADV_TYPE_UUID16_INCOMPLETE, _ADV_TYPE_UUID16_COMPLETE):
-            yield bluetooth.UUID(struct.unpack("<H", u)[0])
-        for u in self._decode_field(_ADV_TYPE_UUID32_INCOMPLETE, _ADV_TYPE_UUID32_COMPLETE):
-            yield bluetooth.UUID(struct.unpack("<I", u)[0])
-        for u in self._decode_field(_ADV_TYPE_UUID128_INCOMPLETE, _ADV_TYPE_UUID128_COMPLETE):
-            yield bluetooth.UUID(u)
+        for uuid_len, codes in (
+            (2, (_ADV_TYPE_UUID16_INCOMPLETE, _ADV_TYPE_UUID16_COMPLETE)),
+            (4, (_ADV_TYPE_UUID32_INCOMPLETE, _ADV_TYPE_UUID32_COMPLETE)),
+            (16, (_ADV_TYPE_UUID128_INCOMPLETE, _ADV_TYPE_UUID128_COMPLETE)),
+        ):
+            for u in self._decode_field(*codes):
+                for i in range(0, len(u), uuid_len):
+                    yield bluetooth.UUID(u[i : i + uuid_len])
 
     # Generator that returns (manufacturer_id, data) tuples.
     def manufacturer(self, filter=None):

--- a/micropython/bluetooth/aioble/manifest.py
+++ b/micropython/bluetooth/aioble/manifest.py
@@ -3,7 +3,7 @@
 # code. This allows (for development purposes) all the files to live in the
 # one directory.
 
-metadata(version="0.5.1")
+metadata(version="0.5.2")
 
 # Default installation gives you everything. Install the individual
 # components (or a combination of them) if you want a more minimal install.

--- a/micropython/bluetooth/aioble/multitests/ble_advertise_services.py
+++ b/micropython/bluetooth/aioble/multitests/ble_advertise_services.py
@@ -1,0 +1,71 @@
+# Test advertising multiple services, and scanning them.
+
+import sys
+
+# ruff: noqa: E402
+sys.path.append("")
+
+import asyncio
+import aioble
+import bluetooth
+
+TIMEOUT_MS = 5000
+
+_SERVICE_16_A = bluetooth.UUID(0x180F)  # Battery Service
+_SERVICE_16_B = bluetooth.UUID(0x181A)  # Environmental Sensing Service
+_SERVICE_32_A = bluetooth.UUID("AB12")  # random
+_SERVICE_32_B = bluetooth.UUID("CD34")  # random
+
+
+# Acting in peripheral role (advertising).
+async def instance0_task():
+    multitest.globals(BDADDR=aioble.config("mac"))
+    multitest.next()
+
+    # Advertise, and wait for central to connect to us.
+    print("advertise")
+    async with await aioble.advertise(
+        20_000,
+        name="MPY",
+        services=[_SERVICE_16_A, _SERVICE_16_B, _SERVICE_32_A, _SERVICE_32_B],
+        timeout_ms=TIMEOUT_MS,
+    ) as connection:
+        print("connected")
+        await connection.disconnected()
+        print("disconnected")
+
+
+def instance0():
+    try:
+        asyncio.run(instance0_task())
+    finally:
+        aioble.stop()
+
+
+# Acting in central role (scanning).
+async def instance1_task():
+    multitest.next()
+
+    wanted_device = aioble.Device(*BDADDR)
+
+    # Scan for the wanted device/peripheral and print its advertised services.
+    async with aioble.scan(5000, interval_us=30000, window_us=30000, active=True) as scanner:
+        async for result in scanner:
+            if result.device == wanted_device:
+                services = list(result.services())
+                if services:
+                    print(services)
+                    break
+
+    # Connect to peripheral and then disconnect.
+    print("connect")
+    device = aioble.Device(*BDADDR)
+    async with await device.connect(timeout_ms=TIMEOUT_MS):
+        print("disconnect")
+
+
+def instance1():
+    try:
+        asyncio.run(instance1_task())
+    finally:
+        aioble.stop()

--- a/micropython/bluetooth/aioble/multitests/ble_advertise_services.py.exp
+++ b/micropython/bluetooth/aioble/multitests/ble_advertise_services.py.exp
@@ -1,0 +1,8 @@
+--- instance0 ---
+advertise
+connected
+disconnected
+--- instance1 ---
+[UUID(0x180f), UUID(0x181a), UUID(0x32314241), UUID(0x34334443)]
+connect
+disconnect

--- a/micropython/bluetooth/aioble/multitests/ble_write_capture.py.exp
+++ b/micropython/bluetooth/aioble/multitests/ble_write_capture.py.exp
@@ -2,7 +2,7 @@
 advertise
 connected
 written b'central0'
-written b'central2'
+written b'central1'
 written b'central0' True
 written b'central1' True
 written b'central2' True

--- a/micropython/bluetooth/aioble/multitests/perf_gatt_notify.py
+++ b/micropython/bluetooth/aioble/multitests/perf_gatt_notify.py
@@ -47,6 +47,8 @@ async def instance0_task():
         20_000, adv_data=b"\x02\x01\x06\x04\xffMPY", timeout_ms=TIMEOUT_MS
     )
 
+    print("connect")
+
     client_characteristic = await discover_server(connection)
 
     # Give the central enough time to discover chars.
@@ -61,7 +63,7 @@ async def instance0_task():
 
     ticks_end = time.ticks_ms()
     ticks_total = time.ticks_diff(ticks_end, ticks_start)
-    print(
+    multitest.output_metric(
         "Acknowledged {} notifications in {} ms. {} ms/notification.".format(
             _NUM_NOTIFICATIONS, ticks_total, ticks_total // _NUM_NOTIFICATIONS
         )
@@ -86,6 +88,8 @@ async def instance1_task():
 
     device = aioble.Device(*BDADDR)
     connection = await device.connect(timeout_ms=TIMEOUT_MS)
+
+    print("connect")
 
     client_characteristic = await discover_server(connection)
 

--- a/micropython/bluetooth/aioble/multitests/perf_gatt_notify.py.exp
+++ b/micropython/bluetooth/aioble/multitests/perf_gatt_notify.py.exp
@@ -1,0 +1,4 @@
+--- instance0 ---
+connect
+--- instance1 ---
+connect

--- a/micropython/bluetooth/aioble/multitests/perf_l2cap.py
+++ b/micropython/bluetooth/aioble/multitests/perf_l2cap.py
@@ -32,6 +32,8 @@ async def instance0_task():
         20_000, adv_data=b"\x02\x01\x06\x04\xffMPY", timeout_ms=TIMEOUT_MS
     )
 
+    print("connect")
+
     channel = await connection.l2cap_accept(_L2CAP_PSM, _L2CAP_MTU, timeout_ms=TIMEOUT_MS)
 
     random.seed(_RANDOM_SEED)
@@ -66,6 +68,8 @@ async def instance1_task():
     device = aioble.Device(*BDADDR)
     connection = await device.connect(timeout_ms=TIMEOUT_MS)
 
+    print("connect")
+
     await asyncio.sleep_ms(500)
 
     channel = await connection.l2cap_connect(_L2CAP_PSM, _L2CAP_MTU, timeout_ms=TIMEOUT_MS)
@@ -90,7 +94,7 @@ async def instance1_task():
     ticks_end = time.ticks_ms()
     total_ticks = time.ticks_diff(ticks_end, ticks_first_byte)
 
-    print(
+    multitest.output_metric(
         "Received {}/{} bytes in {} ms. {} B/s".format(
             recv_bytes, recv_correct, total_ticks, recv_bytes * 1000 // total_ticks
         )

--- a/micropython/bluetooth/aioble/multitests/perf_l2cap.py.exp
+++ b/micropython/bluetooth/aioble/multitests/perf_l2cap.py.exp
@@ -1,0 +1,4 @@
+--- instance0 ---
+connect
+--- instance1 ---
+connect


### PR DESCRIPTION
Following on from #787 , this makes a similar fix on the central side:
- There may be more than one UUID per advertising field.
- The UUID advertising field may be empty (no UUIDs).
- Constructing 32-bit `bluetooth.UUID()` entities, which must be done by passing in a 4-byte bytes object, not an integer.

A multitest is added for these cases.

Also, other minor fixups for the multitests.