### PR TITLE
unix-ffi/ffilib/ffilib.py: Extend libc versions range.

### DIFF
--- a/unix-ffi/ffilib/ffilib.py
+++ b/unix-ffi/ffilib/ffilib.py
@@ -17,7 +17,7 @@ def open(name, maxver=10, extra=()):
         pass
 
     def libs():
-        if sys.platform == "linux":
+        if sys.platform in ("linux", "freebsd"):
             yield "%s.so" % name
             for i in range(maxver, -1, -1):
                 yield "%s.so.%u" % (name, i)
@@ -39,7 +39,7 @@ def open(name, maxver=10, extra=()):
 
 
 def libc():
-    return open("libc", 6)
+    return open("libc", 7)
 
 
 # Find out bitness of the platform, even if long ints are not supported

--- a/unix-ffi/ffilib/manifest.py
+++ b/unix-ffi/ffilib/manifest.py
@@ -1,6 +1,6 @@
 metadata(
     description="MicroPython FFI helper module to easily interface with underlying shared libraries",
-    version="0.1.3",
+    version="0.2.0",
 )
 
 # Originally written by Damien George.


### PR DESCRIPTION
### Summary

This PR extends the range of libc library versions that are looked up when required by user code.

FreeBSD 14.1-RELEASE and later versions require an update to the range since they bumped up their libc major version, from 6 to 7.  This has the side-effect of guaranteeing at least one failed lookup on modern Linux systems, where the libc is still at version 6.

With updated FreeBSD support in MicroPython core, now `sys.platform` properly returns `freebsd`.  This required a minor change in the code deciding whether to look for `.so`, `.dylib`, or `.dll` files, since `linux` is no longer the default fallback for generic unix systems.

(Hopefully) closes #962.

### Testing

Using an interpreter built from MicroPython git `master` with `require("ffilib")` added to the manifest,  `import ffilib; ffilib.libc()` was called making sure the function returned a valid `ffimod` object.

This was done manually both on a current Arch Linux/x64 system and on a FreeBSD 15.0-RELEASE x64 VM.
### Trade-offs and Alternatives

This comes with a 13 bytes increase, mostly to hold the `freebsd` string in the MPY file itself.
### Generative AI

I did not use generative AI tools when creating this PR.