### PR TITLE
net/webrepl: Support LAN interfaces and fix AttributeError on ports without WLAN

### DIFF
--- a/micropython/net/webrepl/manifest.py
+++ b/micropython/net/webrepl/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="WebREPL server.", version="0.1.0")
+metadata(description="WebREPL server.", version="0.1.1")
 
 module("webrepl.py", opt=3)
 module("webrepl_setup.py", opt=3)

--- a/micropython/net/webrepl/webrepl.py
+++ b/micropython/net/webrepl/webrepl.py
@@ -102,10 +102,23 @@ def setup_conn(port, accept_handler):
     listen_s.listen(1)
     if accept_handler:
         listen_s.setsockopt(socket.SOL_SOCKET, 20, accept_handler)
-    for i in (network.WLAN.IF_AP, network.WLAN.IF_STA):
-        iface = network.WLAN(i)
-        if iface.active():
-            print("WebREPL server started on http://%s:%d/" % (iface.ifconfig()[0], port))
+    for i in (0, 1):
+        try:
+            iface = network.LAN(i)
+            if iface.active():
+                print("WebREPL server started on http://%s:%d/" % (iface.ifconfig()[0], port))
+                return listen_s
+        except (AttributeError, TypeError, ValueError):
+            pass
+    try:
+        for i in (network.WLAN.IF_AP, network.WLAN.IF_STA):
+            iface = network.WLAN(i)
+            if iface.active():
+                print("WebREPL server started on http://%s:%d/" % (iface.ifconfig()[0], port))
+                return listen_s
+    except AttributeError:
+        pass
+    print("WebREPL server started on http://0.0.0.0:%d/" % port)
     return listen_s
 
 


### PR DESCRIPTION
WebREPL currently does not support LAN interfaces, and raises an AttributeError on webrepl.start() on boards without network.WLAN, such as the ESP32-P4 port. The exception is raised in setup_conn() in line 105:

```python
    for i in (network.WLAN.IF_AP, network.WLAN.IF_STA):
```

Steps to reproduce:

1. Flash the [latest firmware for the ESP32-P4 port](https://micropython.org/download/ESP32_GENERIC_P4/)
2. Inside the REPL, configure WebREPL using `import webrepl_setup`
3. If configured to enable on startup, it will immediately raise:
```Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "webrepl.py", line 1, in start
  File "webrepl.py", line 1, in setup_conn
AttributeError: 'module' object has no attribute 'WLAN'
```

This PR adds
1. a try-except block for the existing WLAN logic, to catch this AttributeError.
2. support for LAN interfaces, with a try-except block to catch errors (such as a TypeError in the event that the LAN interface has not yet been initialized).
3. A fallback for when neither type of interface has been found.

I have tested this on an ESP32-P4-ETH board, and a generic ESP32 board. Works as intended.

This issue was raised before in #920 by @Romaric-RILLET, but that attempted fix failed to cover the network.WLAN AttributeError (as it happens outside the try-except block), making it impossible for ethernet-only boards to use WebREPL.