### PR TITLE
abc: add ABC base class

### DIFF
--- a/python-stdlib/abc/abc.py
+++ b/python-stdlib/abc/abc.py
@@ -1,2 +1,6 @@
+class ABC:
+    pass
+
+
 def abstractmethod(f):
     return f

--- a/python-stdlib/abc/manifest.py
+++ b/python-stdlib/abc/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.0.1")
+metadata(version="0.1.0")
 
 module("abc.py")


### PR DESCRIPTION
this trivial addition will allow less code differences between standard python classes and micropython code.