### PR TITLE
drivers/radio/nrf24l01: Increase startup delay.

### DIFF
--- a/micropython/drivers/radio/nrf24l01/nrf24l01.py
+++ b/micropython/drivers/radio/nrf24l01/nrf24l01.py
@@ -227,7 +227,7 @@ class NRF24L01:
     def send_start(self, buf):
         # power up
         self.reg_write(CONFIG, (self.reg_read(CONFIG) | PWR_UP) & ~PRIM_RX)
-        utime.sleep_us(150)
+        utime.sleep_us(1500)  # needs to be 1.5ms
         # send the data
         self.cs(0)
         self.spi.readinto(self.buf, W_TX_PAYLOAD)


### PR DESCRIPTION
According to the datasheet of the NRF240L1 chip, 150 μs startup time is only acceptable when the chip is clocked externally. Most modules use crystal, which require 1.5 ms to settle. I think it's okay to wait more in both cases, for a reliable startup.

---

ref: "6.1.7 Timing Information" in nRF24L01+ datasheet rev. 1.0

Without this patch I couldn't make my module to transmit reliably.