### PR TITLE
micropython/mip/mip: Add an alias for codeberg repos.

### DIFF
--- a/micropython/mip/manifest.py
+++ b/micropython/mip/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.4.2", description="On-device package installer for network-capable boards")
+metadata(version="0.5.0", description="On-device package installer for network-capable boards")
 
 require("requests")
 

--- a/micropython/mip/mip/__init__.py
+++ b/micropython/mip/mip/__init__.py
@@ -10,7 +10,19 @@ from micropython import const
 _PACKAGE_INDEX = const("https://micropython.org/pi/v2")
 _CHUNK_SIZE = const(128)
 
-allowed_mip_url_prefixes = ("http://", "https://", "github:", "gitlab:")
+# Since all URLs are accessed via HTTPS, the URL scheme is added by _rewrite_url.
+# The first three format parameters are assumed to be the organisation, the
+# repository names, and the branch/tag name, in this order.
+_HOSTS = {
+    # https://codeberg.org/api/v1/repos/{org}/{repo}/raw/{path}?ref={branch}
+    "codeberg:": "codeberg.org/api/v1/repos/{}/{}/raw/{p}?ref={}",
+    # https://raw.githubusercontent.com/{org}/{repo}/{branch}/{path}
+    "github:": "raw.githubusercontent.com/{}/{}/{}/{p}",
+    # https://gitlab.com/{org}/{repo}/-/raw/{branch}/{path}
+    "gitlab:": "gitlab.com/{}/{}/-/raw/{}/{p}",
+}
+
+_ALLOWED_MIP_URL_PREFIXES = const(("http://", "https://", "codeberg:", "github:", "gitlab:"))
 
 
 # This implements os.makedirs(os.dirname(path))
@@ -62,31 +74,13 @@ def _check_exists(path, short_hash):
 
 
 def _rewrite_url(url, branch=None):
-    if not branch:
-        branch = "HEAD"
-    if url.startswith("github:"):
-        url = url[7:].split("/")
-        url = (
-            "https://raw.githubusercontent.com/"
-            + url[0]
-            + "/"
-            + url[1]
-            + "/"
-            + branch
-            + "/"
-            + "/".join(url[2:])
-        )
-    elif url.startswith("gitlab:"):
-        url = url[7:].split("/")
-        url = (
-            "https://gitlab.com/"
-            + url[0]
-            + "/"
-            + url[1]
-            + "/-/raw/"
-            + branch
-            + "/"
-            + "/".join(url[2:])
+    for provider, url_format in _HOSTS.items():
+        if not url.startswith(provider):
+            continue
+        components = url[len(provider) :].split("/")
+        # Add https:// prefix to final URL.
+        return _ALLOWED_MIP_URL_PREFIXES[1] + url_format.format(
+            components[0], components[1], branch or "HEAD", p="/".join(components[2:])
         )
     return url
 
@@ -130,7 +124,7 @@ def _install_json(package_json_url, index, target, version, mpy):
     base_url = package_json_url.rpartition("/")[0]
     for target_path, url in package_json.get("urls", ()):
         fs_target_path = target + "/" + target_path
-        is_full_url = any(url.startswith(p) for p in allowed_mip_url_prefixes)
+        is_full_url = any(url.startswith(p) for p in _ALLOWED_MIP_URL_PREFIXES)
         if base_url and not is_full_url:
             url = f"{base_url}/{url}"  # Relative URLs
         if not _download_file(_rewrite_url(url, version), fs_target_path):
@@ -143,7 +137,7 @@ def _install_json(package_json_url, index, target, version, mpy):
 
 
 def _install_package(package, index, target, version, mpy):
-    if any(package.startswith(p) for p in allowed_mip_url_prefixes):
+    if any(package.startswith(p) for p in _ALLOWED_MIP_URL_PREFIXES):
         if package.endswith(".py") or package.endswith(".mpy"):
             print("Downloading {} to {}".format(package, target))
             return _download_file(


### PR DESCRIPTION
### Summary

This PR introduces an alias to access codeberg repos from within the mip embedded package manager.

Right now packages hosted on codeberg could only be referenced by their full URL, unlike other packages hosted on either GitHub or GitLab.  To make access those packages easier, now they can be referenced as "codeberg:org/repo".

This is the `micropython-lib` counterpart of https://github.com/micropython/micropython/pull/18989.

### Testing

The same package mentioned in the other repo's PR (https://codeberg.org/agatti/micropython-package-test) was installed successfully via `import mip; mip.install("$URL")` on an ESP32C3.

The ESP8266 is not able to access codeberg repos due to a SSL cipher incompatibility (see #400), but there isn't much that can be done for that right now.

### Trade-offs and Alternatives

The same remarks about whether adding a new provider or not, mentioned in the micropython PR still apply.

A similar refactoring has been applied to the on-device python code - albeit with a few more aggressive size optimisations, having a final size impact of -6 bytes.  Unfortunately codeberg using a different parameter order than the other hosts forces having some named parameters in the string template so some more space could have been saved there.  A further size reduction could be had by renaming `_HOSTS` into something shorter.  Suggestions for the new name are welcome :)

### Generative AI

I did not use generative AI tools when creating this PR.