### PR TITLE
fix: correctly handle WebSocket message fragmentation

### DIFF
--- a/python-ecosys/aiohttp/manifest.py
+++ b/python-ecosys/aiohttp/manifest.py
@@ -1,6 +1,6 @@
 metadata(
     description="HTTP client module for MicroPython asyncio module",
-    version="0.0.6",
+    version="0.0.7",
     pypi="aiohttp",
 )
 


### PR DESCRIPTION
Handle WebSocket fragmentation was properly by taking into account the "fin" flag to know if a frame is "final" or whether there will be continuations before it's final.