### PR TITLE
unix-ffi: Remove ip add/drop membership from socket.

### DIFF
--- a/unix-ffi/socket/manifest.py
+++ b/unix-ffi/socket/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.5.2")
+metadata(version="0.5.3")
 
 # Originally written by Paul Sokolovsky.
 

--- a/unix-ffi/socket/socket.py
+++ b/unix-ffi/socket/socket.py
@@ -4,8 +4,6 @@ import usocket as _socket
 
 _GLOBAL_DEFAULT_TIMEOUT = 30
 IPPROTO_IP = 0
-IP_ADD_MEMBERSHIP = 35
-IP_DROP_MEMBERSHIP = 36
 INADDR_ANY = 0
 
 error = OSError


### PR DESCRIPTION
### Summary

Remove the `IP_ADD_MEMBERSHIP` and `IP_DROP_MEMBERSHIP` in `unix-ffi/socket.py` since they are being defined in `usocket` in the on the main micropython repository in the following PR if merged.

Depends on: https://github.com/micropython/micropython/pull/18459