### PR TITLE
unix-ffi/machine/timer: Use libc if librt is not present

### DIFF
--- a/unix-ffi/machine/machine/timer.py
+++ b/unix-ffi/machine/machine/timer.py
@@ -5,7 +5,10 @@ import os
 from signal import *
 
 libc = ffilib.libc()
-librt = ffilib.open("librt")
+try:
+    librt = ffilib.open("librt")
+except OSError as e:
+    librt = libc
 
 CLOCK_REALTIME = 0
 CLOCK_MONOTONIC = 1

--- a/unix-ffi/machine/manifest.py
+++ b/unix-ffi/machine/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.1")
+metadata(version="0.2.2")
 
 # Originally written by Paul Sokolovsky.
 


### PR DESCRIPTION
Newer implementations of libc integrate the functions from librt, for example glibc since 2.17 and uClibc-ng. So if the librt.so cannot be loaded, it can be assumed that libc contains the expected functions.