### PR TITLE
machine: Retrieve an unique identifier if one is known.

### DIFF
--- a/unix-ffi/machine/machine/__init__.py
+++ b/unix-ffi/machine/machine/__init__.py
@@ -4,4 +4,13 @@ from .pin import *
 
 
 def unique_id():
+    for base in ("/etc", "/var/lib/dbus"):
+        try:
+            with open(base + "/machine-id", "rb") as source:
+                data = source.read(32)
+                if len(data) == 32:
+                    # unhexlify might not be available
+                    return bytes([int(data[i : i + 2], 16) for i in range(0, 32, 2)])
+        except OSError as e:
+            pass
     return b"upy-non-unique"

--- a/unix-ffi/machine/manifest.py
+++ b/unix-ffi/machine/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.2.2")
+metadata(version="0.2.3")
 
 # Originally written by Paul Sokolovsky.
 


### PR DESCRIPTION
### Summary

This PR adds a proper implementation for `machine.unique_id` for selected systems, as opposed to returning a fixed value in every case.

On a Unix system there are several incompatible ways to retrieve something that can be called an unique machine identifier.  However, the only semblance of a specification comes from freedesktop.org, which says that a file called `/etc/machine-id` has to exist and must contain a 32-digits long hexadecimal identifier - thus having a 128 bits unique identifier value.

Given that the current specification is the DBus unique identifier retrieval mechanism made official, if the identifier file is not found the code will attempt to read the file provided by DBus.

These changes only apply to Linux and recent BSD systems.  On other systems the old, fixed value for the machine identifier will be returned instead, to avoid breaking compatibility with existing code.

The specification used in this commit is available at https://www.freedesktop.org/software/systemd/man/latest/machine-id.html.

<hr>

The manifest's version was bumped up by 0.0.1 since these changes only affect the behaviour of the module without making changes to the existing API.

### Testing

This was tested on current MicroPython master, by adding `require("machine")` to `ports/unix/variants/manifest.py` and rebuilding the `standard` variant of the interpreter.

Then the output of `import machine; machine.unique_id()` was checked against the contents of `/etc/machine-id` on the host system.  The fallback was tested by changing `/etc` into something else, and I/O error passthrough was tested by adding a directory that is not accessible by the running user to the front of the list of paths to check.

### Trade-offs and Alternatives

These changes add 198 bytes to the `machine` module.  Things could be made smaller by removing the identifier validation and skipping the DBus fallback.

Preliminary identifier value validation in theory could be removed, since the "unhexlification" step will raise an exception if the input data is not a series of hexadecimal digits.  The current behaviour is to ignore the data read from the current machine identifier file and try the next one in the list.  If stopping the identification process on unexpected data at any point is acceptable rather than gracefully handling the condition, this could shrink down by 43 bytes.

However, since there is an existing specification and a known alternative path for the same data, maybe it's not a bad idea to keep those two bits of code in.

### Generative AI

I did not use generative AI tools when creating this PR.