### PR TITLE
Fix unix-ffi/re: Fix OverflowError in re.groups().

### DIFF
--- a/unix-ffi/re/manifest.py
+++ b/unix-ffi/re/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.5")
+metadata(version="0.2.6")
 
 # Originally written by Paul Sokolovsky.
 

--- a/unix-ffi/re/re.py
+++ b/unix-ffi/re/re.py
@@ -38,6 +38,10 @@ PCRE2_SIZE_TYPE = "L"
 # to -1
 PCRE2_ZERO_TERMINATED = -1
 
+# PCRE2_UNSET is used for offsets of groups that didn't participate in a match
+# It's SIZE_MAX: 0xFFFFFFFF for 32bit, 0xFFFFFFFFFFFFFFFF for 64bit
+PCRE2_UNSET = (1 << (PCRE2_SIZE_SIZE * 8)) - 1
+
 
 IGNORECASE = I = 0x8
 MULTILINE = M = 0x400
@@ -62,12 +66,11 @@ class PCREMatch:
         if not n:
             return self.s[self.offsets[0] : self.offsets[1]]
         if len(n) == 1:
-            return self.s[self.offsets[n[0] * 2] : self.offsets[n[0] * 2 + 1]]
-        return tuple(self.s[self.offsets[i * 2] : self.offsets[i * 2 + 1]] for i in n)
+            return None if self.offsets[n[0] * 2] == PCRE2_UNSET else self.s[self.offsets[n[0] * 2] : self.offsets[n[0] * 2 + 1]]
+        return tuple(None if self.offsets[i * 2] == PCRE2_UNSET else self.s[self.offsets[i * 2] : self.offsets[i * 2 + 1]] for i in n)
 
     def groups(self, default=None):
-        assert default is None
-        return tuple(self.group(i + 1) for i in range(self.num - 1))
+        return tuple(default if self.offsets[(i + 1) * 2] == PCRE2_UNSET else self.group(i + 1) for i in range(self.num - 1))
 
     def start(self, n=0):
         return self.offsets[n * 2]

--- a/unix-ffi/re/test_re.py
+++ b/unix-ffi/re/test_re.py
@@ -60,3 +60,9 @@ assert indents == ["\t", "\t"]
 text = "  \thello there\n  \t  how are you?"
 indents = _leading_whitespace_re.findall(text)
 assert indents == ["  \t", "  \t  "]
+
+m = re.match(r"(.)?", "")
+assert m.group() == ""
+assert m.group(0, 1) == ("", None)
+assert m.groups() == (None,)
+assert m.groups("default") == ("default",)


### PR DESCRIPTION
Adjust the `re.groups()` methods to properly handle the `PCRE2_UNSET` value for unmatched optional groups. 
This change prevents `OverflowError` when calling `groups()` on a match with no content. 

The return matches CPython's.


A test case for an empty string match has been added to verify expected behavior.

Fixes micropython/micropython#18877