### PR TITLE
usb-device-core: Fix comment describing the signature of done_cb.

### DIFF
--- a/micropython/usb/usb-device/usb/device/core.py
+++ b/micropython/usb/usb-device/usb/device/core.py
@@ -575,10 +575,10 @@ class Interface:
         # - data. Buffer containing data to send, or for data to be read into
         #   (depending on endpoint direction).
         #
-        # - done_cb. Optional callback function for when the transfer
-        # completes. The callback is called with arguments (ep_addr, result,
-        # xferred_bytes) where result is one of xfer_result_t enum (see top of
-        # this file), and xferred_bytes is an integer.
+        # - done_cb. Optional callback function for when the transfer completes.
+        # The callback is called with arguments (ep_addr, result, xferred_bytes)
+        # where result is an integer equal to one of machine.USBDevice.XFER_nnn
+        # enums, and xferred_bytes is an integer.
         #
         # If the function returns, the transfer is queued.
         #


### PR DESCRIPTION
Small comment change to reference the new enums added in https://github.com/micropython/micropython/pull/19052 (The other enums referenced in the comment were never added!)

None of the existing drivers in micropython-lib use this `result` argument, they all just look at the number of bytes transferred and continue accordingly.