### PR TITLE
usb/usb-device-keyboard : Add key release.

### DIFF
--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -75,9 +75,7 @@ class KeyboardInterface(HIDInterface):
         if self.send_report(self._key_reports[0], 200):
             return True
         return False
-    
     '''Example usage
-
     k = KeyboardInterface()
     usb.device.get().init(k, builtin_driver=True)
     key = [4] #It clicks letter A (refer KeyCode class)

--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -68,14 +68,14 @@ class KeyboardInterface(HIDInterface):
             self._key_reports[1] = r
             return True
         return False
-    
+
     def release_all(self):
         for i in range(_KEY_REPORT_LEN):
             self._key_reports[0][i] = 0
         if self.send_report(self._key_reports[0], 200):
             return True
         return False
-    
+
     '''Example usage
         k = KeyboardInterface()
         usb.device.get().init(k, builtin_driver=True)

--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -75,13 +75,13 @@ class KeyboardInterface(HIDInterface):
         if self.send_report(self._key_reports[0], 200):
             return True
         return False
+    
     '''Example usage
-    k = KeyboardInterface()
-    usb.device.get().init(k, builtin_driver=True)
-    key = [4] #It clicks letter A (refer KeyCode class)
-    k.send_keys(key)
-    k.release_all()
-
+        k = KeyboardInterface()
+        usb.device.get().init(k, builtin_driver=True)
+        key = [4] #It clicks letter A (refer KeyCode class)
+        k.send_keys(key)
+        k.release_all()
     '''
 
 

--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -85,6 +85,7 @@ class KeyboardInterface(HIDInterface):
     '''
 
 
+
 # HID keyboard report descriptor
 #
 # From p69 of http://www.usb.org/developers/devclass_docs/HID1_11.pdf

--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -68,6 +68,23 @@ class KeyboardInterface(HIDInterface):
             self._key_reports[1] = r
             return True
         return False
+    
+    def release_all(self):
+        for i in range(_KEY_REPORT_LEN):
+            self._key_reports[0][i] = 0
+        if self.send_report(self._key_reports[0], 200):
+            return True
+        return False
+    
+    '''Example usage
+
+    k = KeyboardInterface()
+    usb.device.get().init(k, builtin_driver=True)
+    key = [4] #It clicks letter A (refer KeyCode class)
+    k.send_keys(key)
+    k.release_all()
+
+    '''
 
 
 # HID keyboard report descriptor


### PR DESCRIPTION
Micropython 1.23 preview version is used with Raspberry pi pico w board.
Trying to send keys using usb-keyboard library. It was clicking the key, but not releasing it, similar to #873 . Resulting in continuous sending key.
Hence added release_all() function, which releases all keys. And it worked with Rpi pico w.