### PR TITLE
aioespnow, webrepl: Use recommended network.WLAN.IF_[AP|STA] constants.

### DIFF
--- a/micropython/aioespnow/README.md
+++ b/micropython/aioespnow/README.md
@@ -55,7 +55,7 @@ A small async server example::
     import asyncio
 
     # A WLAN interface must be active to send()/recv()
-    network.WLAN(network.STA_IF).active(True)
+    network.WLAN(network.WLAN.IF_STA).active(True)
 
     e = aioespnow.AIOESPNow()  # Returns AIOESPNow enhanced with async support
     e.active(True)

--- a/micropython/net/webrepl/webrepl.py
+++ b/micropython/net/webrepl/webrepl.py
@@ -102,7 +102,7 @@ def setup_conn(port, accept_handler):
     listen_s.listen(1)
     if accept_handler:
         listen_s.setsockopt(socket.SOL_SOCKET, 20, accept_handler)
-    for i in (network.AP_IF, network.STA_IF):
+    for i in (network.WLAN.IF_AP, network.WLAN.IF_STA):
         iface = network.WLAN(i)
         if iface.active():
             print("WebREPL server started on http://%s:%d/" % (iface.ifconfig()[0], port))


### PR DESCRIPTION
Sibling PR of https://github.com/micropython/micropython/pull/16155. Removes the deprecated network.[AP|STA]_IF form.

This work was funded through GitHub Sponsors.