### PR TITLE
requests: ensure requests use local copy of headers dict.

### DIFF
--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -46,6 +46,8 @@ def request(
 ):
     if headers is None:
         headers = {}
+    else:
+        headers = headers.copy()    # local copy so we don't extend caller's
 
     redirect = None  # redirection url, None means no redirection
     chunked_data = data and getattr(data, "__next__", None) and not getattr(data, "__len__", None)

--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -47,7 +47,7 @@ def request(
     if headers is None:
         headers = {}
     else:
-        headers = headers.copy()    # local copy so we don't extend caller's
+        headers = headers.copy()
 
     redirect = None  # redirection url, None means no redirection
     chunked_data = data and getattr(data, "__next__", None) and not getattr(data, "__len__", None)


### PR DESCRIPTION
Currently requests() only creates a local copy of headers() if no headers dict is passed in. This means that any headers dict passed in will have extra entries added incorrectly. The code snip below illustrates the problem:
```
import requests
# test to demonstrate that micropython urequest incorrectly modifies called headers
headers = {}

response = requests.get(
            url="http://www.google.com",
            headers=headers,
            data="string",
        )
print(headers)
assert headers == {}, "requests returned changed headers to parent"
```
This fix uses a copy of the called headers to process the actual request.