### PR TITLE
usb-device-keyboard: Fix ; and ` keycode names.

### DIFF
--- a/micropython/usb/usb-device-keyboard/manifest.py
+++ b/micropython/usb/usb-device-keyboard/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 require("usb-device-hid")
 package("usb")

--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -163,9 +163,9 @@ class KeyCode:
     CLOSE_BRACKET = 48  # ] }
     BACKSLASH = 49  # \ |
     HASH = 50  # # ~
-    COLON = 51  # ; :
+    SEMICOLON = 51  # ; :
     QUOTE = 52  # ' "
-    TILDE = 53  # ` ~
+    GRAVE = 53  # ` ~
     COMMA = 54  # , <
     DOT = 55  # . >
     SLASH = 56  # / ?


### PR DESCRIPTION
They should be named as the un-shifted version.