### PR TITLE
settimeout for mqtt socket

### DIFF
--- a/micropython/umqtt.simple/manifest.py
+++ b/micropython/umqtt.simple/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="Lightweight MQTT client for MicroPython.", version="1.4.0")
+metadata(description="Lightweight MQTT client for MicroPython.", version="1.5.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -60,8 +60,9 @@ class MQTTClient:
         self.lw_qos = qos
         self.lw_retain = retain
 
-    def connect(self, clean_session=True):
+    def connect(self, clean_session=True, timeout=None):
         self.sock = socket.socket()
+        self.sock.settimeout(timeout)
         addr = socket.getaddrinfo(self.server, self.port)[0][-1]
         self.sock.connect(addr)
         if self.ssl:


### PR DESCRIPTION
Problem statement:
If there are any network issues, mqtt will block on socket non-deterministically.
In such cases, only way to come out of the blocking is to reboot using watch dog timers.
This is costly solution.

Solution:
Alternatively, developer can set the max timeout for the socket.
Upon any issue, mqtt lib will throw exception. Developer can catch it, take
right actions like, restarting the task without rebooting the whole device.

This brings determinism and gives the control to developer to choose right time for her/his use case. This fix works for async applications too.

(I plan to make whole umqtt async compatible.)