### PR TITLE
pathlib: Fix glob() to return Path objects rather than strings.

### DIFF
--- a/python-stdlib/pathlib/pathlib.py
+++ b/python-stdlib/pathlib/pathlib.py
@@ -126,7 +126,7 @@ class Path:
         for name, mode, *_ in os.ilistdir(path):
             full_path = path + _SEP + name
             if name.startswith(prefix) and name.endswith(suffix):
-                yield full_path
+                yield Path(full_path)
             if recursive and mode & 0x4000:  # is_dir
                 yield from self._glob(full_path, pattern, recursive=recursive)
 


### PR DESCRIPTION
Fix glob() to return Path objects rather than bare strings, same as CPython https://docs.python.org/3/library/pathlib.html#pathlib.Path.glob