### PR TITLE
usb/usb-device-keyboard: Add key release.

### DIFF
--- a/micropython/usb/usb-device-keyboard/manifest.py
+++ b/micropython/usb/usb-device-keyboard/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 require("usb-device-hid")
 package("usb")

--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -69,6 +69,22 @@ class KeyboardInterface(HIDInterface):
             return True
         return False
 
+    def release_all(self):
+        for i in range(_KEY_REPORT_LEN):
+            self._key_reports[0][i] = 0
+        if self.send_report(self._key_reports[0], 200):
+            return True
+        return False
+
+    '''Example usage
+
+    k = KeyboardInterface()
+    usb.device.get().init(k, builtin_driver=True)
+    key = [4] #It clicks letter A (refer KeyCode class)
+    k.send_keys(key)
+    k.release_all()
+
+    '''
 
 # HID keyboard report descriptor
 #

--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -76,15 +76,15 @@ class KeyboardInterface(HIDInterface):
             return True
         return False
 
-    '''Example usage
+    """Example usage
 
     k = KeyboardInterface()
     usb.device.get().init(k, builtin_driver=True)
     key = [4] #It clicks letter A (refer KeyCode class)
     k.send_keys(key)
     k.release_all()
+    """
 
-    '''
 
 # HID keyboard report descriptor
 #


### PR DESCRIPTION
Micropython 1.23 preview version is used with Raspberry pi pico w board.
Trying to send keys using usb-keyboard library. It was clicking the key, but not releasing it, similar to #873 . Resulting in continuous sending key.
Hence added release_all() function, which releases all keys. And it worked with Rpi pico w.