### PR TITLE
aiorepl: Fix Enter key handling in raw terminal mode

### DIFF
--- a/micropython/aiorepl/manifest.py
+++ b/micropython/aiorepl/manifest.py
@@ -1,5 +1,5 @@
 metadata(
-    version="0.2.2",
+    version="0.2.3",
     description="Provides an asynchronous REPL that can run concurrently with an asyncio, also allowing await expressions.",
 )
 


### PR DESCRIPTION
## Summary
Fix aiorepl to properly handle the Enter key when stdin is in raw terminal mode by accepting both CR (0x0D) and LF (0x0A) for command execution.

## Problem
When using aiorepl with MicroPython ports that put stdin in raw mode (such as the updated unix port using pyexec), the Enter key sends CR (0x0D) instead of LF (0x0A). The original aiorepl only handled LF, requiring users to use Ctrl+Enter instead of Enter to execute commands.

## Solution
- Handle both CR (0x0D) and LF (0x0A) for command execution
- Improve handling of various newline sequences (CRLF, double-LF, double-CR) to prevent double-execution
- Preserve original behavior in paste mode

## Test plan
- [x] Verify Enter key now executes commands in raw terminal mode
- [x] Verify CRLF sequences don't cause double-execution
- [x] Verify paste mode still works correctly
- [x] Test with unix MicroPython port using new pyexec REPL

🤖 Generated with [Claude Code](https://claude.ai/code)