### PR TITLE
unittest: Always use "raise" with an argument.

### DIFF
--- a/python-stdlib/unittest/manifest.py
+++ b/python-stdlib/unittest/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.10.3")
+metadata(version="0.10.4")
 
 package("unittest")

--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -198,7 +198,7 @@ class TestCase:
         except Exception as e:
             if isinstance(e, exc):
                 return
-            raise
+            raise e
 
         assert False, "%r not raised" % exc
 
@@ -407,7 +407,7 @@ def _run_suite(c, test_result: TestResult, suite_name=""):
                 current_test=(name, c), test_result=test_result, exc_info=(type(ex), ex, None)
             )
             # Uncomment to investigate failure in detail
-            # raise
+            # raise ex
         finally:
             __test_result__ = None
             __current_test__ = None


### PR DESCRIPTION
So this code can be compiled with the MicroPython native emitter, which does not support "raise" without any arguments.