### PR TITLE
aiorepl: Handle stream shutdown.

### DIFF
--- a/micropython/aiorepl/aiorepl.py
+++ b/micropython/aiorepl/aiorepl.py
@@ -114,6 +114,8 @@ async def task(g=None, prompt="--> "):
             curs = 0  # cursor offset from end of cmd buffer
             while True:
                 b = await s.read(1)
+                if not b:  # Handle EOF/empty read
+                    break
                 pc = c  # save previous character
                 c = ord(b)
                 pt = t  # save previous time


### PR DESCRIPTION
Resolves errors when a stream is closed like:
```
--> 
Traceback (most recent call last):
  File "aiorepl.py", line 118, in task
TypeError: ord() expected a character, but string of length 0 found
```