### PR TITLE
unittest: Allow SkipTest to work within a subTest.

### DIFF
--- a/python-stdlib/unittest/tests/exception.py
+++ b/python-stdlib/unittest/tests/exception.py
@@ -1,3 +1,5 @@
+# This makes unittest return an error code, so is not named "test_xxx.py".
+
 import unittest
 
 

--- a/python-stdlib/unittest/tests/test_subtest.py
+++ b/python-stdlib/unittest/tests/test_subtest.py
@@ -1,0 +1,14 @@
+import unittest
+
+
+class Test(unittest.TestCase):
+    def test_subtest_skip(self):
+        for i in range(4):
+            with self.subTest(i=i):
+                print("sub test", i)
+                if i == 2:
+                    self.skipTest("skip 2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -348,7 +348,13 @@ def _handle_test_exception(
     exc = exc_info[1]
     traceback = exc_info[2]
     ex_str = _capture_exc(exc, traceback)
-    if isinstance(exc, AssertionError):
+    if isinstance(exc, SkipTest):
+        reason = exc.args[0]
+        test_result.skippedNum += 1
+        test_result.skipped.append((current_test, reason))
+        print(" skipped:", reason)
+        return
+    elif isinstance(exc, AssertionError):
         test_result.failuresNum += 1
         test_result.failures.append((current_test, ex_str))
         if verbose:
@@ -396,11 +402,6 @@ def _run_suite(c, test_result: TestResult, suite_name=""):
                 print(" FAIL")
             else:
                 print(" ok")
-        except SkipTest as e:
-            reason = e.args[0]
-            print(" skipped:", reason)
-            test_result.skippedNum += 1
-            test_result.skipped.append((name, c, reason))
         except Exception as ex:
             _handle_test_exception(
                 current_test=(name, c), test_result=test_result, exc_info=(type(ex), ex, None)

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -63,6 +63,7 @@ function ci_package_tests_run {
         python-stdlib/os-path/test_path.py \
         python-stdlib/pickle/test_pickle.py \
         python-stdlib/string/test_translate.py \
+        python-stdlib/unittest/tests/exception.py \
         unix-ffi/gettext/test_gettext.py \
         unix-ffi/pwd/test_getpwnam.py \
         unix-ffi/re/test_re.py \
@@ -90,6 +91,7 @@ function ci_package_tests_run {
         python-stdlib/shutil \
         python-stdlib/tempfile \
         python-stdlib/time \
+        python-stdlib/unittest/tests \
         python-stdlib/unittest-discover/tests \
         ; do
         (cd $path && $MICROPYTHON -m unittest)


### PR DESCRIPTION
This refactors things slightly so that `SkipTest` exceptions are handled correctly within a sub-test context manager.

Also enabled `unittest` tests on CI.