### PR TITLE
python-stdlib: Add typing modules that can be frozen or mip installable.

### DIFF
--- a/micropython/bundles/bundle-typing/manifest.py
+++ b/micropython/bundles/bundle-typing/manifest.py
@@ -1,0 +1,26 @@
+# type: ignore[all]
+# Bundle to simplify including typing support in MicroPython projects.
+# This is not a full implementation of the typing module, but balances
+# functionality with code size, while ignoring type hints at runtime
+# to save resources.
+# Usage:
+# require("bundle-typing")
+# require("bundle-typing", extensions=True)
+
+metadata(
+    version="1.0.0",
+    description="Limited runtime typing support for MicroPython.",
+)
+
+options.defaults(opt_level=3, extensions=False)
+
+# Primary typing related modules
+require("__future__", opt_level=options.opt_level)
+require("typing", opt_level=options.opt_level)
+require("typing_extensions", opt_level=options.opt_level)
+
+# Optional typing modules
+if options.extensions:
+    require("collections", opt_level=options.opt_level)
+    require("collections-abc", opt_level=options.opt_level)
+    require("abc", opt_level=options.opt_level)

--- a/python-stdlib/__future__/manifest.py
+++ b/python-stdlib/__future__/manifest.py
@@ -1,3 +1,5 @@
-metadata(version="0.1.0")
+metadata(version="0.1.1")
 
-module("__future__.py")
+options.defaults(opt_level=3)
+
+module("__future__.py", opt=options.opt_level)

--- a/python-stdlib/abc/abc.py
+++ b/python-stdlib/abc/abc.py
@@ -1,6 +1,14 @@
+# type: ignore
 class ABC:
     pass
 
 
-def abstractmethod(f):
-    return f
+def abstractmethod(arg):
+    return arg
+
+try:
+    # add functionality if typing module is available
+    from typing import __getattr__ as __getattr__
+
+except: # naked except saves 4 bytes
+    pass

--- a/python-stdlib/abc/manifest.py
+++ b/python-stdlib/abc/manifest.py
@@ -1,3 +1,6 @@
-metadata(version="0.1.0")
+metadata(version="0.2.0")
 
-module("abc.py")
+options.defaults(opt_level=3)
+module("abc.py", opt=options.opt_level)
+
+require("typing")

--- a/python-stdlib/collections-abc/collections/abc.py
+++ b/python-stdlib/collections-abc/collections/abc.py
@@ -1,0 +1,7 @@
+# collections.abc
+# minimal support for runtime typing
+# type: ignore
+try:
+    from typing import __Ignore as ABC, __getattr__ as __getattr__
+except:
+    pass

--- a/python-stdlib/collections-abc/manifest.py
+++ b/python-stdlib/collections-abc/manifest.py
@@ -1,0 +1,6 @@
+metadata(version="1.0.0", description="Collections ABC module for MicroPython.")
+
+require("collections")
+
+require("typing")
+package("collections")

--- a/python-stdlib/collections/collections/__init__.py
+++ b/python-stdlib/collections/collections/__init__.py
@@ -6,6 +6,14 @@ try:
     from .defaultdict import defaultdict
 except ImportError:
     pass
+# optional collections.abc typing dummy module
+try:
+    # cannot use relative import here
+    import collections.abc as abc
+    import sys
+    sys.modules['collections.abc'] = abc
+except ImportError:
+    pass
 
 
 class MutableMapping:

--- a/python-stdlib/typing/manifest.py
+++ b/python-stdlib/typing/manifest.py
@@ -1,0 +1,8 @@
+# type: ignore
+
+metadata(version="1.0.0", description="Typing module for MicroPython.")
+
+# default to opt_level 3 for minimal firmware size
+options.defaults(opt_level=3)
+
+module("typing.py", opt=options.opt_level)

--- a/python-stdlib/typing/typing.py
+++ b/python-stdlib/typing/typing.py
@@ -1,0 +1,111 @@
+"""
+This module provides runtime support for type hints.
+based on : 
+- https://github.com/micropython/micropython-lib/pull/584
+- https://github.com/Josverl/micropython-stubs/tree/main/mip
+- https://github.com/Josverl/rt_typing
+
+"""
+
+# -------------------------------------
+# code reduction by Ignoring type hints
+# -------------------------------------
+class __Ignore:
+    """A class to ignore type hints in code."""
+
+    def __call__(*keys, **values):
+        # May need some guardrails here
+        pass
+
+    def __getitem__(self, key):
+        # May need some guardrails here
+        return __ignore
+
+    def __getattr__(self, key):
+        return self.__dict__.get(key, __ignore)
+
+
+__ignore = __Ignore()
+# -----------------
+# typing essentials
+# -----------------
+TYPE_CHECKING = False
+def reveal_type(value):
+    return value
+
+override = final = reveal_type # saves bytes, and is semantically similar
+
+# def overload(arg):  # ( 27 bytes)
+#     # ignore functions signatures with @overload decorator
+#     return None
+overload = __ignore # saves bytes, and is semantically similar
+
+def NewType(_, value):  # (21 bytes)
+    # https://docs.python.org/3/library/typing.html#newtype
+    # MicroPython: just use the original type.
+    return value
+
+def TypeVar(key, *types, bound = None, covariant=False, contravariant=False, infer_variance=False):
+    return key
+# ---------------
+#  useful methods
+# ---------------
+# is semantically similar
+TypeVarTuple = final
+
+# https://docs.python.org/3/library/typing.html#typing.cast
+# def cast(type, arg):  # ( 23 bytes)
+#     return arg
+cast = NewType # saves bytes, and is semantically similar
+
+# https://docs.python.org/3/library/typing.html#typing.no_type_check
+# def no_type_check(arg):  # ( 26 bytes)
+#     # decorator to disable type checking on a function or method
+#     return arg
+no_type_check = final # saves bytes, and is semantically similar
+
+# -----------------
+# less used methods
+# -----------------
+
+# def reveal_type(x):  # ( 38 bytes)
+# #     # https://docs.python.org/3/library/typing.html#typing.reveal_type
+#     return x
+# or for smaller size:
+reveal_type = final # saves bytes, and is semantically similar
+
+# The get_origin behaviour is # already implemented by the __getattr__ 
+# method of __Ignore, which passes the current test suite.
+
+# def get_origin(type):  # ( 23 bytes)
+#     # https://docs.python.org/3/library/typing.html#typing.get_origin
+#     #  Return None for all unsupported objects.
+#     return None
+
+
+def get_args(_):  # ( 22 bytes)
+    # https://docs.python.org/3/library/typing.html#typing.get_args
+    # Python 3.8+ only
+    return ()
+
+# https://typing.python.org/en/latest/spec/typeddict.html
+# make TypedDict dict-like at runtime.
+TypedDict = dict 
+
+class IO:
+    pass
+class TextIO:
+    pass
+class BinaryIO:
+    pass
+
+AnyStr=str
+
+# ref: https://github.com/micropython/micropython-lib/pull/584#issuecomment-2317690854
+def __getattr__(key):
+    return __ignore
+
+# snarky way to alias typing_extensions to typing ( saving 59 bytes)
+import sys
+sys.modules["typing_extensions"] = sys.modules["typing"]
+del sys

--- a/python-stdlib/typing_extensions/manifest.py
+++ b/python-stdlib/typing_extensions/manifest.py
@@ -1,0 +1,10 @@
+metadata(version="1.0.0", description="Backport of typing_extensions for MicroPython.")
+
+
+# default to opt_level 3 for minimal firmware size
+options.defaults(opt_level=3)
+
+module("typing_extensions.py", opt=options.opt_level)
+package("typing_extensions")
+
+require("typing")

--- a/python-stdlib/typing_extensions/typing_extensions.py
+++ b/python-stdlib/typing_extensions/typing_extensions.py
@@ -1,0 +1,8 @@
+# typing_extensions.py
+# type: ignore
+import typing
+
+# snarky way to alias typing_extensions to typing as import * won't work
+import sys
+sys.modules["typing_extensions"] = sys.modules["typing"]
+del sys

--- a/python-stdlib/unittest/manifest.py
+++ b/python-stdlib/unittest/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.10.5")
+metadata(version="0.11.0")
 
 package("unittest")

--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -228,14 +228,21 @@ def skipUnless(cond, msg):
     return skip(msg)
 
 
+class _ExpectedFailure(Exception):
+    pass
+
+
+class _UnexpectedSuccess(Exception):
+    pass
+
+
 def expectedFailure(test):
     def test_exp_fail(*args, **kwargs):
         try:
             test(*args, **kwargs)
-        except:
-            pass
-        else:
-            assert False, "unexpected success"
+        except Exception:
+            raise _ExpectedFailure
+        raise _UnexpectedSuccess
 
     return test_exp_fail
 
@@ -270,12 +277,29 @@ class TestRunner:
         res.printErrors()
         print("----------------------------------------------------------------------")
         print("Ran %d tests\n" % res.testsRun)
-        if res.failuresNum > 0 or res.errorsNum > 0:
-            print("FAILED (failures=%d, errors=%d)" % (res.failuresNum, res.errorsNum))
+        extras = []
+        if res.skippedNum > 0:
+            extras.append("skipped=%d" % res.skippedNum)
+        if res.expectedFailuresNum > 0:
+            extras.append("expected failures=%d" % res.expectedFailuresNum)
+        if res.unexpectedSuccessesNum > 0:
+            extras.append("unexpected successes=%d" % res.unexpectedSuccessesNum)
+        if (res.failuresNum + res.errorsNum + res.unexpectedSuccessesNum) > 0:
+            parts = [
+                "failures=%d" % res.failuresNum,
+                "errors=%d" % res.errorsNum,
+            ]
+            if res.unexpectedSuccessesNum > 0:
+                parts.append("unexpected successes=%d" % res.unexpectedSuccessesNum)
+            if res.expectedFailuresNum > 0:
+                parts.append("expected failures=%d" % res.expectedFailuresNum)
+            if res.skippedNum > 0:
+                parts.append("skipped=%d" % res.skippedNum)
+            print("FAILED (%s)" % ", ".join(parts))
         else:
             msg = "OK"
-            if res.skippedNum > 0:
-                msg += " (skipped=%d)" % res.skippedNum
+            if extras:
+                msg += " (%s)" % ", ".join(extras)
             print(msg)
 
         return res
@@ -289,14 +313,22 @@ class TestResult:
         self.errorsNum = 0
         self.failuresNum = 0
         self.skippedNum = 0
+        self.expectedFailuresNum = 0
+        self.unexpectedSuccessesNum = 0
         self.testsRun = 0
         self.errors = []
         self.failures = []
         self.skipped = []
+        self.expectedFailures = []
+        self.unexpectedSuccesses = []
         self._newFailures = 0
 
     def wasSuccessful(self):
-        return self.errorsNum == 0 and self.failuresNum == 0
+        return (
+            self.errorsNum == 0
+            and self.failuresNum == 0
+            and self.unexpectedSuccessesNum == 0
+        )
 
     def printErrors(self):
         if self.errors or self.failures:
@@ -325,10 +357,14 @@ class TestResult:
         self.errorsNum += other.errorsNum
         self.failuresNum += other.failuresNum
         self.skippedNum += other.skippedNum
+        self.expectedFailuresNum += other.expectedFailuresNum
+        self.unexpectedSuccessesNum += other.unexpectedSuccessesNum
         self.testsRun += other.testsRun
         self.errors.extend(other.errors)
         self.failures.extend(other.failures)
         self.skipped.extend(other.skipped)
+        self.expectedFailures.extend(other.expectedFailures)
+        self.unexpectedSuccesses.extend(other.unexpectedSuccesses)
         return self
 
 
@@ -352,6 +388,19 @@ def _handle_test_exception(
         test_result.skippedNum += 1
         test_result.skipped.append((current_test, reason))
         print(" skipped:", reason)
+        return
+    elif isinstance(exc, _ExpectedFailure):
+        test_result.expectedFailuresNum += 1
+        test_result.expectedFailures.append((current_test, ""))
+        if verbose:
+            print(" expected failure")
+        return
+    elif isinstance(exc, _UnexpectedSuccess):
+        test_result.unexpectedSuccessesNum += 1
+        test_result.unexpectedSuccesses.append((current_test, ""))
+        if verbose:
+            print(" unexpected success")
+        test_result._newFailures += 1
         return
     elif isinstance(exc, AssertionError):
         test_result.failuresNum += 1

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -174,7 +174,12 @@ function ci_push_package_index {
 
     cp -r ${PACKAGE_INDEX_PATH}/* .
 
+    # Disable Jekyll processing to avoid excluding files with a _ prefix.
+    # (e.g. the "__future__" package)
+    touch ${PAGES_PATH}/.nojekyll
+
     git add .
+    git -C ${PAGES_PATH} add .nojekyll
     git_bot_commit "Add CI built packages from commit ${GITHUB_SHA} of ${GITHUB_REF_NAME}"
 
     if [ "$NEW_BRANCH" -eq 0 ]; then


### PR DESCRIPTION
As this PR have changed very significantly I have completely rewritten the PR Description. 
The old description can be found at the end.


This is a MicroPython alternative to: 
 - the C-based minimal typing module proposed in micropython/micropython#15911
 - the MicroPython Py-based typing module proposed in micropython/micropython-lib#584
 - MicroPython-Stubs typing modules https://github.com/Josverl/micropython-stubs/tree/main/mip#micropythons-typingmpy-module

based on all the above and tuned for reduced firmware/frozen size, while keeping provable consistence with the relevant typing PEPs for features that are supported by MicroPython. 
 
It consists of a number of modules that can be mip-installed  or frozen as part of a firmware..  
Note that the modules have been optimized for size - somewhat impacting readability - but where relevant the orignal code has been kept as comments.

For other related changes see later in this section.

Fixes: #190
Closes: micropython/micropython#15911
Closes:  micropython/micropython-lib#584

I want to explicitly recognize that this work is in part based on and inspired the work by in PRs @stinos and @andrewleech and other individuals that have directly contributed to the typing stubs on the MicroPython-Stubs repo.

### Summary of the modules:
- `__future__` : contains the `annotations` feature, which allows for postponed evaluation
- `typing` : contains the core typing features, such as `TypeVar`, `Generic`, `Protocol`, `Union`, `Optional`, `Callable` and more.
- `typing_extensions` : features that are/were not yet part of the standard library for Python 3.4/3.5.
- `collections.abc` : contains the abstract base classes for collections, such as `Iterable`, `Sequence`, `Mapping` and more.
- `abc` : contains the `ABC` and `abstractmethod` features, while they are deprecated in Python 3.11, they are still relevant.

### Implementation details:

The `__future__` already existed as a basic list of assignments, and has been extended with only the `annotations` feature.

In order to save space in the firmware or on the file system the `typing` module uses a module level `__getattr__` to lazily load the features of the module, rather than implement each typing class, method or decorator in detail. Care has been taken to match the runtime signatures of the CPython/Micropythn runtime , and reduce runtime overhead as much as possible. 

The `typing_extensions`, `abc` and `collections.abc` modules re-use the same `__getattr__` from the `typing` module and also include only limited implementations, again to save space.

each module can be frozen or installed individually, it will automatically pull in any required dependencies.

In order to further simplify installation or freezing a `bundle-typing` has been created that contains:
- `__future__`
- `typing`
- `typing_extensions`
And optionally ( extensions=true ) also:
- `abc`
- `collections.abc`

The bundle also set the `opt_level` to 3, which will further reduce the size of the modules, but may impact readability of tracebacks.

```py
# typing related modules
require(
    "bundle-typing",
    # extensions=False,  # Set to True to include collections.abc
    # opt_level=3,
)
```

## Install from this PR:
The modules can be installed from this PR using the following command:
```sh
# install the bundle-typing 
mpremote mip install --index https://josverl.github.io/micropython-lib/mip/add_typing_py bundle-typing
# or each module individually
mpremote mip install --index https://josverl.github.io/micropython-lib/mip/add_typing_py __future__ typing typing_extensions collections-abc abc

# unittest 0.11.0
mpremote mip install --index https://josverl.github.io/micropython-lib/mip/add_typing_py unittest
```
( **Do** try this at home :-) 

### Testing:

I have spent perhaps more time on creating the tests than on the implementation, as I wanted to make sure that the implementation is consistent with the relevant PEPs and also to have a good coverage of the implemented features.
Currently there are 187 typing runtime tests, which are based on:
- The examples provided in the relevant PEPs, such as PEP 484, PEP 544, PEP 560 and more.
- A number of tests from the CPython test suite, such as `test_typing` and `test_typing_extensions`.
- Existing tests created for the MicroPython-stubs project
- AI generated, hand curated, tests for edge cases and features that are not covered by the above sources.
- A report generator that uses the existing test results to simplify comparison of the different implementations and variants.


## Tests and test results

- Tests for all typing modules are located in `micropython:tests/typing_runtime`
- A tests for the new functionality of `unittest` has been added to `micropython-lib:python-stdlib/unittest/tests`


### Test matrix
in order to compare the different optionas for implementation on both size and functionaly the followin variants have been tested:


Variant | Description
--------|--------------
standard | MicroPython unix standard variant. no typing modules.
1_mp-stubs | standard + frozen MicroPython-stubs implementation of the typing modules, which is a pure Python implementation that is not optimized for size.
2a_typing | standard + frozen `require("typing")` from this PR, which is optimized for size and uses lazy loading.
2b_bundle_typing_S | standard + frozen `require("bundle-typing")` which includes  the core typing features and is optimized for size.
2c_bundle_typing_L | standard + frozen `require("bundle-typing", extensions=True)` with which includes all typing modules and is optimized for size.
3_builtintypingmodule | the C-implementation of the typing module micropython/micropython#15911, rebased to get a accurate size comparison.
5_standard_mip_installed | standard + `mip install` all the typing modules.
6_coverage | unix coverage + frozen `require("bundle-typing", extensions=True)`.
RPI_PICO2 | regular MicroPython v1.28.0 RPI_PICO2  + `mpremote mip install <all typing modules>`


#### Summary of test results

 - Specified test(s): typing_runtime
   - micropython: yetanothertypingbranch (a0dcc1e43a8a)
   - micropython-lib: add_typing_py (02911436eb73)
 - Generated: 2026-06-04 22:08:51

| Variant | PASS | xfail | skip | FAIL | False Positive | ERROR | total | text | data | bss | size | Δsize |
|:---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| standard | 3 | 1 | 183 | 0 | 0 | 0 | 187 | 784_958 | 70_904 | 2_960 | 858_822 | ref |
| 1_mp-stubs | 122 | 29 | 36 | 0 | 0 | 0 | 187 | 790_390 | 72_056 | 2_960 | 865_406 | +6_584 |
| 2a_typing | 107 | 27 | 53 | 0 | 0 | 0 | 187 | 786_830 | 71_352 | 2_960 | 861_142 | +2_320 |
| 2b_bundle_typing_S | 122 | 29 | 36 | 0 | 0 | 0 | 187 | 787_614 | 71_512 | 2_960 | 862_086 | +3_264 |
| 2c_bundle_typing_L | 127 | 29 | 31 | 0 | 0 | 0 | 187 | 788_486 | 71_704 | 2_960 | 863_150 | +4_328 |
| 3_builtintypingmodule | 128 | 31 | 8 | 16 | 2 | 2 | 187 | 786_870 | 71_352 | 2_960 | 861_182 | +2_360 |
| 5_standard_mip_installed | 152 | 33 | 2 | 0 | 0 | 0 | 187 | 784_958 | 70_904 | 2_960 | 858_822 | +0 |
| 6_coverage | 152 | 33 | 2 | 0 | 0 | 0 | 187 | 1_844_803 | 353_696 | 264_608 | 2_463_107 | +1_604_285 |
| RPI_PICO2 | 152 | 33 | 2 | 0 | 0 | 0 | 187 | - | - | - | - | - |

Legend:
 - **ok**=passed, **xfail**=expected failure, **skip**=test skipped
 - **FAIL**=test failed, **False Positive**=unexpected success
 - **ERROR**=test errored (also used when the test module crashed).
 - Firmware sizes are reported in bytes from `size <binary>`.




#### typing_runtime/check_all_modules.py
    probe module availability
    test import only

| Class | Test | standard | 1_mp-stubs | 2a_typing | 2b_bundle_typing_S | 2c_bundle_typing_L | 3_builtintypingmodule | 5_standard_mip_installed | 6_coverage | RPI_PICO2 |
|---|---|---|---|---|---|---|---|---|---|---|
| TestModuleIncluded | test_typing | skip | ok | ok | ok | ok | ok | ok | ok | ok |
| TestModuleIncluded | test_typing_extensions | skip | ok | ok | ok | ok | ok | ok | ok | ok |
| TestModuleIncluded | test_future | skip | ok | skip | ok | ok | ok | ok | ok | ok |
| TestModuleIncluded | test_abc | skip | skip | skip | skip | skip | ok | ok | ok | ok |
| TestModuleIncluded | test_collections | skip | ok | ok | ok | ok | ok | ok | ok | ok |
| TestModuleIncluded | test_collections_abc | skip | skip | skip | skip | ok | skip | ok | ok | ok |

[See the full report.md](https://github.com/user-attachments/files/28615054/report.md)

### PR and merge dependencies

See the companion PR: micropython/micropython#19310

I'm open to recommendation on how the different parts needed to implement and test this functionality should be seperated into different PRs, across the different repos.

Apart from this PR there are at the following components needed:

1. **`unittest@0.11.0`**  
In order to be able to create tests, and clear reporting across the alternative implementations, I needed the test suite to be able to make use `unittest.expectedFailure`, and for `unittest` to report the Expected Failures and unexpected successes to the `run-test.py` test runner. This allows to distinguish on things that are not implemented in MicroPython, but are expected to fail ( User defined Generics[], MetaClass), from things that are implemented but not working as expected.

2. **`micropython:tests/run-test.py`**  
In turn, the `run-test.py` test runner needed to be updated to handle the additional information.
3. **`micropython:tools/make_report.py`**  
In order to keep an overview of all test results I have created a new tool `make_report.py` that builds a markdown report of the test results, which can be used to compare the results of different implementations and variants. This tool could also be used to compare other sets of PRs that implement the same features.

    <details><summary>Example report runner</summary>
    <p>

    ```justfile
    # example report run 
    report tests="typing_runtime": make_test_venv
        MICROPYPATH="{{MICROPYPATH_MIP}}" uv run tools/make_report.py \
            --variant standard=/home/jos/micropython.worktrees/runtime_typing/ports/unix/build-standard/micropython \
            --variant 1_mp-stubs=/home/jos/micropython.worktrees/runtime_typing/ports/unix/build-typing1/micropython \
            --variant 2a_typing=/home/jos/micropython.worktrees/runtime_typing/ports/unix/build-typing2a/micropython \
            --variant 2b_bundle_typing_S=/home/jos/micropython.worktrees/runtime_typing/ports/unix/build-typing2b/micropython \
            --variant 2c_bundle_typing_L=/home/jos/micropython.worktrees/runtime_typing/ports/unix/build-typing2c/micropython \
            --variant 3_builtintypingmodule=/home/jos/micropython.worktrees/runtime_typing/ports/unix/build-typing3/micropython \
            --variant 5_standard_mip_installed=/home/jos/micropython.worktrees/runtime_typing/ports/unix/build-standard/micropython \
            --variant 6_coverage=/home/jos/micropython.worktrees/runtime_typing/ports/unix/build-coverage/micropython \
            --keep-path 5_standard_mip_installed \
            --board RPI_PICO2=/dev/ttyACM0 \
            --board ESP32_C5=/dev/ttyACM1 \
            --out report.md \
            {{tests}}
    ```

    </p>
    </details> 



### Trade-offs and Alternatives

 -  **Size versus accuracy:**  
    The implementation is optimized for size, which may impact readability and traceability of errors.
    Also due to the use of `__getattr__` for lazy loading, some features may appear to be available, while they are actually not.
    For example: 
    - `from typing import NoSuchThing` will not raise an `ImportError` at runtime.
    - `import typing; dir(typing)` will not work as expected but show a list of all QSTR's in the firmware.
    This is deemed acceptable as static type checkers and linter will catch this at development time.

 -  **Size versus composability:**  
    While the freeezing of all .py files is larger than a fuctionally equivalant C implementation, it has the advanatge that is can be `mip installed` and also easily extended with new features, without the need to recompile the firmware.
    or any median can be accomplished by freezing only the core `bundle-typing` and `mip installing` other modules as appropriate.
    vfs size impact:
    ```
    $ mpremote df tree -s
    filesystem     size     used    avail use% mounted on
    <VfsLfs2>   3145728    45056  3100672    1 /
    tree :
    :/
    └── lib
        ├── [      194]  __future__.mpy
        ├── [      139]  abc.mpy
        ├── collections
        │   ├── [      274]  __init__.mpy
        │   └── [      112]  abc.mpy
        ├── [      642]  typing.mpy
        └── [      130]  typing_extensions.mpy
    ```
- **Freezing methods:**  
  durign the quest to save firmware size, I have experimented with different freezing method. I noticed in particular that the `__future__` made the fimware size increase by more that its .py file size. and could actually be stored smaller using `freeze_as_str()` at the cost of additional runtime overhead while loading. This was explained in [Discussion](https://github.com/micropython/micropython/issues/19288#issuecomment-4597960249) 
  This PR currently uses the `require()` method for all modules,to reduce or avoid memory fragmentation that is likely caused by compilation at runtime.

 - **`unittest@0.11.0` and `tools/run-tests.py`:**  
   In order to be able to create tests for the typing modules, and to have clear reporting of expected failures and unexpected successes, I have added CPython compatible functionality to `unittest`

     That was defintly needed in order to develop this PR, but just guarding against regressiosn could be done using `unittest@0.10.5`, but that would require either removing.chaining the expected failure tests, or putting them behind a version check, which would make the tests less clear and more difficult to maintain.

     The update to `tools/run-tests.py` is minor, and adds just the abaility to parse the additional information, and is backward compatible with `unittest@0.10.5`.

     There is however no way for (a) unittest to check by which version of `tools/run-tests.py` it is being run. 


### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.






<details><summary>Outdated Original PR Summary</summary>
<p>

This is a improved MicroPython alternative to 
 - the .c based minimal typing module proposed in https://github.com/micropython/micropython/pull/15911
 - the .pyhon based https://github.com/micropython/micropython-lib/pull/584
 - https://github.com/Josverl/micropython-stubs/tree/main/mip#micropythons-typingmpy-module

based on all the above and tuned for reduced firmware/frozen size, while keeping provable consistence with the relevant typing PEPs for features that are supported by MicroPython. 
 
It consists of a number of modules that can be mip-installed  or frozen as part of a firmware..  
Note that the modules have been optimized for size - somewhat impacting readability - but where relevant the orignal code has been kept as comments.

cloases: #190

## Documentation

Documentation is not created yet.
- [ ] Document availability of the modules
- [ ] Document the use of the bundle-typing and it's options 

## Testing:
The same set of tests has been run against both implementations and while there are a few differences , both pass the majority of tests. 
The remaining differences to CPython should be documented as such, and then can be excluded from the verification tests.

The tests are created at part of MicroPython's tests suite , and are mot included in this PR.
Currently they are part of https://github.com/micropython/micropython/pull/15911, but could be separated for testing ( may require a new variant for testing in this in the MicroPython repo) 

The PR includes the `bundle-typing`  to allow simple addition to a board defintition 
```py
# typing related modules
require(
    "bundle-typing",
    # extensions=False,  # Set to True to include collections.abc
    # opt_level=2,
)
```

This also defaults the mpy-cross opt level to 3, to reduce firmware size.

The impact to firmware size of the `modtyping.c` and the `typing.py` variant are surprisingly close,
although I think there may be room for additional optimisation for the `modtyping.c` alternative.

### Comparison  without collections.abc 

Note: both PRs are changing , so the below is a point-in-time comparison ( 14/10/'25) 

| method | modules included | size (bytes) | diff| 
|--------|------------------|--------------|---|
| standard | - |  841_295	| 0 |
| modtyping.c | no collections.abc | 843887 | 2592 | 
| typing.py | no collections.abc | 843807 | 2.512 (-80) |


Test Results:

| Module | count | FIXME |
|--------|-------|---|
| typing.py | 3 | |
|  |  |- [ ] FIXME: from collections.abc import Callable|
|  |  |- [ ] FIXME: document cpy_diff - get_args(int) should be ()|
|  |  |- [ ] FIXME: document cpydiff : Final cannot be used with container types|
| modtyping.c | 6 | |
|  |  |- [ ] FIXME: Difference or Crash - multiple bases have instance lay-out conflict: multiple bases have instance lay-out conflict|
|  |  |- [ ] FIXME: Difference or Crash - multiple bases have instance lay-out conflict: multiple bases have instance lay-out conflict|
|  |  |- [ ] FIXME: from collections.abc import Callable|
|  |  |- [ ] FIXME: document cpy_diff - get_origin(str) should be None|
|  |  |- [ ] FIXME: document cpy_diff - get_args(int) should be ()|
|  |  |- [ ] FIXME: document cpydiff : Final cannot be used with container types|

### Comparison including collections.abc 

| method | modules included | size (bytes) | diff| 
|--------|------------------|--------------|---|
| standard | - |  841_295	| 0 |
| modtyping.c | no collections.abc | 843_887 | 2592 | 
| typing.py | with collections.abc | 844_063 | 2668 (+76 bytes) |

Test results:


| Module | count | FIXME |
|--------|-------|---|
| typing.py | 2 | Size: 844063	   |
|  |  |- [ ] FIXME: document cpy_diff - get_args(int) should be ()|
|  |  |- [ ] FIXME: document cpydiff : Final cannot be used with container types|
| modtyping.c | 6 | Size: 843887	  |
|  |  |- [ ] FIXME: Difference or Crash - multiple bases have instance lay-out conflict: multiple bases have instance lay-out conflict|
|  |  |- [ ] FIXME: Difference or Crash - multiple bases have instance lay-out conflict: multiple bases have instance lay-out conflict|
|  |  |- [ ] FIXME: from collections.abc import Callable|
|  |  |- [ ] FIXME: document cpy_diff - get_origin(str) should be None|
|  |  |- [ ] FIXME: document cpy_diff - get_args(int) should be ()|
|  |  |- [ ] FIXME: document cpydiff : Final cannot be used with container types|


</p>
</details> 