### PR TITLE
aiohttp: fix header problem

### DIFF
--- a/python-ecosys/aiohttp/aiohttp/__init__.py
+++ b/python-ecosys/aiohttp/aiohttp/__init__.py
@@ -269,7 +269,7 @@ class ClientSession:
         return _WSRequestContextManager(self, self._ws_connect(url, ssl=ssl))
 
     async def _ws_connect(self, url, ssl=None):
-        ws_client = WebSocketClient(None)
+        ws_client = WebSocketClient(self._base_headers.copy())
         await ws_client.connect(url, ssl=ssl, handshake_request=self.request_raw)
         self._reader = ws_client.reader
         return ClientWebSocketResponse(ws_client)

--- a/python-ecosys/aiohttp/aiohttp/aiohttp_ws.py
+++ b/python-ecosys/aiohttp/aiohttp/aiohttp_ws.py
@@ -136,7 +136,7 @@ class WebSocketClient:
         return frame + payload
 
     async def handshake(self, uri, ssl, req):
-        headers = {}
+        headers = self.params
         _http_proto = "http" if uri.protocol != "wss" else "https"
         url = f"{_http_proto}://{uri.hostname}:{uri.port}{uri.path or '/'}"
         key = binascii.b2a_base64(bytes(random.getrandbits(8) for _ in range(16)))[:-1]

--- a/python-ecosys/aiohttp/manifest.py
+++ b/python-ecosys/aiohttp/manifest.py
@@ -1,6 +1,6 @@
 metadata(
     description="HTTP client module for MicroPython asyncio module",
-    version="0.0.4",
+    version="0.0.5",
     pypi="aiohttp",
 )
 


### PR DESCRIPTION
Latest version of aiohttp:
When making connection to a Websocket, the header argument is ignored.

The consequence is that you cannot make a connection to most online MQTT broker's over websocket
because they need the header entry: **"Sec-WebSocket-Protocol":"mqtt"** in the handshake of
the upgrade protocol.

See this small example code:
It connects to a MQTT broker and then sends the CONNECT mqtt packet.
Then it should get a reply of **opcode:2, data: b' \x02\x00\x00'** where 'data' is a CONNACK mqtt package
Because of the missing header entry **"Sec-WebSocket-Protocol":"mqtt"** most brokers will refuse the connection or
refuse to accept MQTT packets.

```python
import aiohttp
import asyncio

async def connect():
    url = "ws://test.mosquitto.org:8080"
    headers = {"Sec-WebSocket-Protocol":"mqtt"}
    connect_pkt = bytearray(b'\x10\x10\x00\x04MQTT\x04\x02\x00x\x00\x04fz54')
    
    async with aiohttp.ClientSession(headers=headers).ws_connect(url) as ws:
            print("Connected")
            await ws.send_bytes(connect_pkt)
            opcode, data = await ws.ws.receive()
            print(f"opcode:{opcode}, data{data}")

asyncio.run(connect())

```