### PR TITLE
micropython/mip: Allow relative URLs in package.json files.

### DIFF
--- a/micropython/mip/manifest.py
+++ b/micropython/mip/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.3.0", description="On-device package installer for network-capable boards")
+metadata(version="0.4.0", description="On-device package installer for network-capable boards")
 
 require("requests")
 


### PR DESCRIPTION
This PR allows URLs in package.json files to be specified relative to the directory containing the `package.json` file. This mirrors the functionality added to mpremote in [micropython:#12477](https://github.com/micropython/micropython/pull/12477).

This simplifies use of mip packages from forked or copied repos.

Example package.json:

```
{
    "urls": [
        ["ota/rollback.py", "rollback.py"],
        ["ota/status.py", "status.py"],
        ["ota/update.py", "update.py"],
        ["ota/blockdev_writer.py", "blockdev_writer.py"]
    ],
    "deps": [
    ],
    "version": "0.2"
}
```