### PR TITLE
pathlib: Fix glob/rglob to return Path objects rather than strings.

### DIFF
--- a/python-stdlib/pathlib/manifest.py
+++ b/python-stdlib/pathlib/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.0.1")
+metadata(version="0.0.2")
 
 module("pathlib.py")

--- a/python-stdlib/pathlib/pathlib.py
+++ b/python-stdlib/pathlib/pathlib.py
@@ -126,7 +126,7 @@ class Path:
         for name, mode, *_ in os.ilistdir(path):
             full_path = path + _SEP + name
             if name.startswith(prefix) and name.endswith(suffix):
-                yield full_path
+                yield Path(full_path)
             if recursive and mode & 0x4000:  # is_dir
                 yield from self._glob(full_path, pattern, recursive=recursive)
 

--- a/python-stdlib/pathlib/tests/test_pathlib.py
+++ b/python-stdlib/pathlib/tests/test_pathlib.py
@@ -164,7 +164,10 @@ class TestPathlib(unittest.TestCase):
         glob_gen = path.glob("*.txt")
         self.assertTrue(_isgenerator(glob_gen))
 
-        res = [str(x) for x in glob_gen]
+        res = list(glob_gen)
+        for p in res:
+            self.assertIsInstance(p, Path)
+
         self.assertTrue(len(res) == 2)
         self.assertTrue(foo_txt in res)
         self.assertTrue(bar_txt in res)
@@ -190,7 +193,10 @@ class TestPathlib(unittest.TestCase):
         glob_gen = path.rglob("*.txt")
         self.assertTrue(_isgenerator(glob_gen))
 
-        res = [str(x) for x in glob_gen]
+        res = list(glob_gen)
+        for p in res:
+            self.assertIsInstance(p, Path)
+
         self.assertTrue(len(res) == 3)
         self.assertTrue(foo_txt in res)
         self.assertTrue(bar_txt in res)


### PR DESCRIPTION
### Summary

This now matches CPython behaviour.

(This fix was made in #1027 but that PR was closed.)

## Testing

Updated the unittest that runs under CI.

### Generative AI

Not used.