### PR TITLE
requests: Add context manager for response object.

### DIFF
--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -32,6 +32,12 @@ class Response:
 
         return json.loads(self.content)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
 
 def request(
     method,


### PR DESCRIPTION
### Summary

When accessing `response.raw` it's not always obvious you should call `response.close()` to close and free the socket. Since lwIP has a five socket limit by default this can very quickly result in cryptic ENOMEM errors.

A context manager is widely understood to handle freeing resources on exit and permits the following, Pythonic pattern without leaking open sockets:

```python
buffer = bytearray(1024)
with requests.get("some-resource") as response:
    while length := response.raw.readinto(buffer)
        output.write(memoryview(buffer)[:length])
```

While I came up with this idea and wrote this code independently , this PR transpired to be partially a dupe of https://github.com/micropython/micropython-lib/pull/278 but I have excluded the iteration features in favour of a clean, concise change in the hope it would be easier to consider.

### Testing

This is a minor change adding well understood magic methods, I did a cursory check to make sure it would work.

### Trade-offs and Alternatives

This is a very minor change for a lot of potential utility, though without associated documentation changes it's unlikely to receive adoption.

CPython's "requests" library has the concept of a `Session`, which includes a context manager at a lower level, and implements get/post etc using a transient Session. This is a potentially useful concept in MicroPython because the time cost of re-opening a socket when TLS is involved is prohibitive - 300-400ms. I'm currently using a completely custom HTTP library to avoid this.

This change also has some minor functional overlap with `urllib urequest`'s `urlopen` which is sometimes favoured for streaming requests.

### Generative AI

I did not use generative AI tools when creating this PR.