### PR TITLE
aioble/examples: Change variable name to _ADV_INTERVAL_US.

### DIFF
--- a/micropython/bluetooth/aioble/examples/l2cap_file_server.py
+++ b/micropython/bluetooth/aioble/examples/l2cap_file_server.py
@@ -33,7 +33,7 @@ _FILE_SERVICE_UUID = bluetooth.UUID("0492fcec-7194-11eb-9439-0242ac130002")
 _CONTROL_CHARACTERISTIC_UUID = bluetooth.UUID("0492fcec-7194-11eb-9439-0242ac130003")
 
 # How frequently to send advertising beacons.
-_ADV_INTERVAL_MS = 250_000
+_ADV_INTERVAL_US = 250_000
 
 
 _COMMAND_SEND = const(0)
@@ -162,7 +162,7 @@ async def peripheral_task():
     while True:
         print("Waiting for connection")
         connection = await aioble.advertise(
-            _ADV_INTERVAL_MS,
+            _ADV_INTERVAL_US,
             name="mpy-file",
             services=[_FILE_SERVICE_UUID],
         )


### PR DESCRIPTION
Following 28136d837ab936324d46f2cbe50e686475f5c38c