### PR TITLE
lora: Fix IRQ bit mask for sx126x

### DIFF
--- a/micropython/lora/lora-sx126x/lora/sx126x.py
+++ b/micropython/lora/lora-sx126x/lora/sx126x.py
@@ -233,7 +233,7 @@ class _SX126x(BaseModem):
             self._cmd(
                 ">BHHHH",
                 _CMD_CFG_DIO_IRQ,
-                (_IRQ_RX_DONE | _IRQ_TX_DONE | _IRQ_TIMEOUT),  # IRQ mask
+                (_IRQ_RX_DONE | _IRQ_TX_DONE | _IRQ_TIMEOUT | _IRQ_CRC_ERR),  # IRQ mask
                 (_IRQ_RX_DONE | _IRQ_TX_DONE | _IRQ_TIMEOUT),  # DIO1 mask
                 0x0,  # DIO2Mask, not used
                 0x0,  # DIO3Mask, not used

--- a/micropython/lora/lora-sx126x/lora/sx126x.py
+++ b/micropython/lora/lora-sx126x/lora/sx126x.py
@@ -224,12 +224,9 @@ class _SX126x(BaseModem):
 
         # If DIO1 is set, mask in just the IRQs that the driver may need to be
         # interrupted by. This is important because otherwise an unrelated IRQ
-        # can trigger the ISR and may not be reset by the driver, leaving DIO1 high.
-        #
-        # If DIO1 is not set, all IRQs can stay masked which is the power-on state.
+        # can trigger the ISR and may not be reset by the driver, leaving DIO1
+        # high.
         if dio1:
-            # Note: we set both Irq mask and DIO1 mask to the same value, which is redundant
-            # (one could be 0xFFFF) but may save a few bytes of bytecode.
             self._cmd(
                 ">BHHHH",
                 _CMD_CFG_DIO_IRQ,

--- a/micropython/lora/lora-sx126x/manifest.py
+++ b/micropython/lora/lora-sx126x/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.5")
+metadata(version="0.1.6")
 require("lora")
 package("lora")


### PR DESCRIPTION
Fixes #1112 which causes corrupt packets to silently be passed as valid by the driver. 