### PR TITLE
umqtt.simple: Restore legacy ssl/ssl_params arguments.

### DIFF
--- a/micropython/umqtt.simple/manifest.py
+++ b/micropython/umqtt.simple/manifest.py
@@ -1,5 +1,7 @@
-metadata(description="Lightweight MQTT client for MicroPython.", version="1.5.0")
+metadata(description="Lightweight MQTT client for MicroPython.", version="1.6.0")
 
 # Originally written by Paul Sokolovsky.
+
+require("ssl")
 
 package("umqtt")

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -17,6 +17,7 @@ class MQTTClient:
         password=None,
         keepalive=0,
         ssl=None,
+        ssl_params={},
     ):
         if port == 0:
             port = 8883 if ssl else 1883
@@ -25,6 +26,7 @@ class MQTTClient:
         self.server = server
         self.port = port
         self.ssl = ssl
+        self.ssl_params = ssl_params
         self.pid = 0
         self.cb = None
         self.user = user
@@ -65,7 +67,12 @@ class MQTTClient:
         self.sock.settimeout(timeout)
         addr = socket.getaddrinfo(self.server, self.port)[0][-1]
         self.sock.connect(addr)
-        if self.ssl:
+        if self.ssl is True:
+            # Legacy support for ssl=True and ssl_params arguments.
+            import ssl
+
+            self.sock = ssl.wrap_socket(self.sock, **self.ssl_params)
+        elif self.ssl:
             self.sock = self.ssl.wrap_socket(self.sock, server_hostname=self.server)
         premsg = bytearray(b"\x10\0\0\0\0\0")
         msg = bytearray(b"\x04MQTT\x04\x02\0\0")


### PR DESCRIPTION
### Summary

Commit 35d41dbb0e4acf1518f520220d405ebe2db257d6 changed the API for using SSL with umqtt, but only did a minor version increase.  This broke various uses of this library, eg
https://github.com/aws-samples/aws-iot-core-getting-started-micropython

Reinstate the original API for specifying an SSL connection.  This library now supports the following:
- default, ssl=None or ssl=False: no SSL
- ssl=True and optional ssl_params specified: use ssl.wrap_socket
- ssl=<SSLContext instance>: use provided SSL context to wrap socket

### Testing

TODO