### PR TITLE
[lora-sx126x,lora-sx127x]: Add dependencies for sync/async modems.

### DIFF
--- a/micropython/lora/lora/lora/__init__.py
+++ b/micropython/lora/lora/lora/__init__.py
@@ -5,6 +5,12 @@ from .modem import RxPacket  # noqa: F401
 
 ok = False  # Flag if at least one modem driver package is installed
 
+
+def _can_ignore_error(e):
+    """Check if ImportError can be ignored due to missing module."""
+    return all(x in str(e) for x in ["no module named", "lora"])
+
+
 # Various lora "sub-packages"
 
 try:
@@ -12,7 +18,7 @@ try:
 
     ok = True
 except ImportError as e:
-    if "no module named 'lora." not in str(e):
+    if not _can_ignore_error(e):
         raise
 
 try:
@@ -20,7 +26,7 @@ try:
 
     ok = True
 except ImportError as e:
-    if "no module named 'lora." not in str(e):
+    if not _can_ignore_error(e):
         raise
 
 try:
@@ -28,7 +34,7 @@ try:
 
     ok = True
 except ImportError as e:
-    if "no module named 'lora." not in str(e):
+    if not _can_ignore_error(e):
         raise
 
 


### PR DESCRIPTION
## Problem
When installing `lora-sx126x` or `lora-sx127x` packages via mip, users will generally install only one of them (either SyncModem or AsyncModem wrapper classes), and this can lead to runtime errors.

When handling import in `lora/__init__.py`, an `ImportError` would can be incorrectly raised when the error message contained `lib.lora` instead of just `lora`.

I noticed this after installing the `lora-sx1262` package via `Thonny` package manager.

## Solution
To fix the import problem, I added an extra check to prevent this from happening by checking if the error message contains both "no module named", and "lora". Since the check was the same for all imports, I centralized the check in a function.

## Testing
Install the package and verify the modem classes are available:
```python
import mip
mip.install("lora-sx126x")
from lora import SX1262, AsyncSX1262  # Should work now
```