### PR TITLE
python-ecosys/requests/requests/__init__.py: Use the host in the redirect url, not the one in headers.

### DIFF
--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -181,8 +181,7 @@ def request(
     if redirect:
         s.close()
         # use the Host in the redirect URL
-        if "Host" in headers:
-            headers.pop("Host")
+        headers.pop("Host", None)
         if status in [301, 302, 303]:
             return request("GET", redirect, None, None, headers, stream)
         else:

--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -180,6 +180,9 @@ def request(
 
     if redirect:
         s.close()
+        # use the Host in the redirect URL
+        if "Host" in headers:
+            headers.pop("Host")
         if status in [301, 302, 303]:
             return request("GET", redirect, None, None, headers, stream)
         else:

--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -180,7 +180,7 @@ def request(
 
     if redirect:
         s.close()
-        # use the Host in the redirect URL
+        # Use the host specified in the redirect URL, as it may not be the same as the original URL.
         headers.pop("Host", None)
         if status in [301, 302, 303]:
             return request("GET", redirect, None, None, headers, stream)


### PR DESCRIPTION
removing the host header when redirect

The host in headers extracted from the original url may not be the same as the host in the redirect url. It shoud use the host in the redirect url, not the one in the headers.