### PR TITLE
unittest/discover: Reverse order of parent/top in sys.path.

### DIFF
--- a/python-stdlib/unittest-discover/manifest.py
+++ b/python-stdlib/unittest-discover/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.1.2")
+metadata(version="0.1.3")
 
 require("argparse")
 require("fnmatch")

--- a/python-stdlib/unittest-discover/tests/sub/sub.py
+++ b/python-stdlib/unittest-discover/tests/sub/sub.py
@@ -1,0 +1,1 @@
+imported = True

--- a/python-stdlib/unittest-discover/tests/sub/test_module_import.py
+++ b/python-stdlib/unittest-discover/tests/sub/test_module_import.py
@@ -1,0 +1,13 @@
+import sys
+import unittest
+
+
+class TestModuleImport(unittest.TestCase):
+    def test_ModuleImportPath(self):
+        try:
+            from sub.sub import imported
+            assert imported
+        except ImportError:
+            print("This test is intended to be run with unittest discover"
+                  "from the unittest-discover/tests dir. sys.path:", sys.path)
+            raise


### PR DESCRIPTION
When running tests from subfolders, import by "full dotted path" rather than just module name, removing the need to add the test parent folder to sys.path.

---

I found a problem with unittest-discover in a project which uses microdot. A recent update in microdot includes a `test_client.py` in the src folder, which caused it to be pulled in when freezing the module via manifest, and this test file was also then run with `unittest discover`.

The issue is related to import path ordering. [The unit test in question](https://github.com/miguelgrinberg/microdot/blob/main/src/microdot/test_client.py) starts with `from microdot.microdot import Request, Response, AsyncBytesIO` which seems reasonable. The microdot package has this `microdot/microdot.py` file and that import line works fine normally.

However currently, when unittest discover finds a test file in a subdirectory https://github.com/micropython/micropython-lib/blob/50ed36fbeb919753bcc26ce13a8cffd7691d06ef/python-stdlib/unittest-discover/unittest/__main__.py#L48 

it inserts the test file parent folder `path` at the start of `sys.path`, followed by `top`,  resulting in an import path like `['./microdot', '.', '', '.frozen', '/home/.micropython/lib', '/usr/lib/micropython']`
This means from this point, an `import microdot` is finding the `microdot.py` file, not the parent `microdot` package. Hence, `import microdot.microdot` fails.

I believe I wrote the existing code with `reversed` on the path insertions by mistake and it's only now I've found a situation that shows the bug. As such I think it makes the most sense to have `top` as the first element on path, espectially as this is a value that can be directly overridden on the command line when running `unittest discover`, so putting it highest priority gives the user the best flexibility.
