### PR TITLE
usb-device-hid: Fix boot protocol config in descriptor, default protocol mode, and protocol mode recover.

### DIFF
--- a/micropython/usb/usb-device-hid/manifest.py
+++ b/micropython/usb/usb-device-hid/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.1")
+metadata(version="0.1.2")
 require("usb-device")
 package("usb")

--- a/micropython/usb/usb-device-hid/usb/device/hid.py
+++ b/micropython/usb/usb-device-hid/usb/device/hid.py
@@ -207,6 +207,8 @@ class HIDInterface(Interface):
                     if desc_type == _DESC_HID_TYPE:
                         return self.get_hid_descriptor()
                     if desc_type == _DESC_REPORT_TYPE:
+                        # Reset to report protocol when report descriptor is requested
+                        self.protocol = 1
                         return self.report_descriptor
             elif req_type == _REQ_TYPE_CLASS:
                 # HID Spec p50: 7.2 Class-Specific Requests


### PR DESCRIPTION
Set the subclass value of the HID interface descriptor according to the supported interface protocol specified. Therefore BIOS will enumerate the keyboard.

The default interface protocol is set to report protocol according to the specification.

Since BIOS doesn't depend on the HID report descriptor, reset the device to report protocol when the report descriptor is read.

This is tested with a laptop and a RP2040 board with mpy 1.25.0 official release.

I use this to implement a NKRO keyboard with boot protocol support.

---

My understanding of 2 protocols:

- Boot protocol: device acts like a predefined HID device, regardless of the report descriptor.
- Report protocol: device acts just like what its report descriptor says.