### PR TITLE
Update __init__.py to prevent changes to caller's headers dict

### DIFF
--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -46,6 +46,8 @@ def request(
 ):
     if headers is None:
         headers = {}
+    else:
+        headers = headers.copy()    # local copy so we don't extend caller's
 
     redirect = None  # redirection url, None means no redirection
     chunked_data = data and getattr(data, "__next__", None) and not getattr(data, "__len__", None)


### PR DESCRIPTION
The Micropython version of urequests behaves differently to Python's in that if a **headers** dict is passed in it gets extended by entries such as Content-Length that are added to the caller's dict.

Change is to take a local copy of any headers passed in to urequests() otherwise the caller's **headers** gets incorrectly extended.

The snip below illustrates the problem.

```
import urequests as requests
# test to demonstrate that micropython urequest incorrectly modifies passed headers dict
headers = {}

response = requests.patch(
            url="http://www.google.com",
            headers=headers,
            data="string",
        )
assert headers == {}, "urequests returned changed headers to parent"
```

