### PR TITLE
usb-device-cdc: Fix lost data in read() path if short reads happened.

### DIFF
--- a/micropython/usb/usb-device-cdc/manifest.py
+++ b/micropython/usb/usb-device-cdc/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 require("usb-device")
 package("usb")


### PR DESCRIPTION
If the CDC receive buffer was full and some code read less than 64 bytes (wMaxTransferSize), the CDC code would submit an OUT transfer with N<64 bytes length to fill the buffer back up.

However if the host had more than N bytes to send then it would still send the full 64 bytes (correctly) in the transfer. The remaining (64-N) bytes would be lost.

Fix is to not send a new transfer until 64 bytes is free. Adds the restriction that CDCInterface rxbuf has to be at least 64 bytes.

Closes #885.

*This work was funded through GitHub Sponsors.*