### PR TITLE
Add `ticks` property to logging records

### DIFF
--- a/python-stdlib/logging/logging.py
+++ b/python-stdlib/logging/logging.py
@@ -36,6 +36,7 @@ class LogRecord:
         self.ct = time.time()
         self.msecs = int((self.ct - int(self.ct)) * 1000)
         self.asctime = None
+        self.ticks = time.ticks_ms()
 
 
 class Handler:
@@ -102,6 +103,7 @@ class Formatter:
             "msecs": record.msecs,
             "asctime": record.asctime,
             "levelname": record.levelname,
+            "ticks": record.ticks,
         }
 
 


### PR DESCRIPTION
`ticks` is the value of `time.ticks_ms()` when the log record is setup. For systems without a millisecond-accurate RTC, such as the RP2, this helps bring time-granularity to log entries.