### PR TITLE
usb-device-cdc: Fix default timeout in CDCInterface.init().

### DIFF
--- a/micropython/usb/usb-device-cdc/manifest.py
+++ b/micropython/usb/usb-device-cdc/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.2")
+metadata(version="0.1.3")
 require("usb-device")
 package("usb")

--- a/micropython/usb/usb-device-cdc/usb/device/cdc.py
+++ b/micropython/usb/usb-device-cdc/usb/device/cdc.py
@@ -122,7 +122,7 @@ class CDCInterface(io.IOBase, Interface):
         self.init(**kwargs)
 
     def init(
-        self, baudrate=9600, bits=8, parity="N", stop=1, timeout=None, txbuf=256, rxbuf=256, flow=0
+        self, baudrate=9600, bits=8, parity="N", stop=1, timeout=1000, txbuf=256, rxbuf=256, flow=0
     ):
         # Configure the CDC serial port. Note that many of these settings like
         # baudrate, bits, parity, stop don't change the USB-CDC device behavior


### PR DESCRIPTION
### Summary

`CDCInterface` is broken when constructed with default arguments — calling `read()`, `write()`, `readinto()`, or `flush()` raises `TypeError: unsupported types for __ge__: 'int', 'NoneType'` because `self._timeout` ends up as `None`.

`__init__` sets `self._timeout = 1000` then immediately calls `self.init(**kwargs)`. The `init()` method has `timeout=None` as default and unconditionally assigns `self._timeout = timeout`, overwriting the 1000 with None. All the stream methods then fail on `time.ticks_diff(...) >= self._timeout`.

Fix is changing the default parameter from `timeout=None` to `timeout=1000`, consistent with how the other init parameters (baudrate, bits, parity, stop) all carry their real defaults in the signature.

### Testing

Tested on ESP32-S3 as USB CDC device with an MIMXRT1170-EVK as USB host. Confirmed `cdc._timeout` is now 1000 after default construction and `read()`, `write()`, `readinto()` all work without error. Also verified explicit `timeout=` parameter still takes effect.