### PR TITLE
usb-device: Allow signaling capability of remote_wakeup.

### DIFF
--- a/micropython/usb/usb-device/manifest.py
+++ b/micropython/usb/usb-device/manifest.py
@@ -1,2 +1,2 @@
-metadata(version="0.1.1")
+metadata(version="0.2.0")
 package("usb")

--- a/micropython/usb/usb-device/usb/device/core.py
+++ b/micropython/usb/usb-device/usb/device/core.py
@@ -110,6 +110,7 @@ class _Device:
         device_protocol=0,
         config_str=None,
         max_power_ma=None,
+        remote_wakeup=False,
     ):
         # Configure the USB device with a set of interfaces, and optionally reconfiguring the
         # device and configuration descriptor fields
@@ -199,7 +200,7 @@ class _Device:
         bmAttributes = (
             (1 << 7)  # Reserved
             | (0 if max_power_ma else (1 << 6))  # Self-Powered
-            # Remote Wakeup not currently supported
+            | ((1 << 5) if remote_wakeup else 0)
         )
 
         # Configuration string is optional but supported


### PR DESCRIPTION
To use this feature you need to create a usb device signaling remote wakeup and then enable remote wakeup on the host (on linux write `enabled` to `/sys/bus/usb/devices/<device>/power/wakeup`, or let `udev` do that). Then you can wake up the host when it is on standby using USBDevice.remote_wakeup.

See also [micropython#15262](https://github.com/micropython/micropython/pull/15262).