### PR TITLE
iperf3: fix server UDP mode

### DIFF
--- a/python-ecosys/iperf3/manifest.py
+++ b/python-ecosys/iperf3/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.4", pypi="iperf3", pypi_publish="uiperf3")
+metadata(version="0.1.5", pypi="iperf3", pypi_publish="uiperf3")
 
 module("iperf3.py")


### PR DESCRIPTION
This PR gets `iperf3.server()` working in UDP and UDP reverse mode.

Tested on unix MicroPython (needs unix sockets to support `sendall()`), CPython and OPENMV_N6, in all 8 configurations (client/server x TCP/UDP x reverse).