### PR TITLE
fix(logging): allow child loggers to set independent log levels

### DIFF
--- a/python-stdlib/logging/logging.py
+++ b/python-stdlib/logging/logging.py
@@ -242,7 +242,7 @@ def basicConfig(
         else:
             handler = FileHandler(filename, filemode, encoding)
 
-        handler.setLevel(level)
+        handler.setLevel(NOTSET)
         handler.setFormatter(Formatter(format, datefmt))
 
         logger.setLevel(level)


### PR DESCRIPTION
The handler's level was being set to the root logger's level in basicConfig(), which prevented child loggers from setting their own levels. This violated the standard logging architecture where handlers should not filter by level - that's the logger's responsibility.

Changed handler.setLevel(level) to handler.setLevel(NOTSET) in basicConfig() so that handlers pass through all messages and let loggers control filtering.

This allows code like:
  logger = logging.getLogger("myapp")
  logger.setLevel(logging.INFO)
  logger.info("message")  # Now works correctly

Previously, INFO messages would be filtered out if the root logger was at WARNING.

Fixes: Child loggers unable to log at levels lower than root logger's level