### PR TITLE
StreamHandler should call parent constructor

### DIFF
--- a/python-stdlib/logging/logging.py
+++ b/python-stdlib/logging/logging.py
@@ -58,6 +58,7 @@ class Handler:
 
 class StreamHandler(Handler):
     def __init__(self, stream=None):
+        super().__init__()
         self.stream = _stream if stream is None else stream
         self.terminator = "\n"
 

--- a/python-stdlib/logging/manifest.py
+++ b/python-stdlib/logging/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.6.0")
+metadata(version="0.6.1")
 
 module("logging.py")


### PR DESCRIPTION
Otherwise there's a crash on line 70 where `level` is not a property of the class unless explicitly set with ::setLevel