### PR TITLE
lora-sx126x: Enable all IRQ Mask bits unconditionally.

### DIFF
--- a/micropython/lora/lora-sx126x/lora/sx126x.py
+++ b/micropython/lora/lora-sx126x/lora/sx126x.py
@@ -227,15 +227,21 @@ class _SX126x(BaseModem):
         # can trigger the ISR and may not be reset by the driver, leaving DIO1
         # high.
         if dio1:
-            self._cmd(
-                ">BHHHH",
-                _CMD_CFG_DIO_IRQ,
-                (_IRQ_RX_DONE | _IRQ_TX_DONE | _IRQ_TIMEOUT | _IRQ_CRC_ERR),  # IRQ mask
-                (_IRQ_RX_DONE | _IRQ_TX_DONE | _IRQ_TIMEOUT),  # DIO1 mask
-                0x0,  # DIO2Mask, not used
-                0x0,  # DIO3Mask, not used
-            )
-            dio1.irq(self._radio_isr, Pin.IRQ_RISING)
+            dio1_mask = _IRQ_RX_DONE | _IRQ_TX_DONE | _IRQ_TIMEOUT
+        else:
+            dio1_mask = 0
+
+        self._cmd(
+            ">BHHHH",
+            _CMD_CFG_DIO_IRQ,
+            # The Irq Mask byte needs to be set so that _CMD_GET_IRQ_STATUS returns all
+            # relevant flags that driver might check
+            _IRQ_TX_DONE | _IRQ_DRIVER_RX_MASK,
+            dio1_mask,  # DIO1Mask
+            0x0,  # DIO2Mask, not used
+            0x0,  # DIO3Mask, not used
+        )
+        dio1.irq(self._radio_isr, Pin.IRQ_RISING)
 
         self._clear_irq()
 


### PR DESCRIPTION
Expands _IRQ_CRC_ERR fix from #1113 by always enabling all the Irq Mask bits that the driver may want to read back later, i.e. also including the header error bit.

Currently unclear if this is necessary or a mistake, but the idea is:

* Ensure all status IRQ flags can be read even if `dio1` is not set.
* Correctly detect header errors on RX by masking them in. (It is unclear if this approach is correct - i.e. if the header error IRQ bit behaves the same as the CRC error or whether it is "sticky", in which case this approach will lead to spurious errors being flagged...)

Needs more time to test, but opening as a Draft for now.