### PR TITLE
unix-ffi/json: Fix json.loads() of a bytes object.

### DIFF
--- a/unix-ffi/json/json/__init__.py
+++ b/unix-ffi/json/json/__init__.py
@@ -391,6 +391,8 @@ def loads(
     The ``encoding`` argument is ignored and deprecated.
 
     """
+    if isinstance(s, (bytes, bytearray)):
+        s = s.decode('utf-8')
     if (
         cls is None
         and object_hook is None
@@ -413,6 +415,4 @@ def loads(
         kw["parse_int"] = parse_int
     if parse_constant is not None:
         kw["parse_constant"] = parse_constant
-    if isinstance(s, (bytes, bytearray)):
-        s = s.decode('utf-8')
     return cls(**kw).decode(s)

--- a/unix-ffi/json/manifest.py
+++ b/unix-ffi/json/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.0")
+metadata(version="0.2.1")
 
 require("re")
 package("json")

--- a/unix-ffi/json/test_json.py
+++ b/unix-ffi/json/test_json.py
@@ -11,3 +11,9 @@ print(outp)
 
 # Doesn't work because JSON doesn't have tuples
 # assert inp == outp
+
+b = b'["foo", {"bar": ["baz", null, 1, 2]}]'
+outp2 = json.loads(b)
+
+assert b.decode('utf-8') == s
+assert outp == outp2


### PR DESCRIPTION
The conversion from bytes to string previously worked only if some other argument was also given to `loads`.  This makes even a basic call with no other arguments work.

NOTE: The `test_json.py` file fails, and failed before this PR, because of #1083.  If I patch `scanner.py` to only parse ints (and thus not need optional groups), the tests pass.