### PR TITLE
drivers/radio/nrf24l01: Optimized status reading.

### DIFF
--- a/micropython/drivers/radio/nrf24l01/manifest.py
+++ b/micropython/drivers/radio/nrf24l01/manifest.py
@@ -1,3 +1,3 @@
-metadata(description="nrf24l01 2.4GHz radio driver.", version="0.1.0")
+metadata(description="nrf24l01 2.4GHz radio driver.", version="0.2.0")
 
 module("nrf24l01.py", opt=3)

--- a/micropython/drivers/radio/nrf24l01/nrf24l01.py
+++ b/micropython/drivers/radio/nrf24l01/nrf24l01.py
@@ -130,6 +130,13 @@ class NRF24L01:
         self.cs(1)
         return ret
 
+    def read_status(self):
+        self.cs(0)
+        # STATUS register is always shifted during command transmit
+        self.spi.readinto(self.buf, NOP)
+        self.cs(1)
+        return self.buf[0]
+
     def flush_rx(self):
         self.cs(0)
         self.spi.readinto(self.buf, FLUSH_RX)
@@ -250,7 +257,8 @@ class NRF24L01:
 
     # returns None if send still in progress, 1 for success, 2 for fail
     def send_done(self):
-        if not (self.reg_read(STATUS) & (TX_DS | MAX_RT)):
+        status = self.read_status()
+        if not (status & (TX_DS | MAX_RT)):
             return None  # tx not finished
 
         # either finished or failed: get and clear status flags, power down


### PR DESCRIPTION
The value of the STATUS register is always transmitted by the chip when reading any command. So a R_REGISTER command and the turnaround time can be spared by issuing a NOP command instead.

This implementation suggested by the datasheet.

This operation is compatible with both nRF24L01 and nRF24L01+.

----

In my testing, this reduced the STATUS read time from 41 μs to 27 μs. This allows for quicker polling, and thus more responsive operation. 


Old behavior:

![Screenshot_2024-12-30_16-08-35](https://github.com/user-attachments/assets/9bdf579d-f3fd-459d-8c98-af236b73309a)

New behavior:

![Screenshot_2024-12-30_16-06-31](https://github.com/user-attachments/assets/1572b8ee-1213-4b61-85b9-ab6d24bb874b)




