### PR TITLE
python-stdlib/unittest/unittest: Remove f-strings.

### DIFF
--- a/python-stdlib/unittest/manifest.py
+++ b/python-stdlib/unittest/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.10.4")
+metadata(version="0.10.5")
 
 package("unittest")

--- a/python-stdlib/unittest/unittest/__init__.py
+++ b/python-stdlib/unittest/unittest/__init__.py
@@ -1,5 +1,4 @@
 import io
-import os
 import sys
 
 try:
@@ -49,10 +48,10 @@ class SubtestContext:
             global __test_result__, __current_test__
             test_details = __current_test__
             if self.msg:
-                test_details += (f" [{self.msg}]",)
+                test_details += (" [%s]" % self.msg,)
             if self.params:
-                detail = ", ".join(f"{k}={v}" for k, v in self.params.items())
-                test_details += (f" ({detail})",)
+                detail = ", ".join("%s=%s" % k_v for k_v in self.params.items())
+                test_details += (" (%s)" % detail,)
 
             _handle_test_exception(test_details, __test_result__, exc_info, False)
         # Suppress the exception as we've captured it above
@@ -310,7 +309,7 @@ class TestResult:
         for c, e in lst:
             detail = " ".join((str(i) for i in c))
             print("======================================================================")
-            print(f"FAIL: {detail}")
+            print("FAIL:", detail)
             print(sep)
             print(e)
 
@@ -391,7 +390,7 @@ def _run_suite(c, test_result: TestResult, suite_name=""):
         print("%s (%s) ..." % (name, suite_name), end="")
         set_up()
         __test_result__ = test_result
-        test_container = f"({suite_name})"
+        test_container = "(%s)" % suite_name
         __current_test__ = (name, test_container)
         try:
             test_result._newFailures = 0


### PR DESCRIPTION
### Summary

This PR removes usage of f-strings from the unittest module, in favour to the old printf-style raw string formatting operations.

The module is a bit special since it is meant to be also validate the behaviour of MicroPython interpreters, and those may come with any combination of configuration options.  For example, f-strings are not available by default on some feature levels, and thus the test suite won't run cleanly on certain targets unless the support for that feature is explicitly enabled.

See the discussion at https://github.com/micropython/micropython/pull/19111 for more information.

I've had a quick look at ruff's available rules and I didn't find a ruff rule that would prevent f-strings to reappear in the future, otherwise I'd have put the restriction in place for this file.

As a bonus, now the module is 31 bytes shorter :)

### Testing

Overwriting the `__init__.py` file on a board compiled with `MICROPY_CONFIG_ROM_LEVEL_CORE_FEATURES` doesn't trigger a `SyntaxError` exception anymore.  Tests in MicroPython's test suite that depend on `unittest` to be available on device now execute.

### Generative AI

I did not use generative AI tools when creating this PR.