### PR TITLE
CONTRIBUTING: Remove references to `black`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,15 +27,14 @@ or packages from micropython-lib, please post at the
 The same rules for commit messages, signing-off commits, and commit structure
 apply [as for the main MicroPython repository](https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md).
 
-All Python code is formatted using the [black](https://github.com/psf/black)
+All Python code is formatted using the [ruff](https://github.com/astral-sh/ruff)
 tool. You can run [`tools/codeformat.py`](tools/codeformat.py) to apply
-`black` automatically before submitting a PR. The GitHub CI will also run the
-[ruff](https://github.com/astral-sh/ruff) tool to apply further "linting"
-checks.
+`ruff` automatically before submitting a PR. The GitHub CI will also use `ruff`
+to apply further "linting" checks.
 
 Similar to the main repository, a configuration is provided for the
-[pre-commit](https://pre-commit.com/) tool to apply `black` code formatting
-rules and run `ruff` automatically. See the documentation for using pre-commit
+[pre-commit](https://pre-commit.com/) tool to apply `ruff` code formatting
+rules and apply linting checks. See the documentation for using pre-commit
 in [the code conventions document](https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md#automatic-pre-commit-hooks)
 
 In addition to the conventions from the main repository, there are some


### PR DESCRIPTION
### Summary

This PR updates the contribution guidelines, removing references to the `black` formatting tool since `ruff` is used to do both linting and formatting these days.

### Testing

Running `grep -ir black` in the repository directory didn't yield any references to the `black` formatting tool :)

### Generative AI

I did not use generative AI tools when creating this PR.