### PR TITLE
sdcard: Updating sector calculation for SDXC.

### DIFF
--- a/micropython/drivers/storage/sdcard/manifest.py
+++ b/micropython/drivers/storage/sdcard/manifest.py
@@ -1,3 +1,3 @@
-metadata(description="SDCard block device driver.", version="0.1.0")
+metadata(description="SDCard block device driver.", version="0.1.1")
 
 module("sdcard.py", opt=3)

--- a/micropython/drivers/storage/sdcard/sdcard.py
+++ b/micropython/drivers/storage/sdcard/sdcard.py
@@ -97,7 +97,7 @@ class SDCard:
         csd = bytearray(16)
         self.readinto(csd)
         if csd[0] & 0xC0 == 0x40:  # CSD version 2.0
-            self.sectors = ((csd[8] << 8 | csd[9]) + 1) * 1024
+            self.sectors = ((csd[7] << 16 | csd[8] << 8 | csd[9]) + 1) * 1024
         elif csd[0] & 0xC0 == 0x00:  # CSD version 1.0 (old, <=2GB)
             c_size = (csd[6] & 0b11) << 10 | csd[7] << 2 | csd[8] >> 6
             c_size_mult = (csd[9] & 0b11) << 1 | csd[10] >> 7


### PR DESCRIPTION
The current code only calculates sectors for SDHC, with a max of 32G
The new code will calculate sectors for SDXC, with a max of 2T

C_SIZE is 22 bits[69:48] and the high 2 bits of csd[7] are required
to be 0, currently, so i'm not masking them off.

The max value for C_SIZE is 0x3FFEFF, so C_SIZE+1*1024 is a 32-bit number.