### PR TITLE
logging: Allow logging.exception helper to handle tracebacks.

### DIFF
--- a/python-stdlib/logging/logging.py
+++ b/python-stdlib/logging/logging.py
@@ -202,8 +202,8 @@ def critical(msg, *args):
     getLogger().critical(msg, *args)
 
 
-def exception(msg, *args):
-    getLogger().exception(msg, *args)
+def exception(msg, *args, exc_info=True):
+    getLogger().exception(msg, *args, exc_info=exc_info)
 
 
 def shutdown():

--- a/python-stdlib/logging/manifest.py
+++ b/python-stdlib/logging/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.6.1")
+metadata(version="0.6.2")
 
 module("logging.py")


### PR DESCRIPTION
Although `Logger.exception` supports passing exception info with `exc_info`, when you use `logging.exception`, keyword arguments are not forwarded to the root logger, which makes passing `exc_info` raise TypeError.