### PR TITLE
umqtt.simple: Add unsubscribe method.

### DIFF
--- a/micropython/umqtt.simple/README.rst
+++ b/micropython/umqtt.simple/README.rst
@@ -53,6 +53,7 @@ follows MQTT control operations, and maps them to class methods:
 * ``ping()`` - Ping server (response is processed automatically by wait_msg()).
 * ``publish()`` - Publish a message.
 * ``subscribe()`` - Subscribe to a topic.
+* ``unsubscribe()`` - Unsubscribe to a topic.
 * ``set_callback()`` - Set callback for received subscription messages.
 * ``set_last_will()`` - Set MQTT "last will" message. Should be called
   *before* connect().

--- a/micropython/umqtt.simple/manifest.py
+++ b/micropython/umqtt.simple/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="Lightweight MQTT client for MicroPython.", version="1.6.0")
+metadata(description="Lightweight MQTT client for MicroPython.", version="1.7.0")
 
 # Originally written by Paul Sokolovsky.
 


### PR DESCRIPTION
This PR adds the missing unsubscribe method for the umqtt.simple lib. 

This should close #512 and #197

**Considerations**
Works for MQTT 3.1.1