### PR TITLE
usb/cdc: writing small blocks should not require allocation

### DIFF
--- a/micropython/usb/usb-device-cdc/manifest.py
+++ b/micropython/usb/usb-device-cdc/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.1")
+metadata(version="0.1.2")
 require("usb-device")
 package("usb")

--- a/micropython/usb/usb-device-cdc/usb/device/cdc.py
+++ b/micropython/usb/usb-device-cdc/usb/device/cdc.py
@@ -350,10 +350,9 @@ class CDCInterface(io.IOBase, Interface):
     ###
 
     def write(self, buf):
-        # use a memoryview to track how much of 'buf' we've written so far
-        # (unfortunately, this means a 1 block allocation for each write, but it's otherwise allocation free.)
         start = time.ticks_ms()
-        mv = memoryview(buf)
+        mv = buf
+
         while True:
             # Keep pushing buf into _wb into it's all gone
             nbytes = self._wb.write(mv)
@@ -362,6 +361,10 @@ class CDCInterface(io.IOBase, Interface):
             if nbytes == len(mv):
                 return len(buf)  # Success
 
+            # if buf couldn't be fully written on the first attempt
+            # convert it to a memoryview to track partial writes
+            if mv is buf:
+                mv = memoryview(buf)
             mv = mv[nbytes:]
 
             # check for timeout


### PR DESCRIPTION
Only allocate a memoryview when the (first) write was partial.