### PR TITLE
usb-device-keyboard: Add a simpler keyboard example, document releasing.

### DIFF
--- a/micropython/usb/README.md
+++ b/micropython/usb/README.md
@@ -98,8 +98,9 @@ source code of the other USB device packages.
 ### Package usb-device-keyboard
 
 This package provides the `usb.device.keyboard` module. See
-[keyboard_example.py](examples/device/keyboard_example.py) for an example
-program.
+[keyboard_hello_example.py](examples/device/keyboard_hello_example.py) and
+[keyboard_pin_example.py](examples/device/keyboard_pin_example.py) for example
+programs.
 
 ### Package usb-device-mouse
 

--- a/micropython/usb/examples/device/hid_custom_keypad_example.py
+++ b/micropython/usb/examples/device/hid_custom_keypad_example.py
@@ -3,8 +3,8 @@
 # This example demonstrates creating a custom HID device with its own
 # HID descriptor, in this case for a USB number keypad.
 #
-# For higher level examples that require less code to use, see mouse_example.py
-# and keyboard_example.py
+# For higher level examples that require less code to use, see mouse_example.py,
+# keyboard_hello_example.py and keyboard_pin_example.py
 #
 # To run this example:
 #

--- a/micropython/usb/examples/device/keyboard_hello_example.py
+++ b/micropython/usb/examples/device/keyboard_hello_example.py
@@ -1,0 +1,71 @@
+# MicroPython USB Keyboard simple "Hello" example
+#
+# Simulates a keyboard pressing "H", "e", "l", "l", "o" in sequence, then exits.
+#
+# To run this example:
+#
+# 1. Make sure `usb-device-keyboard` is installed via: mpremote mip install usb-device-keyboard
+#
+# 2. Run the example via: mpremote run keyboard_hello_example.py
+#
+# 3. mpremote will exit with an error after the previous step, because when the
+#    example runs the existing USB device disconnects and then re-enumerates with
+#    the keyboard interface present. At this point, the example is running.
+#
+# 4. The example should stop running after USB has enumerated and it has typed Hello.
+#    At this point it will be possible to access the REPL again, but if you re-initialise
+#    USB then it will exit with an error again.
+#
+# For a more complex keyboard example that includes LED support, see keyboard_pin_example.py.
+#
+# MIT license; Copyright (c) 2026 Angus Gratton
+import usb.device
+from usb.device.keyboard import KeyboardInterface, KeyCode as KC
+import time
+
+
+def keyboard_example():
+    # Sequence to type.
+    #
+    # See 'class KeyCode' in usb-device-keyboard/usb/device/keyboard.py for
+    # the list of key codes
+    SEQUENCE = [
+        (KC.LEFT_SHIFT, KC.H),
+        (KC.E,),
+        (KC.L,),
+        (KC.L,),
+        (KC.O,),
+    ]
+
+    # Register the keyboard interface and re-enumerate
+    k = KeyboardInterface()
+    usb.device.get().init(k, builtin_driver=True)
+
+    print("Waiting for keyboard to enumerate...")
+    while not k.is_open():
+        time.sleep_ms(100)
+
+    # Give the host a moment to be ready to receive keys (this delay can be shorter on most hosts)
+    time.sleep_ms(1000)
+
+    print("Typing sequence...")
+    for keys in SEQUENCE:
+        # wait for host to process any pending keyboard events
+        while k.busy():
+            time.sleep_ms(10)
+
+        k.send_keys(keys)
+        time.sleep_ms(20)
+
+        # After setting a key code, need to un-set to release the key again.
+        # For this example we release all keys by sending an empty
+        # tuple of key codes
+        k.send_keys(())
+
+        # Add a visible delay between each key
+        time.sleep_ms(500)
+
+    print("Done")
+
+
+keyboard_example()

--- a/micropython/usb/examples/device/keyboard_pin_example.py
+++ b/micropython/usb/examples/device/keyboard_pin_example.py
@@ -1,4 +1,9 @@
-# MicroPython USB Keyboard example
+# MicroPython USB Keyboard pin example
+#
+# Simulates a basic keyboard using one or more pin inputs to the board.
+#
+# See also the example keyboard_hello_example.py, which is a one-shot example
+# that types something and then exits.
 #
 # To run this example:
 #
@@ -10,7 +15,7 @@
 #
 # 2. Make sure `usb-device-keyboard` is installed via: mpremote mip install usb-device-keyboard
 #
-# 3. Run the example via: mpremote run keyboard_example.py
+# 3. Run the example via: mpremote run keyboard_pin_example.py
 #
 # 4. mpremote will exit with an error after the previous step, because when the
 #    example runs the existing USB device disconnects and then re-enumerates with
@@ -79,13 +84,24 @@ def keyboard_example():
     # iteration will always send
     while True:
         if k.is_open():
+            # Wait for host to process any outstanding keyboard events
+            while k.busy():
+                time.sleep_ms(1)
+
+            # Build the list of keys which are held down, each time around the
+            # loop. The key will stay 'down' for as long as it is in this list,
+            # and will be released as soon as send_keys() is called and it's not
+            # in the list.
             keys.clear()
             for pin, code in KEYS:
                 if not pin():  # active-low
                     keys.append(code)
+
+            # Send a new list of keys each time the list changes
             if keys != prev_keys:
                 # print(keys)
                 k.send_keys(keys)
+
                 prev_keys.clear()
                 prev_keys.extend(keys)
 

--- a/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
+++ b/micropython/usb/usb-device-keyboard/usb/device/keyboard.py
@@ -41,6 +41,12 @@ class KeyboardInterface(HIDInterface):
         #
         # Will block for up to timeout_ms if a previous report is still
         # pending to be sent to the host. Returns True on success.
+        #
+        # After passing a keycode value in down_keys, it's necessary to call the
+        # function again without that key code set in order to release the key.
+        #
+        # Calling send_keys(()) (i.e. empty down_keys argument) will release all
+        # keys.
 
         r, s = self._key_reports  # next report buffer to send, spare report buffer
         r[0] = 0  # modifier byte


### PR DESCRIPTION
### Summary

The existing keyboard example doesn't make it obvious how to release a key, so rename that example to `keyboard_pin_example.py` and make a very simple `keyboard_hello_example.py` that presses and releases keys in sequence to type out "Hello".

Also add a note on the `send_keys()` API about how to release a key.

This is an alternative to adding a new key release API, as contributed in #892.

*This work was funded through GitHub Sponsors.*

### Testing

* Ran the new example on an RPI_PICO2_W and an ESP32-S3 board.

### Trade-offs and Alternatives

* Adding a new API just for releasing keys (as implemented in #892 by @amogha1234) may be easier to use, but this way keeps the library as small as possible and it more closely maps to how USB HID works (i.e. even with a key release API, `send_keys()` will still release a key if it's not included in the argument). 

### Generative AI

I did not use generative AI tools when creating this PR.