### PR TITLE
argparse: Add support for custom argument types.

### DIFF
--- a/python-stdlib/argparse/manifest.py
+++ b/python-stdlib/argparse/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.4.0")
+metadata(version="0.5.0")
 
 # Originally written by Damien George.
 


### PR DESCRIPTION
This PR adds support for optional custom argument type validation to argparse.ArgumentParser, allowing for shorter argument validation code for both simple builtins and complex types, as supported by CPython.

CPython also provides the `argparse.FileType` class to simplify argument file/directory handling, but that was not added to the MicroPython module.  Its behaviour is rather easy to manually replicate if needed anyway.

This change increases the size of the `argparse` module by 291 bytes, and that's mostly due to the extra error handling and related text strings.  Probably those new strings can be shortened, but given that this module isn't usually included in production code, the size increase shouldn't hurt too much I guess.

The unit tests unfortunately do not cover the case of a parameter failing validation, as the module will automatically issue a `sys.exit` call on error, after printing the relevant exception message.  If there are cleaner ways to test that without hijacking `sys.exit`, let me know so I can update the tests accordingly.