### PR TITLE
minor lora sx126x _cmd optimization

### DIFF
--- a/micropython/lora/lora-sx126x/lora/sx126x.py
+++ b/micropython/lora/lora-sx126x/lora/sx126x.py
@@ -152,7 +152,8 @@ class _SX126x(BaseModem):
             dio3_tcxo_start_time_us if dio3_tcxo_millivolts else 0
         )
 
-        self._buf = bytearray(9)  # shared buffer for commands
+        self._buf = bytearray(9)  # shared buffer for commands, access through _buf_view
+        self._buf_view = memoryview(self._buf) 
 
         # These settings are kept in the object (as can't read them back from the modem)
         self._output_power = 14
@@ -704,11 +705,11 @@ class _SX126x(BaseModem):
         # have happened well before _cmd() is called again.
         self._wait_not_busy(self._busy_timeout)
 
-        # Pack write_args into _buf and wrap a memoryview of the correct length around it
+        # Pack write_args into slice of _buf_view memoryview of correct length
         wrlen = struct.calcsize(fmt)
-        assert n_read + wrlen <= len(self._buf)  # if this fails, make _buf bigger!
-        struct.pack_into(fmt, self._buf, 0, *write_args)
-        buf = memoryview(self._buf)[: (wrlen + n_read)]
+        assert n_read + wrlen <= len(self._buf_view)  # if this fails, make _buf bigger!
+        struct.pack_into(fmt, self._buf_view, 0, *write_args)
+        buf = self._buf_view[: (wrlen + n_read)]
 
         if _DEBUG:
             print(">>> {}".format(buf[:wrlen].hex()))
@@ -723,7 +724,7 @@ class _SX126x(BaseModem):
         self._cs(1)
 
         if n_read > 0:
-            res = memoryview(buf)[wrlen : (wrlen + n_read)]  # noqa: E203
+            res = self._buf_view[wrlen : (wrlen + n_read)]  # noqa: E203
             if _DEBUG:
                 print("<<< {}".format(res.hex()))
             return res

--- a/micropython/lora/lora-sx126x/lora/sx126x.py
+++ b/micropython/lora/lora-sx126x/lora/sx126x.py
@@ -152,8 +152,7 @@ class _SX126x(BaseModem):
             dio3_tcxo_start_time_us if dio3_tcxo_millivolts else 0
         )
 
-        self._buf = bytearray(9)  # shared buffer for commands, access through _buf_view
-        self._buf_view = memoryview(self._buf) 
+        self._buf_view = memoryview(bytearray(9))  # shared buffer for commands
 
         # These settings are kept in the object (as can't read them back from the modem)
         self._output_power = 14

--- a/micropython/lora/lora-sx126x/manifest.py
+++ b/micropython/lora/lora-sx126x/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.2")
+metadata(version="0.1.3")
 require("lora")
 package("lora")


### PR DESCRIPTION
Currently, the micropython-lib lora sx126x driver dynamically creates at least one, sometimes two, `memoryview` objects with each call to `_cmd`. This PR simply provides the class with a long-lived memoryview object for `_cmd` to easily slice as necessary. 

Unlike the SX127x chips, Semtech unfortunately designed the SX126x modems to be more command-centric (as opposed to directly setting registers). Given the amount `_cmd` is called during normal device operation, even a minor improvement here should have a decent impact.

Basic TX and RX tests pass on hardware.

@projectgus, care to review? 