### PR TITLE
python-stdlib/collections-defaultdict: Add items() function.

### DIFF
--- a/python-stdlib/collections-defaultdict/collections/defaultdict.py
+++ b/python-stdlib/collections-defaultdict/collections/defaultdict.py
@@ -33,3 +33,6 @@ class defaultdict:
         if self.default_factory is None:
             raise KeyError(key)
         return self.default_factory()
+
+    def items(self):
+        return self.d.items()

--- a/python-stdlib/collections-defaultdict/manifest.py
+++ b/python-stdlib/collections-defaultdict/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.3.0")
+metadata(version="0.4.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/python-stdlib/collections-defaultdict/test_defaultdict.py
+++ b/python-stdlib/collections-defaultdict/test_defaultdict.py
@@ -8,3 +8,11 @@ del d[1]
 assert d[1] == 42
 
 assert "foo" not in d
+
+d = defaultdict.defaultdict(list)
+for k, v in [('a', 1), ('b', 2), ('c', 3), ('a', 4), ('b', 5), ('c', 6)]:
+    d[k].append(v)
+i = list(sorted(d.items()))
+assert i[0] == ('a', [1, 4])
+assert i[1] == ('b', [2, 5])
+assert i[2] == ('c', [3, 6])


### PR DESCRIPTION
### Summary

This PR adds the `items()` functions to `collections.defaultdict`, acting as a simple proxy to the underlying dictionary container.

This fixes #350.

The package's version number was bumped up by 0.1.0 since a new function was added to the module.

### Testing

The added tests in `python-stdlib/collections-defaultdict` were run successfully both on CPython (with a tweaked import harness) and on MicroPython's git master.

### Trade-offs and Alternatives

This adds 81 bytes to the final module.  I'm a bit surprised it took that much, but unless it is documented that the backing dictionary can be accessed via `self.d` when code runs on MicroPython, I don't see any other safe way to enumerate the contents [1].

### Generative AI

I did not use generative AI tools when creating this PR.

<hr>

[1]

This trips up MicroPython, for example:

```py
from collections import defaultdict
a = defaultdict.defaultdict(list)
for i in a:
    print(i)
```

On current MicroPython's git master:

```bash
$ cd python-stdlib/collections-defaultdict
$ $MICROPYTHON
MicroPython v1.28.0-preview.306.g5c00edcee2.dirty on 2026-03-23; linux [GCC 15.2.1] version
Type "help()" for more information.
>>> from collections import defaultdict
>>> a = defaultdict.defaultdict(list)
>>> for i in a:
...     print(i)
...
[]
[]
[]
[]
# `[]` being repeated a fairly large number of times here...
[]
[]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "collections/defaultdict.py", line 20, in __getitem__
MemoryError: memory allocation failed, allocating 260368 bytes
>>>
```

Whilst this works as expected on CPython 3.14 (and probably earlier versions too):

```bash
$ python
Python 3.14.3 (main, Feb 13 2026, 15:31:44) [GCC 15.2.1 20260209] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from collections import defaultdict
>>> a = defaultdict(list)
>>> for i in a:
...     print(i)
... 
>>>
```