### PR TITLE
all: remove u-module naming where possible

### DIFF
--- a/micropython/aioespnow/README.md
+++ b/micropython/aioespnow/README.md
@@ -4,7 +4,7 @@ A supplementary module which extends the micropython `espnow` module to provide
 `asyncio` support.
 
 - Asyncio support is available on all ESP32 targets as well as those ESP8266
-boards which include the `uasyncio` module (ie. ESP8266 devices with at least
+boards which include the `asyncio` module (ie. ESP8266 devices with at least
 2MB flash storage).
 
 ## API reference
@@ -52,7 +52,7 @@ A small async server example::
 ```python
     import network
     import aioespnow
-    import uasyncio as asyncio
+    import asyncio
 
     # A WLAN interface must be active to send()/recv()
     network.WLAN(network.STA_IF).active(True)

--- a/micropython/aioespnow/aioespnow.py
+++ b/micropython/aioespnow/aioespnow.py
@@ -1,12 +1,12 @@
 # aioespnow module for MicroPython on ESP32 and ESP8266
 # MIT license; Copyright (c) 2022 Glenn Moloney @glenn20
 
-import uasyncio as asyncio
+import asyncio
 import espnow
 
 
-# Modelled on the uasyncio.Stream class (extmod/stream/stream.py)
-# NOTE: Relies on internal implementation of uasyncio.core (_io_queue)
+# Modelled on the asyncio.Stream class (extmod/asyncio/stream.py)
+# NOTE: Relies on internal implementation of asyncio.core (_io_queue)
 class AIOESPNow(espnow.ESPNow):
     # Read one ESPNow message
     async def arecv(self):

--- a/micropython/aiorepl/aiorepl.py
+++ b/micropython/aiorepl/aiorepl.py
@@ -41,7 +41,7 @@ async def execute(code, g, s):
                 code = "return {}".format(code)
 
             code = """
-import uasyncio as asyncio
+import asyncio
 async def __code():
     {}
 

--- a/micropython/bluetooth/aioble/aioble/central.py
+++ b/micropython/bluetooth/aioble/aioble/central.py
@@ -6,7 +6,7 @@ from micropython import const
 import bluetooth
 import struct
 
-import uasyncio as asyncio
+import asyncio
 
 from .core import (
     ensure_active,

--- a/micropython/bluetooth/aioble/aioble/client.py
+++ b/micropython/bluetooth/aioble/aioble/client.py
@@ -3,7 +3,7 @@
 
 from micropython import const
 from collections import deque
-import uasyncio as asyncio
+import asyncio
 import struct
 
 import bluetooth

--- a/micropython/bluetooth/aioble/aioble/device.py
+++ b/micropython/bluetooth/aioble/aioble/device.py
@@ -3,7 +3,7 @@
 
 from micropython import const
 
-import uasyncio as asyncio
+import asyncio
 import binascii
 
 from .core import ble, register_irq_handler, log_error

--- a/micropython/bluetooth/aioble/aioble/l2cap.py
+++ b/micropython/bluetooth/aioble/aioble/l2cap.py
@@ -3,7 +3,7 @@
 
 from micropython import const
 
-import uasyncio as asyncio
+import asyncio
 
 from .core import ble, log_error, register_irq_handler
 from .device import DeviceConnection

--- a/micropython/bluetooth/aioble/aioble/peripheral.py
+++ b/micropython/bluetooth/aioble/aioble/peripheral.py
@@ -6,7 +6,7 @@ from micropython import const
 import bluetooth
 import struct
 
-import uasyncio as asyncio
+import asyncio
 
 from .core import (
     ensure_active,

--- a/micropython/bluetooth/aioble/aioble/security.py
+++ b/micropython/bluetooth/aioble/aioble/security.py
@@ -2,7 +2,7 @@
 # MIT license; Copyright (c) 2021 Jim Mussared
 
 from micropython import const, schedule
-import uasyncio as asyncio
+import asyncio
 import binascii
 import json
 

--- a/micropython/bluetooth/aioble/aioble/server.py
+++ b/micropython/bluetooth/aioble/aioble/server.py
@@ -4,7 +4,7 @@
 from micropython import const
 from collections import deque
 import bluetooth
-import uasyncio as asyncio
+import asyncio
 
 from .core import (
     ensure_active,

--- a/micropython/bluetooth/aioble/examples/l2cap_file_client.py
+++ b/micropython/bluetooth/aioble/examples/l2cap_file_client.py
@@ -10,7 +10,7 @@ sys.path.append("")
 
 from micropython import const
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/examples/l2cap_file_server.py
+++ b/micropython/bluetooth/aioble/examples/l2cap_file_server.py
@@ -21,7 +21,7 @@ sys.path.append("")
 
 from micropython import const
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/examples/temp_client.py
+++ b/micropython/bluetooth/aioble/examples/temp_client.py
@@ -5,7 +5,7 @@ sys.path.append("")
 
 from micropython import const
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/examples/temp_sensor.py
+++ b/micropython/bluetooth/aioble/examples/temp_sensor.py
@@ -5,7 +5,7 @@ sys.path.append("")
 
 from micropython import const
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/ble_buffered_characteristic.py
+++ b/micropython/bluetooth/aioble/multitests/ble_buffered_characteristic.py
@@ -9,7 +9,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/ble_characteristic.py
+++ b/micropython/bluetooth/aioble/multitests/ble_characteristic.py
@@ -9,7 +9,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/ble_descriptor.py
+++ b/micropython/bluetooth/aioble/multitests/ble_descriptor.py
@@ -9,7 +9,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/ble_notify.py
+++ b/micropython/bluetooth/aioble/multitests/ble_notify.py
@@ -9,7 +9,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/ble_shutdown.py
+++ b/micropython/bluetooth/aioble/multitests/ble_shutdown.py
@@ -9,7 +9,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/ble_write_capture.py
+++ b/micropython/bluetooth/aioble/multitests/ble_write_capture.py
@@ -9,7 +9,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/ble_write_order.py
+++ b/micropython/bluetooth/aioble/multitests/ble_write_order.py
@@ -9,7 +9,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/ble_write_order.py
+++ b/micropython/bluetooth/aioble/multitests/ble_write_order.py
@@ -44,12 +44,12 @@ async def instance0_task():
 
     # Register characteristic.written() handlers as asyncio background tasks.
     # The order of these is important!
-    asyncio.create_task(task_written(characteristic_second, "second"))
-    asyncio.create_task(task_written(characteristic_first, "first"))
+    task_second = asyncio.create_task(task_written(characteristic_second, "second"))
+    task_first = asyncio.create_task(task_written(characteristic_first, "first"))
 
     # This dummy task simulates background processing on a real system that
     # can block the asyncio loop for brief periods of time
-    asyncio.create_task(task_dummy())
+    task_dummy_ = asyncio.create_task(task_dummy())
 
     multitest.globals(BDADDR=aioble.config("mac"))
     multitest.next()
@@ -62,6 +62,10 @@ async def instance0_task():
         print("connected")
 
         await connection.disconnected()
+
+    task_second.cancel()
+    task_first.cancel()
+    task_dummy_.cancel()
 
 
 async def task_written(chr, label):

--- a/micropython/bluetooth/aioble/multitests/perf_gatt_notify.py
+++ b/micropython/bluetooth/aioble/multitests/perf_gatt_notify.py
@@ -9,7 +9,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 

--- a/micropython/bluetooth/aioble/multitests/perf_l2cap.py
+++ b/micropython/bluetooth/aioble/multitests/perf_l2cap.py
@@ -7,7 +7,7 @@ from micropython import const
 import machine
 import time
 
-import uasyncio as asyncio
+import asyncio
 import aioble
 import bluetooth
 import random

--- a/micropython/drivers/display/lcd160cr/lcd160cr.py
+++ b/micropython/drivers/display/lcd160cr/lcd160cr.py
@@ -5,7 +5,7 @@ from micropython import const
 import machine
 from utime import sleep_ms
 from ustruct import calcsize, pack_into
-import uerrno
+import errno
 
 # for set_orient
 PORTRAIT = const(0)
@@ -110,7 +110,7 @@ class LCD160CR:
                 return
             t -= 1
             sleep_ms(1)
-        raise OSError(uerrno.ETIMEDOUT)
+        raise OSError(errno.ETIMEDOUT)
 
     def oflush(self, n=255):
         t = 5000
@@ -121,7 +121,7 @@ class LCD160CR:
                 return
             t -= 1
             machine.idle()
-        raise OSError(uerrno.ETIMEDOUT)
+        raise OSError(errno.ETIMEDOUT)
 
     def iflush(self):
         t = 5000
@@ -131,7 +131,7 @@ class LCD160CR:
                 return
             t -= 1
             sleep_ms(1)
-        raise OSError(uerrno.ETIMEDOUT)
+        raise OSError(errno.ETIMEDOUT)
 
     #### MISC METHODS ####
 
@@ -254,7 +254,7 @@ class LCD160CR:
                 return self.buf[3][1] | self.buf[3][2] << 8
             t -= 1
             sleep_ms(1)
-        raise OSError(uerrno.ETIMEDOUT)
+        raise OSError(errno.ETIMEDOUT)
 
     def get_line(self, x, y, buf):
         l = len(buf) // 2
@@ -268,7 +268,7 @@ class LCD160CR:
                 return
             t -= 1
             sleep_ms(1)
-        raise OSError(uerrno.ETIMEDOUT)
+        raise OSError(errno.ETIMEDOUT)
 
     def screen_dump(self, buf, x=0, y=0, w=None, h=None):
         if w is None:

--- a/micropython/drivers/radio/nrf24l01/nrf24l01test.py
+++ b/micropython/drivers/radio/nrf24l01/nrf24l01test.py
@@ -1,7 +1,7 @@
 """Test for nrf24l01 module.  Portable between MicroPython targets."""
 
-import usys
-import ustruct as struct
+import sys
+import struct
 import utime
 from machine import Pin, SPI, SoftSPI
 from nrf24l01 import NRF24L01
@@ -14,20 +14,20 @@ _RX_POLL_DELAY = const(15)
 # initiator may be a slow device. Value tested with Pyboard, ESP32 and ESP8266.
 _RESPONDER_SEND_DELAY = const(10)
 
-if usys.platform == "pyboard":
+if sys.platform == "pyboard":
     spi = SPI(2)  # miso : Y7, mosi : Y8, sck : Y6
     cfg = {"spi": spi, "csn": "Y5", "ce": "Y4"}
-elif usys.platform == "esp8266":  # Hardware SPI
+elif sys.platform == "esp8266":  # Hardware SPI
     spi = SPI(1)  # miso : 12, mosi : 13, sck : 14
     cfg = {"spi": spi, "csn": 4, "ce": 5}
-elif usys.platform == "esp32":  # Software SPI
+elif sys.platform == "esp32":  # Software SPI
     spi = SoftSPI(sck=Pin(25), mosi=Pin(33), miso=Pin(32))
     cfg = {"spi": spi, "csn": 26, "ce": 27}
-elif usys.platform == "rp2":  # Hardware SPI with explicit pin definitions
+elif sys.platform == "rp2":  # Hardware SPI with explicit pin definitions
     spi = SPI(0, sck=Pin(2), mosi=Pin(3), miso=Pin(4))
     cfg = {"spi": spi, "csn": 5, "ce": 6}
 else:
-    raise ValueError("Unsupported platform {}".format(usys.platform))
+    raise ValueError("Unsupported platform {}".format(sys.platform))
 
 # Addresses are in little-endian format. They correspond to big-endian
 # 0xf0f0f0f0e1, 0xf0f0f0f0d2

--- a/micropython/net/ntptime/ntptime.py
+++ b/micropython/net/ntptime/ntptime.py
@@ -1,13 +1,6 @@
-import utime
-
-try:
-    import usocket as socket
-except:
-    import socket
-try:
-    import ustruct as struct
-except:
-    import struct
+from time import gmtime
+import socket
+import struct
 
 # The NTP host can be configured at runtime by doing: ntptime.host = 'myhost.org'
 host = "pool.ntp.org"
@@ -53,7 +46,7 @@ def time():
 
     # Convert timestamp from NTP format to our internal format
 
-    EPOCH_YEAR = utime.gmtime(0)[0]
+    EPOCH_YEAR = gmtime(0)[0]
     if EPOCH_YEAR == 2000:
         # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
         NTP_DELTA = 3155673600
@@ -71,5 +64,5 @@ def settime():
     t = time()
     import machine
 
-    tm = utime.gmtime(t)
+    tm = gmtime(t)
     machine.RTC().datetime((tm[0], tm[1], tm[2], tm[6] + 1, tm[3], tm[4], tm[5], 0))

--- a/micropython/uaiohttpclient/README
+++ b/micropython/uaiohttpclient/README
@@ -1,4 +1,4 @@
-uaiohttpclient is an HTTP client module for MicroPython uasyncio module,
+uaiohttpclient is an HTTP client module for MicroPython asyncio module,
 with API roughly compatible with aiohttp (https://github.com/KeepSafe/aiohttp)
 module. Note that only client is implemented, for server see picoweb
 microframework.

--- a/micropython/uaiohttpclient/example.py
+++ b/micropython/uaiohttpclient/example.py
@@ -2,7 +2,7 @@
 # uaiohttpclient - fetch URL passed as command line argument.
 #
 import sys
-import uasyncio as asyncio
+import asyncio
 import uaiohttpclient as aiohttp
 
 

--- a/micropython/uaiohttpclient/manifest.py
+++ b/micropython/uaiohttpclient/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="HTTP client module for MicroPython uasyncio module", version="0.5.2")
+metadata(description="HTTP client module for MicroPython asyncio module", version="0.5.2")
 
 # Originally written by Paul Sokolovsky.
 

--- a/micropython/uaiohttpclient/uaiohttpclient.py
+++ b/micropython/uaiohttpclient/uaiohttpclient.py
@@ -1,4 +1,4 @@
-import uasyncio as asyncio
+import asyncio
 
 
 class ClientResponse:

--- a/micropython/udnspkt/example_resolve.py
+++ b/micropython/udnspkt/example_resolve.py
@@ -1,15 +1,15 @@
-import uio
-import usocket
+import io
+import socket
 
 import udnspkt
 
 
-s = usocket.socket(usocket.AF_INET, usocket.SOCK_DGRAM)
-dns_addr = usocket.getaddrinfo("127.0.0.1", 53)[0][-1]
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+dns_addr = socket.getaddrinfo("127.0.0.1", 53)[0][-1]
 
 
 def resolve(domain, is_ipv6):
-    buf = uio.BytesIO(48)
+    buf = io.BytesIO(48)
     udnspkt.make_req(buf, "google.com", is_ipv6)
     v = buf.getvalue()
     print("query: ", v)
@@ -17,11 +17,11 @@ def resolve(domain, is_ipv6):
 
     resp = s.recv(1024)
     print("resp:", resp)
-    buf = uio.BytesIO(resp)
+    buf = io.BytesIO(resp)
 
     addr = udnspkt.parse_resp(buf, is_ipv6)
     print("bin addr:", addr)
-    print("addr:", usocket.inet_ntop(usocket.AF_INET6 if is_ipv6 else usocket.AF_INET, addr))
+    print("addr:", socket.inet_ntop(socket.AF_INET6 if is_ipv6 else socket.AF_INET, addr))
 
 
 resolve("google.com", False)

--- a/micropython/udnspkt/udnspkt.py
+++ b/micropython/udnspkt/udnspkt.py
@@ -1,6 +1,3 @@
-import uio
-
-
 def write_fqdn(buf, name):
     parts = name.split(".")
     for p in parts:

--- a/micropython/umqtt.robust/umqtt/robust.py
+++ b/micropython/umqtt.robust/umqtt/robust.py
@@ -1,4 +1,4 @@
-import utime
+import time
 from . import simple
 
 
@@ -7,7 +7,7 @@ class MQTTClient(simple.MQTTClient):
     DEBUG = False
 
     def delay(self, i):
-        utime.sleep(self.DELAY)
+        time.sleep(self.DELAY)
 
     def log(self, in_reconnect, e):
         if self.DEBUG:

--- a/micropython/umqtt.simple/example_pub_button.py
+++ b/micropython/umqtt.simple/example_pub_button.py
@@ -1,5 +1,5 @@
 import time
-import ubinascii
+import binascii
 import machine
 from umqtt.simple import MQTTClient
 from machine import Pin
@@ -10,7 +10,7 @@ button = Pin(0, Pin.IN)
 
 # Default MQTT server to connect to
 SERVER = "192.168.1.35"
-CLIENT_ID = ubinascii.hexlify(machine.unique_id())
+CLIENT_ID = binascii.hexlify(machine.unique_id())
 TOPIC = b"led"
 
 

--- a/micropython/umqtt.simple/example_sub_led.py
+++ b/micropython/umqtt.simple/example_sub_led.py
@@ -1,6 +1,6 @@
 from umqtt.simple import MQTTClient
 from machine import Pin
-import ubinascii
+import binascii
 import machine
 import micropython
 
@@ -11,7 +11,7 @@ led = Pin(2, Pin.OUT, value=1)
 
 # Default MQTT server to connect to
 SERVER = "192.168.1.35"
-CLIENT_ID = ubinascii.hexlify(machine.unique_id())
+CLIENT_ID = binascii.hexlify(machine.unique_id())
 TOPIC = b"led"
 
 

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -1,6 +1,6 @@
-import usocket as socket
-import ustruct as struct
-from ubinascii import hexlify
+import socket
+import struct
+from binascii import hexlify
 
 
 class MQTTException(Exception):

--- a/micropython/urllib.urequest/urllib/urequest.py
+++ b/micropython/urllib.urequest/urllib/urequest.py
@@ -1,4 +1,4 @@
-import usocket
+import socket
 
 
 def urlopen(url, data=None, method="GET"):
@@ -22,10 +22,10 @@ def urlopen(url, data=None, method="GET"):
         host, port = host.split(":", 1)
         port = int(port)
 
-    ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
+    ai = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
     ai = ai[0]
 
-    s = usocket.socket(ai[0], ai[1], ai[2])
+    s = socket.socket(ai[0], ai[1], ai[2])
     try:
         s.connect(ai[-1])
         if proto == "https:":

--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -1,4 +1,4 @@
-import usocket
+import socket
 
 
 class Response:
@@ -28,9 +28,9 @@ class Response:
         return str(self.content, self.encoding)
 
     def json(self):
-        import ujson
+        import json
 
-        return ujson.loads(self.content)
+        return json.loads(self.content)
 
 
 def request(
@@ -51,11 +51,11 @@ def request(
     chunked_data = data and getattr(data, "__next__", None) and not getattr(data, "__len__", None)
 
     if auth is not None:
-        import ubinascii
+        import binascii
 
         username, password = auth
         formated = b"{}:{}".format(username, password)
-        formated = str(ubinascii.b2a_base64(formated)[:-1], "ascii")
+        formated = str(binascii.b2a_base64(formated)[:-1], "ascii")
         headers["Authorization"] = "Basic {}".format(formated)
 
     try:
@@ -76,14 +76,14 @@ def request(
         host, port = host.split(":", 1)
         port = int(port)
 
-    ai = usocket.getaddrinfo(host, port, 0, usocket.SOCK_STREAM)
+    ai = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
     ai = ai[0]
 
     resp_d = None
     if parse_headers is not False:
         resp_d = {}
 
-    s = usocket.socket(ai[0], usocket.SOCK_STREAM, ai[2])
+    s = socket.socket(ai[0], socket.SOCK_STREAM, ai[2])
 
     if timeout is not None:
         # Note: settimeout is not supported on all platforms, will raise
@@ -103,9 +103,9 @@ def request(
 
         if json is not None:
             assert data is None
-            import ujson
+            from json import dumps
 
-            data = ujson.dumps(json)
+            data = dumps(json)
 
             if "Content-Type" not in headers:
                 headers["Content-Type"] = "application/json"

--- a/python-ecosys/requests/test_requests.py
+++ b/python-ecosys/requests/test_requests.py
@@ -17,20 +17,20 @@ class Socket:
         return self._read_buffer.readline()
 
 
-class usocket:
+class socket:
     AF_INET = 2
     SOCK_STREAM = 1
     IPPROTO_TCP = 6
 
     @staticmethod
     def getaddrinfo(host, port, af=0, type=0, flags=0):
-        return [(usocket.AF_INET, usocket.SOCK_STREAM, usocket.IPPROTO_TCP, "", ("127.0.0.1", 80))]
+        return [(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", 80))]
 
     def socket(af=AF_INET, type=SOCK_STREAM, proto=IPPROTO_TCP):
         return Socket()
 
 
-sys.modules["usocket"] = usocket
+sys.modules["socket"] = socket
 # ruff: noqa: E402
 import requests
 

--- a/python-stdlib/argparse/argparse.py
+++ b/python-stdlib/argparse/argparse.py
@@ -3,7 +3,7 @@ Minimal and functional version of CPython's argparse module.
 """
 
 import sys
-from ucollections import namedtuple
+from collections import namedtuple
 
 
 class _ArgError(BaseException):

--- a/python-stdlib/binascii/test_binascii.py
+++ b/python-stdlib/binascii/test_binascii.py
@@ -1,5 +1,5 @@
 from binascii import *
-import utime
+import time
 
 data = b"zlutoucky kun upel dabelske ody"
 h = hexlify(data)
@@ -14,10 +14,10 @@ if data2 != data:
 
 a2b_base64(b"as==") == b"j"
 
-start = utime.time()
+start = time.time()
 for x in range(100000):
     d = unhexlify(h)
 
-print("100000 iterations in: " + str(utime.time() - start))
+print("100000 iterations in: " + str(time.time() - start))
 
 print("OK")

--- a/python-stdlib/copy/copy.py
+++ b/python-stdlib/copy/copy.py
@@ -62,7 +62,7 @@ class Error(Exception):
 error = Error  # backward compatibility
 
 try:
-    from ucollections import OrderedDict
+    from collections import OrderedDict
 except ImportError:
     OrderedDict = None
 

--- a/python-stdlib/pkg_resources/pkg_resources.py
+++ b/python-stdlib/pkg_resources/pkg_resources.py
@@ -1,4 +1,4 @@
-import uio
+import io
 
 c = {}
 
@@ -18,11 +18,11 @@ def resource_stream(package, resource):
             else:
                 d = "."
             #            if d[0] != "/":
-            #                import uos
-            #                d = uos.getcwd() + "/" + d
+            #                import os
+            #                d = os.getcwd() + "/" + d
             c[package] = d + "/"
 
     p = c[package]
     if isinstance(p, dict):
-        return uio.BytesIO(p[resource])
+        return io.BytesIO(p[resource])
     return open(p + resource, "rb")

--- a/unix-ffi/machine/example_timer.py
+++ b/unix-ffi/machine/example_timer.py
@@ -1,4 +1,4 @@
-import utime
+import time
 from machine import Timer
 
 
@@ -7,5 +7,5 @@ t2 = Timer(1, 3)
 t1.callback(lambda t: print(t, "tick1"))
 t2.callback(lambda t: print(t, "tick2"))
 
-utime.sleep(3)
+time.sleep(3)
 print("done")

--- a/unix-ffi/machine/machine/timer.py
+++ b/unix-ffi/machine/machine/timer.py
@@ -1,9 +1,7 @@
 import ffilib
 import uctypes
 import array
-import uos
 import os
-import utime
 from signal import *
 
 libc = ffilib.libc()

--- a/unix-ffi/os/os/__init__.py
+++ b/unix-ffi/os/os/__init__.py
@@ -1,5 +1,5 @@
 import array
-import ustruct as struct
+import struct
 import errno as errno_
 import stat as stat_
 import ffilib

--- a/unix-ffi/pwd/pwd.py
+++ b/unix-ffi/pwd/pwd.py
@@ -1,8 +1,8 @@
 import ffilib
 import uctypes
-import ustruct
+import struct
 
-from ucollections import namedtuple
+from collections import namedtuple
 
 
 libc = ffilib.libc()
@@ -20,6 +20,6 @@ def getpwnam(user):
     if not passwd:
         raise KeyError("getpwnam(): name not found: {}".format(user))
     passwd_fmt = "SSIISSS"
-    passwd = uctypes.bytes_at(passwd, ustruct.calcsize(passwd_fmt))
-    passwd = ustruct.unpack(passwd_fmt, passwd)
+    passwd = uctypes.bytes_at(passwd, struct.calcsize(passwd_fmt))
+    passwd = struct.unpack(passwd_fmt, passwd)
     return struct_passwd(*passwd)

--- a/unix-ffi/select/select.py
+++ b/unix-ffi/select/select.py
@@ -1,5 +1,5 @@
 import ffi
-import ustruct as struct
+import struct
 import os
 import errno
 import ffilib

--- a/unix-ffi/time/time.py
+++ b/unix-ffi/time/time.py
@@ -1,6 +1,6 @@
 from utime import *
-from ucollections import namedtuple
-import ustruct
+from collections import namedtuple
+import struct
 import uctypes
 import ffi
 import ffilib
@@ -34,13 +34,13 @@ _struct_time = namedtuple(
 
 
 def _tuple_to_c_tm(t):
-    return ustruct.pack(
+    return struct.pack(
         "@iiiiiiiii", t[5], t[4], t[3], t[2], t[1] - 1, t[0] - 1900, (t[6] + 1) % 7, t[7] - 1, t[8]
     )
 
 
 def _c_tm_to_tuple(tm):
-    t = ustruct.unpack("@iiiiiiiii", tm)
+    t = struct.unpack("@iiiiiiiii", tm)
     return _struct_time(
         t[5] + 1900, t[4] + 1, t[3], t[2], t[1], t[0], (t[6] - 1) % 7, t[7] + 1, t[8]
     )
@@ -64,7 +64,7 @@ def localtime(t=None):
         t = time()
 
     t = int(t)
-    a = ustruct.pack("l", t)
+    a = struct.pack("l", t)
     tm_p = localtime_(a)
     return _c_tm_to_tuple(uctypes.bytearray_at(tm_p, 36))
 
@@ -74,7 +74,7 @@ def gmtime(t=None):
         t = time()
 
     t = int(t)
-    a = ustruct.pack("l", t)
+    a = struct.pack("l", t)
     tm_p = gmtime_(a)
     return _c_tm_to_tuple(uctypes.bytearray_at(tm_p, 36))
 


### PR DESCRIPTION
This changes almost all uses of "u-module" to just "module" for the following built-in modules:
    - asyncio
    - binascii
    - collections
    - errno
    - io
    - json
    - socket
    - struct
    - sys
    - time
    
There are some remaining uses of "u-module" naming, for the cases where the built-in module is extended in Python, eg `python-stdlib/os` uses `uos`.
    
Also, there are remaining uses of `utime` when non-standard (compared to CPython) functions are used, like `utime.ticks_ms()`.
