### PR TITLE
copy: Provide top-level documentation.

### DIFF
--- a/python-stdlib/copy/README.md
+++ b/python-stdlib/copy/README.md
@@ -1,0 +1,23 @@
+# copy
+
+Non-trivial objects (eg. classes) instantiated by CPython are usually able to
+be copied by methods of this module without any modification, as the copying
+mechanism makes use of two functions (`__reduce__` and `__reduce_ex__`) that
+are added to instances by CPython itself.
+
+MicroPython does not do that, to keep the interpreter's binary size down and to
+limit the RAM footprint of object instances.  This means that this module is
+not able to copy non-trivial objects without specific changes to your code.
+
+The `copy` module methods look for two methods being available in an instance:
+[`__copy__`](https://docs.python.org/3/library/copy.html#object.__copy__) and
+[`__deepcopy__`](https://docs.python.org/3/library/copy.html#object.__deepcopy__),
+and the module will call those functions to create a copy (either shallow or
+deep) of the object.  Implementing either of those methods in a class will
+allow instances of that class to be copied both in MicroPython and CPython,
+keeping code compatible with the two interpreters.
+
+`__reduce__` and `__reduce_ex__` will be used in MicroPython if a class
+provides them, but unless you're also planning to use object pickling,
+`__copy__` and `__deepcopy__` are the simplest way to make sure things work in
+all cases.


### PR DESCRIPTION
### Summary

This PR adds documentation for the `copy` module, explaining why the module may require some changes in the objects being copied to behave as CPython.

Unlike CPython, MicroPython does not provide default implementations for either `__reduce__` or `__reduce_ex__`, which are used by the copy module as the fallback methods to create copies of non-trivial objects.  These methods aren't provided by default to minimise both the footprint of the interpreter binary and the RAM taken by object instances.

Users who want simpler ways to allow object copies can implement `__copy__` and `__deepcopy__` instead, as mentioned in CPython's documentation for the `copy` module.

Arguably the lack of `__reduce__` and `__reduce_ex__` could also be mentioned in MicroPython's own documentation as part of the differences from CPython, but it doesn't hurt to mention more module-specific caveats in here too.  This should, in theory, keep user expectations in check w.r.t. the behaviour of this specific module.

This should clarify scenarios like the ones mentioned in #1090.

### Generative AI

I did not use generative AI tools when creating this PR.