### PR TITLE
drivers/radio/nrf24l01: Properly handle timeout.

### DIFF
--- a/micropython/drivers/radio/nrf24l01/nrf24l01.py
+++ b/micropython/drivers/radio/nrf24l01/nrf24l01.py
@@ -220,6 +220,13 @@ class NRF24L01:
         result = None
         while result is None and utime.ticks_diff(utime.ticks_ms(), start) < timeout:
             result = self.send_done()  # 1 == success, 2 == fail
+
+        if result is None:
+            # timed out, cancel sending and power down the module
+            self.flush_tx()
+            self.reg_write(CONFIG, self.reg_read(CONFIG) & ~PWR_UP)
+            raise OSError("timed out")
+
         if result == 2:
             raise OSError("send failed")
 


### PR DESCRIPTION
The timeout condition was not handled before. Upon timeout, this caused the chip to stay active until another send command changed it's state.

Sometimes when it was unable to transmit the data, it got stuck in the tx fifo causing it to fill up over time, which set the TX_FULL flag in the STATUS register.

Since there was no exceptions raised, the user code could not differentiate a successful send or a timeout condition.

----

Note: timeout condition almost always indicate HW failure or improper control of the chip.