### PR TITLE
micropython/senml/docs: Correct capitalization of 'MicroPython'.

### DIFF
--- a/micropython/senml/docs/index.md
+++ b/micropython/senml/docs/index.md
@@ -1,4 +1,4 @@
-Welcome to the API document site for the micro-python SenML library.
+Welcome to the API document site for the MicroPython SenML library.
 
 The following api sections are available:
 


### PR DESCRIPTION
Small change to the correct spelling.