### PR TITLE
sdcard: Set stop bit in SPI command frame.

### DIFF
--- a/micropython/drivers/storage/sdcard/sdcard.py
+++ b/micropython/drivers/storage/sdcard/sdcard.py
@@ -154,7 +154,7 @@ class SDCard:
         buf[2] = arg >> 16
         buf[3] = arg >> 8
         buf[4] = arg
-        buf[5] = crc
+        buf[5] = crc | 0x01  # ensure stop bit is always set
         self.spi.write(buf)
 
         if skip1:


### PR DESCRIPTION
Hello,
first and foremost thank you for maintaining and evolving Micropython, it made my pet project possible !

I'm using 32gb class 10 sd card from Philips for my pet project and stumbled upon an compatibility issues:  without stop bit card does not work with the driver :-(  
If that matters, product information is [here](https://philips-media.com/en/shop/philips-micro-sdhc-xc-uhs-i-u1-card/).

With stop bit set - card works like a charm with the driver, i tested it locally.
Before it failed with: `OSError: timeout waiting for v2 card.`
