### PR TITLE
Fix units in ADV_INTERVAL constant

### DIFF
--- a/micropython/bluetooth/aioble/examples/temp_sensor.py
+++ b/micropython/bluetooth/aioble/examples/temp_sensor.py
@@ -20,7 +20,7 @@ _ENV_SENSE_TEMP_UUID = bluetooth.UUID(0x2A6E)
 _ADV_APPEARANCE_GENERIC_THERMOMETER = const(768)
 
 # How frequently to send advertising beacons.
-_ADV_INTERVAL_MS = 250_000
+_ADV_INTERVAL_US = 250_000
 
 
 # Register GATT server.


### PR DESCRIPTION
The aioble README already has this fix: https://github.com/micropython/micropython-lib/commit/57ce3ba95c65d9823e8cc5284003967ff621bd46

This brings the example makes a similar correction to the `temp_sensor.py` example.