### PR TITLE
base64: Remove struct dependency from manifest.

### DIFF
--- a/python-stdlib/base64/manifest.py
+++ b/python-stdlib/base64/manifest.py
@@ -1,6 +1,5 @@
-metadata(version="3.3.5")
+metadata(version="3.3.6")
 
 require("binascii")
-require("struct")
 
 module("base64.py")


### PR DESCRIPTION
This base64 library only uses `struct.unpack` which is available in the built-in `struct` module, so no need for the micropython-lib extras.