### PR TITLE
mip: Make mip.install() skip /rom*/lib directories.

### DIFF
--- a/micropython/mip/manifest.py
+++ b/micropython/mip/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.4.0", description="On-device package installer for network-capable boards")
+metadata(version="0.4.1", description="On-device package installer for network-capable boards")
 
 require("requests")
 

--- a/micropython/mip/mip/__init__.py
+++ b/micropython/mip/mip/__init__.py
@@ -171,7 +171,7 @@ def _install_package(package, index, target, version, mpy):
 def install(package, index=None, target=None, version=None, mpy=True):
     if not target:
         for p in sys.path:
-            if p.endswith("/lib"):
+            if not p.startswith("/rom") and p.endswith("/lib"):
                 target = p
                 break
         else:


### PR DESCRIPTION
If a ROMFS is mounted then "/rom/lib" is usually in `sys.path` before the writable filesystem's "lib" entry.  The ROMFS directory cannot be installed to, so skip it if found.

Tested on PYBD_SF2.

Prior to this PR:
```
>>> import mip
>>> mip.install('unittest')
Installing unittest (latest) from https://micropython.org/pi/v2 to /rom/lib
Copying: /rom/lib/unittest/__init__.mpy
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mip/__init__.py", line 1, in install
  File "mip/__init__.py", line 1, in _install_package
  File "mip/__init__.py", line 1, in _install_json
  File "mip/__init__.py", line 1, in _download_file
  File "mip/__init__.py", line 1, in _ensure_path_exists
AttributeError: 'VfsRom' object has no attribute 'mkdir'
```
With this PR applied:
```
>>> import sys
>>> sys.path
['', '.frozen', '/rom', '/rom/lib', '/flash', '/flash/lib']
>>> import mip
>>> mip.install('unittest')
Installing unittest (latest) from https://micropython.org/pi/v2 to /flash/lib
Exists: /flash/lib/unittest/__init__.mpy
Done
```