### PR TITLE
micropython/net/webrepl/webrepl_setup.py: Check for existence of boot.py and create it if needed.

### DIFF
--- a/micropython/net/webrepl/webrepl_setup.py
+++ b/micropython/net/webrepl/webrepl_setup.py
@@ -39,6 +39,12 @@ def exists(fname):
         return False
 
 
+def validate_boot_file():
+    if not exists(RC):
+        with open(RC, "w") as f:
+            f.write("# boot.py -- run on boot-up\n")
+
+
 def get_daemon_status():
     with open(RC) as f:
         for l in f:
@@ -71,6 +77,7 @@ def change_daemon(action):
 
 
 def main():
+    validate_boot_file()
     status = get_daemon_status()
 
     print("WebREPL daemon auto-start status:", "enabled" if status else "disabled")


### PR DESCRIPTION
Hello!

There are many instances online about people complaining of `OSError: [Errno 2] ENOENT` errors when trying to initialize WebREPL, particularly on the Pico W.

It appears that these people are not using `boot.py` in their projects, but `webrepl_setup` relies on its existence to function.

However, it does not create the file if it doesn't exist, and fails with `OSError: [Errno 2] ENOENT`.

Since there isn't a .py file to easily trace through (as `webrepl_setup` and `webrepl` are usually pre-compiled and included in pre-built Micropython binaries), many users struggle to realize that they're missing a `boot.py` file for `webrepl_setup` to write to.

This PR adds a check (new function `validate_boot_file()`) before `get_daemon_status()`, which checks for the existence of `boot.py` and creates the file if it doesn't exist. This solves the `OSError: [Errno 2] ENOENT` error when trying to run `webrepl_setup.py` without a `boot.py` file!