### PR TITLE
usb: Fix USB device library transfer thread safety

### DIFF
--- a/micropython/usb/README.md
+++ b/micropython/usb/README.md
@@ -134,3 +134,15 @@ USB MIDI devices in MicroPython.
 
 The example [midi_example.py](examples/device/midi_example.py) demonstrates how
 to create a simple MIDI device to send MIDI data to and from the USB host.
+
+### Limitations
+
+#### Buffer thread safety
+
+The internal Buffer class that's used by most of the USB device classes expects data
+to be written to it (i.e. sent to the host) by only one thread. Bytes may be
+lost from the USB transfers if more than one thread (or a thread and a callback)
+try to write to the buffer simultaneously.
+
+If writing USB data from multiple sources, your code may need to add
+synchronisation (i.e. locks).

--- a/micropython/usb/usb-device/manifest.py
+++ b/micropython/usb/usb-device/manifest.py
@@ -1,2 +1,2 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 package("usb")


### PR DESCRIPTION
The USB pending transfer flag was cleared before calling the completion callback, to allow the callback code to call submit_xfer() again.

Unfortunately this isn't safe in a multi-threaded environment, as another thread may see the endpoint is available before the callback is done executing and submit a new transfer.

Rather than adding extra locking, specifically treat the transfer as still pending if checked from another thread while the callback is executing.

Together with https://github.com/micropython/micropython/pull/15264 this closes #874.

Tested using the sample code from the linked issue.

*This work was funded through GitHub Sponsors.*