### PR TITLE
aioble: Pass additional connection arguments to gap_connect.

### DIFF
--- a/micropython/bluetooth/aioble-central/manifest.py
+++ b/micropython/bluetooth/aioble-central/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.2")
+metadata(version="0.3.0")
 
 require("aioble-core")
 

--- a/micropython/bluetooth/aioble-core/manifest.py
+++ b/micropython/bluetooth/aioble-core/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.3.0")
+metadata(version="0.4.0")
 
 package(
     "aioble",

--- a/micropython/bluetooth/aioble/aioble/central.py
+++ b/micropython/bluetooth/aioble/aioble/central.py
@@ -104,7 +104,9 @@ async def _cancel_pending():
 
 # Start connecting to a peripheral.
 # Call device.connect() rather than using method directly.
-async def _connect(connection, timeout_ms):
+async def _connect(
+    connection, timeout_ms, scan_duration_ms, min_conn_interval_us, max_conn_interval_us
+):
     device = connection.device
     if device in _connecting:
         return
@@ -122,7 +124,13 @@ async def _connect(connection, timeout_ms):
 
     try:
         with DeviceTimeout(None, timeout_ms):
-            ble.gap_connect(device.addr_type, device.addr)
+            ble.gap_connect(
+                device.addr_type,
+                device.addr,
+                scan_duration_ms,
+                min_conn_interval_us,
+                max_conn_interval_us,
+            )
 
             # Wait for the connected IRQ.
             await connection._event.wait()

--- a/micropython/bluetooth/aioble/aioble/device.py
+++ b/micropython/bluetooth/aioble/aioble/device.py
@@ -132,14 +132,26 @@ class Device:
     def addr_hex(self):
         return binascii.hexlify(self.addr, ":").decode()
 
-    async def connect(self, timeout_ms=10000):
+    async def connect(
+        self,
+        timeout_ms=10000,
+        scan_duration_ms=None,
+        min_conn_interval_us=None,
+        max_conn_interval_us=None,
+    ):
         if self._connection:
             return self._connection
 
         # Forward to implementation in central.py.
         from .central import _connect
 
-        await _connect(DeviceConnection(self), timeout_ms)
+        await _connect(
+            DeviceConnection(self),
+            timeout_ms,
+            scan_duration_ms,
+            min_conn_interval_us,
+            max_conn_interval_us,
+        )
 
         # Start the device task that will clean up after disconnection.
         self._connection._run_task()

--- a/micropython/bluetooth/aioble/manifest.py
+++ b/micropython/bluetooth/aioble/manifest.py
@@ -3,7 +3,7 @@
 # code. This allows (for development purposes) all the files to live in the
 # one directory.
 
-metadata(version="0.5.2")
+metadata(version="0.6.0")
 
 # Default installation gives you everything. Install the individual
 # components (or a combination of them) if you want a more minimal install.


### PR DESCRIPTION
In my project I am connecting using aioble to a human input device. There is noticeable input lag. Turns out the RTT latency is a little over 200ms (I test this by timing `await char.write(b'foo', response=1)`). I suspect this is because the BLE connection interval is being set to 100ms. The [gap_connect](https://docs.micropython.org/en/latest/library/bluetooth.html#bluetooth.BLE.gap_connect) function allows setting `min_conn_interval_us` and `max_conn_interval_us`, however there is no way to do so using aioble.

This PR allows the following additional arguments to be passed to `device.connect()`:

* scan_duration_ms
* min_conn_interval_us
* max_conn_interval_us

These are passed as-is to `gap_connect()`. The default value for all of these is `None`, which causes gap_connect to use its own defaults.

With this change I managed to get the RTT latency down to ~60ms, this feels a lot better in my project.

Package: https://joris-van-der-wel.github.io/micropython-lib/mip/gap_connect_params/