### PR TITLE
aioble: Raise correct error if l2cap disconnects in middle of send.

### DIFF
--- a/micropython/bluetooth/aioble/aioble/l2cap.py
+++ b/micropython/bluetooth/aioble/aioble/l2cap.py
@@ -141,6 +141,7 @@ class L2CAPChannel:
             if self._stalled:
                 await self.flush(timeout_ms)
             # l2cap_send returns True if you can send immediately.
+            self._assert_connected()
             self._stalled = not ble.l2cap_send(
                 self._connection._conn_handle,
                 self._cid,


### PR DESCRIPTION
When using aioble/l2cap to send data from micropython to a cental like a phone, if the ble disconnects in the middle of a send process it can currently fail with the exception:
``` python
Traceback (most recent call last):
  File "aioble/l2cap.py", line 147, in send
TypeError: can't convert NoneType to int
```

This is because the send function is operating in a loop sending the data in chunks. 
At the top of the function `self._assert_connected()` is already called which will raise a `L2CAPDisconnectedError` if the connection has already been dropped (as detected by `self._cid is None` however the chunk send loop can run for some time, a disconnect in the middle of this results in `self._cid = None` being passed to `ble.l2cap_send()` resulting in the exception above.

This PR simply adds the correct connection check immediately before each loop of `l2cap_send()`.