### PR TITLE
micropython/aiorepl: Use blocking reads for raw_repl.

### DIFF
--- a/micropython/aiorepl/manifest.py
+++ b/micropython/aiorepl/manifest.py
@@ -1,5 +1,5 @@
 metadata(
-    version="0.2.0",
+    version="0.2.1",
     description="Provides an asynchronous REPL that can run concurrently with an asyncio, also allowing await expressions.",
 )
 


### PR DESCRIPTION
raw repl mode is generally  used as a command channel where all stdio traffic is related directly to the raw commands and responses sent. 

For this to work in aiorepl we need to ensure background tasks don't sent/receive anything on stdio else the command channel will be corrupted.

The simplest way to achieve this is to make the raw commands blocking rather than asyncio, assuming the user wont leave the device in raw mode for too long at any one time.