### PR TITLE
inspect: Fix isgenerator logic.

### DIFF
--- a/python-stdlib/inspect/inspect.py
+++ b/python-stdlib/inspect/inspect.py
@@ -25,6 +25,11 @@ def isgenerator(obj):
     return isinstance(obj, type((_g)()))
 
 
+# In MicroPython there's currently no way to distinguish between generators and coroutines.
+iscoroutinefunction = isgeneratorfunction
+iscoroutine = isgenerator
+
+
 class _Class:
     def meth():
         pass

--- a/python-stdlib/inspect/inspect.py
+++ b/python-stdlib/inspect/inspect.py
@@ -1,5 +1,7 @@
 import sys
 
+_g = lambda: (yield)
+
 
 def getmembers(obj, pred=None):
     res = []
@@ -16,11 +18,11 @@ def isfunction(obj):
 
 
 def isgeneratorfunction(obj):
-    return isinstance(obj, type(lambda: (yield)))
+    return isinstance(obj, type(_g))
 
 
 def isgenerator(obj):
-    return isinstance(obj, type(lambda: (yield)()))
+    return isinstance(obj, type((_g)()))
 
 
 class _Class:

--- a/python-stdlib/inspect/manifest.py
+++ b/python-stdlib/inspect/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.2")
+metadata(version="0.1.3")
 
 module("inspect.py")

--- a/python-stdlib/inspect/test_inspect.py
+++ b/python-stdlib/inspect/test_inspect.py
@@ -44,6 +44,12 @@ class TestInspect(unittest.TestCase):
     def test_isgenerator(self):
         self._test_is_helper(inspect.isgenerator, entities[2])
 
+    def test_iscoroutinefunction(self):
+        self._test_is_helper(inspect.iscoroutinefunction, entities[1])
+
+    def test_iscoroutine(self):
+        self._test_is_helper(inspect.iscoroutine, entities[2])
+
     def test_ismethod(self):
         self._test_is_helper(inspect.ismethod, entities[5])
 

--- a/python-stdlib/inspect/test_inspect.py
+++ b/python-stdlib/inspect/test_inspect.py
@@ -1,0 +1,54 @@
+import inspect
+import unittest
+
+
+def fun():
+    return 1
+
+
+def gen():
+    yield 1
+
+
+class Class:
+    def meth(self):
+        pass
+
+
+entities = (
+    fun,
+    gen,
+    gen(),
+    Class,
+    Class.meth,
+    Class().meth,
+    inspect,
+)
+
+
+class TestInspect(unittest.TestCase):
+    def _test_is_helper(self, f, *entities_true):
+        for entity in entities:
+            result = f(entity)
+            if entity in entities_true:
+                self.assertTrue(result)
+            else:
+                self.assertFalse(result)
+
+    def test_isfunction(self):
+        self._test_is_helper(inspect.isfunction, entities[0], entities[4])
+
+    def test_isgeneratorfunction(self):
+        self._test_is_helper(inspect.isgeneratorfunction, entities[1])
+
+    def test_isgenerator(self):
+        self._test_is_helper(inspect.isgenerator, entities[2])
+
+    def test_ismethod(self):
+        self._test_is_helper(inspect.ismethod, entities[5])
+
+    def test_isclass(self):
+        self._test_is_helper(inspect.isclass, entities[3])
+
+    def test_ismodule(self):
+        self._test_is_helper(inspect.ismodule, entities[6])

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -86,6 +86,7 @@ function ci_package_tests_run {
         python-stdlib/datetime \
         python-stdlib/fnmatch \
         python-stdlib/hashlib \
+        python-stdlib/inspect \
         python-stdlib/pathlib \
         python-stdlib/quopri \
         python-stdlib/shutil \


### PR DESCRIPTION
Fix the `isgenerator()` logic.

Also optimise both `isgenerator()` and `isgeneratorfunction()` so they use the same lambda, and don't have to create it each time they are called.

And add some basic unit tests for this package.

Fixes issue #997.
    
