### PR TITLE
webrepl: send Content-Type: text/html for index

### DIFF
--- a/micropython/net/webrepl/webrepl.py
+++ b/micropython/net/webrepl/webrepl.py
@@ -78,6 +78,7 @@ def send_html(cl):
     cl.send(
         b"""\
 HTTP/1.0 200 OK\r
+Content-Type: text/html; charset=utf-8\r
 \r
 <base href=\""""
     )


### PR DESCRIPTION
If we don't do this then Firefox incorrectly guesses text/plain and just shows the source.  Adding the Content-Type: fixes the issue.