### PR TITLE
requests: Do not leak header modifications when calling request()

### DIFF
--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -46,6 +46,8 @@ def request(
 ):
     if headers is None:
         headers = {}
+    else:
+        headers = dict(headers)
 
     redirect = None  # redirection url, None means no redirection
     chunked_data = data and getattr(data, "__next__", None) and not getattr(data, "__len__", None)

--- a/python-ecosys/requests/test_requests.py
+++ b/python-ecosys/requests/test_requests.py
@@ -145,6 +145,14 @@ def test_overwrite_post_chunked_data_headers():
     ), format_message(response)
 
 
+def test_do_not_modify_headers_argument():
+    original_headers = {}
+    headers = dict(original_headers)
+    requests.request("GET", "https://example.com", headers=original_headers)
+
+    assert headers == original_headers
+
+
 test_simple_get()
 test_get_auth()
 test_get_custom_header()
@@ -153,3 +161,4 @@ test_post_chunked_data()
 test_overwrite_get_headers()
 test_overwrite_post_json_headers()
 test_overwrite_post_chunked_data_headers()
+test_do_not_modify_headers_argument()


### PR DESCRIPTION
The requests() function takes a headers dict argument (call-by-reference). This object is then modified in the function. For instance the host is added and authentication information. Such behavior is not expected. It is also problematic:

- Modifications of the header dictionary will be visible on the caller site.
- When reusing the same (supposedly read-only) headers object for differenct calls, the second call will apparently re-use wrong headers from the previous call and may fail.

This patch should also fix #839.