### PR TITLE
Extend Unittest with @expectedFailure

### DIFF
--- a/python-stdlib/unittest-discover/manifest.py
+++ b/python-stdlib/unittest-discover/manifest.py
@@ -1,4 +1,4 @@
-metadata(version="0.1.3")
+metadata(version="0.1.4")
 
 require("argparse")
 require("fnmatch")

--- a/python-stdlib/unittest-discover/unittest/__main__.py
+++ b/python-stdlib/unittest-discover/unittest/__main__.py
@@ -146,8 +146,9 @@ def discover_main():
         # Ensure an appropriate output is printed if no tests are found.
         runner.run(TestSuite())
 
-    # Terminate with non zero return code in case of failures.
-    sys.exit(result.failuresNum + result.errorsNum)
+    # Terminate with non zero return code in case of failures. unexpectedSuccessesNum
+    # is only present when the unittest-expectedfailure add-on is installed.
+    sys.exit(result.failuresNum + result.errorsNum + getattr(result, "unexpectedSuccessesNum", 0))
 
 
 discover_main()

--- a/python-stdlib/unittest-expectedfailure/README.md
+++ b/python-stdlib/unittest-expectedfailure/README.md
@@ -1,0 +1,86 @@
+# unittest-expectedfailure
+
+An optional add-on for the MicroPython [`unittest`](../unittest) package that
+adds CPython-compatible tracking of **expected failures** and **unexpected
+successes**.
+
+## Background
+
+The base `unittest` package is intentionally small. Its
+`@unittest.expectedFailure` decorator swallows a failing test and raises
+`AssertionError` on an unexpected pass, but it does not track those two cases as
+separate result categories the way CPython does.
+
+This package layers that behaviour on top of the base package without modifying
+it, in the same "overlay" style as `unittest-discover`: installing it adds a
+single module, `unittest/expectedfailure.py`, next to the base
+`unittest/__init__.py`, and importing that module patches `unittest` at runtime.
+
+## What it adds
+
+Once activated, results are reported like CPython:
+
+| Case                       | Counter                 | `wasSuccessful()` | Runner summary                   |
+| -------------------------- | ----------------------- | ----------------- | -------------------------------- |
+| Decorated test that fails  | `expectedFailuresNum`   | stays `True`      | `OK (expected failures=N)`       |
+| Decorated test that passes | `unexpectedSuccessesNum`| becomes `False`   | `FAILED (unexpected successes=N)`|
+
+Matching CPython, an unexpected success is **not** counted as a failure or
+error — it has its own counter — but it still makes the overall run
+unsuccessful.
+
+`TestResult` gains `expectedFailuresNum` and `unexpectedSuccessesNum` counters,
+aggregated across modules by `TestResult.__add__` (as used by
+`unittest-discover`). They are class-level defaults, so a `TestResult` allocates
+no extra memory until a test is actually recorded.
+
+## Installation
+
+Using `mip`:
+
+```
+mip install unittest-expectedfailure
+```
+
+or add `require("unittest-expectedfailure")` to your `manifest.py`. It pulls in
+`unittest` automatically.
+
+## Usage
+
+Activate the add-on by importing it once, before your tests run, then use the
+decorator through the `unittest` namespace:
+
+```python
+import unittest
+import unittest.expectedfailure  # activates the add-on (import for its side effect)
+
+
+class MyTests(unittest.TestCase):
+    @unittest.expectedFailure
+    def test_known_bug(self):
+        self.assertEqual(buggy(), 42)  # currently fails; that's expected
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+Notes:
+
+- Reference the decorator as `@unittest.expectedFailure` (looked up at call
+  time) and make sure `import unittest.expectedfailure` runs first. Binding the
+  name early with `from unittest import expectedFailure` would capture the
+  un-patched decorator.
+- The module is safe to import more than once (for example under
+  `unittest-discover`, which re-imports test modules); it patches the base
+  package only once.
+- Like the base package since its size optimisation, this module avoids `assert`
+  so it keeps working when compiled with `-O3`.
+
+## `unittest-discover` exit code
+
+`unittest-discover` (>= 0.1.4) includes unexpected successes in its process exit
+code, so `micropython -m unittest` returns non-zero when a decorated test
+unexpectedly passes — even though such a test is tracked separately and is not
+counted as a `failure`. Older versions considered only `failuresNum + errorsNum`
+and would exit `0` for an unexpected-success-only run.

--- a/python-stdlib/unittest-expectedfailure/manifest.py
+++ b/python-stdlib/unittest-expectedfailure/manifest.py
@@ -1,0 +1,8 @@
+metadata(
+    version="0.1.0",
+    description="Adds CPython-compatible expected-failure / unexpected-success tracking to unittest.",
+)
+
+require("unittest")
+
+package("unittest")

--- a/python-stdlib/unittest-expectedfailure/tests/test_expectedfailure.py
+++ b/python-stdlib/unittest-expectedfailure/tests/test_expectedfailure.py
@@ -1,0 +1,103 @@
+# Tests for the optional "unittest-expectedfailure" add-on.
+#
+# The add-on is activated purely by importing it: it monkey-patches the base
+# "unittest" package to add CPython-compatible expected-failure / unexpected-
+# success tracking.
+#
+# Each test runs an inner TestCase through its own TestResult and inspects the
+# counters, so the outer test run is never made to fail by the cases under test.
+import sys
+import unittest
+import unittest.expectedfailure  # noqa: F401  (imported for its side effect)
+
+
+def _run(test_cls):
+    result = unittest.TestResult()
+    suite = unittest.TestSuite()
+    suite.addTest(test_cls)
+    suite.run(result)
+    return result
+
+
+class TestExpectedFailure(unittest.TestCase):
+    def test_expected_failure_is_not_a_failure(self):
+        class Inner(unittest.TestCase):
+            @unittest.expectedFailure
+            def test_x(self):
+                self.assertEqual(1, 0)  # fails as expected
+
+        r = _run(Inner)
+        self.assertEqual(r.testsRun, 1)
+        self.assertEqual(r.expectedFailuresNum, 1)
+        self.assertEqual(r.failuresNum, 0)
+        self.assertEqual(r.errorsNum, 0)
+        self.assertTrue(r.wasSuccessful())
+
+    def test_unexpected_success_is_tracked_separately(self):
+        class Inner(unittest.TestCase):
+            @unittest.expectedFailure
+            def test_x(self):
+                self.assertEqual(1, 1)  # passes -> unexpected success
+
+        r = _run(Inner)
+        self.assertEqual(r.testsRun, 1)
+        self.assertEqual(r.unexpectedSuccessesNum, 1)
+        # CPython semantics: an unexpected success is NOT a failure or error ...
+        self.assertEqual(r.failuresNum, 0)
+        self.assertEqual(r.errorsNum, 0)
+        # ... but it does make the overall run unsuccessful.
+        self.assertFalse(r.wasSuccessful())
+
+    def test_regular_failure_still_counts_as_failure(self):
+        class Inner(unittest.TestCase):
+            def test_x(self):
+                self.assertEqual(1, 0)
+
+        r = _run(Inner)
+        self.assertEqual(r.failuresNum, 1)
+        self.assertEqual(r.expectedFailuresNum, 0)
+        self.assertEqual(r.unexpectedSuccessesNum, 0)
+        self.assertFalse(r.wasSuccessful())
+
+    def test_error_is_unaffected(self):
+        class Inner(unittest.TestCase):
+            def test_x(self):
+                raise ValueError("boom")
+
+        r = _run(Inner)
+        self.assertEqual(r.errorsNum, 1)
+        self.assertEqual(r.expectedFailuresNum, 0)
+        self.assertEqual(r.unexpectedSuccessesNum, 0)
+        self.assertFalse(r.wasSuccessful())
+
+    def test_results_aggregate_across_modules(self):
+        # unittest-discover combines per-module results with "+"; the new
+        # counters must be carried across.
+        class ExpFail(unittest.TestCase):
+            @unittest.expectedFailure
+            def test_x(self):
+                self.assertEqual(1, 0)
+
+        class UnexpSucc(unittest.TestCase):
+            @unittest.expectedFailure
+            def test_x(self):
+                self.assertEqual(1, 1)
+
+        combined = _run(ExpFail) + _run(UnexpSucc)
+        self.assertEqual(combined.expectedFailuresNum, 1)
+        self.assertEqual(combined.unexpectedSuccessesNum, 1)
+        self.assertFalse(combined.wasSuccessful())
+
+    def test_reimport_does_not_repatch(self):
+        # unittest-discover re-imports test modules with a restored sys.modules,
+        # so the add-on may be imported more than once. Re-importing must not
+        # patch the machinery a second time.
+        before = unittest._handle_test_exception
+        sys.modules.pop("unittest.expectedfailure", None)
+        __import__("unittest.expectedfailure")
+
+        self.assertIs(unittest._handle_test_exception, before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python-stdlib/unittest-expectedfailure/unittest/expectedfailure.py
+++ b/python-stdlib/unittest-expectedfailure/unittest/expectedfailure.py
@@ -1,0 +1,117 @@
+# Optional add-on for the "unittest" package that adds CPython-compatible
+# tracking of expected failures and unexpected successes.
+#
+# Activate it by importing this module once, before running your tests:
+#
+#     import unittest
+#     import unittest.expectedfailure  # imported for its side effect
+#
+# then decorate tests as usual with @unittest.expectedFailure.
+#
+# Behaviour (matching CPython):
+#   - a decorated test that fails    -> counted in expectedFailuresNum,
+#                                        the run stays successful
+#   - a decorated test that passes   -> counted in unexpectedSuccessesNum,
+#                                        NOT counted as a failure/error, but
+#                                        wasSuccessful() becomes False
+import unittest
+
+# unittest-discover re-imports test modules with a restored sys.modules, so this
+# module can execute more than once per session.
+if not getattr(unittest, "_expectedfailure_patched", False):
+
+    class _ExpectedFailure(Exception):
+        pass
+
+    class _UnexpectedSuccess(Exception):
+        pass
+
+    _orig_handle = unittest._handle_test_exception
+    _orig_result_add = unittest.TestResult.__add__
+
+    # Decorator: run the wrapped test and raise a sentinel exception so the
+    # result machinery can tell an expected failure (the test raised) from an
+    # unexpected success (the test passed).
+    def expectedFailure(test):
+        def wrapper(*args, **kwargs):
+            try:
+                test(*args, **kwargs)
+            except Exception:
+                raise _ExpectedFailure
+            raise _UnexpectedSuccess
+
+        return wrapper
+
+    # Replaces unittest._handle_test_exception: record the two sentinel outcomes
+    # in their own result categories, and delegate any other exception to the
+    # original handler (failures, errors, skips).
+    def _handle_test_exception(current_test, test_result, exc, verbose=True):
+        if isinstance(exc, _ExpectedFailure):
+            test_result.expectedFailuresNum += 1
+            if verbose:
+                print(" expected failure")
+            return
+        if isinstance(exc, _UnexpectedSuccess):
+            test_result.unexpectedSuccessesNum += 1
+            if verbose:
+                print(" unexpected success")
+            return
+        return _orig_handle(current_test, test_result, exc, verbose)
+
+    # Extend TestResult.__add__ so the new counters are aggregated when
+    # per-module results are combined (unittest-discover sums results with "+").
+    def _result_add(self, other):
+        _orig_result_add(self, other)
+        self.expectedFailuresNum += other.expectedFailuresNum
+        self.unexpectedSuccessesNum += other.unexpectedSuccessesNum
+        return self
+
+    def _was_successful(self):
+        # An unexpected success is not a failure or error, but (like CPython) it
+        # does make the overall run unsuccessful.
+        return self.errorsNum == 0 and self.failuresNum == 0 and self.unexpectedSuccessesNum == 0
+
+    # Replaces TestRunner.run: like the base runner, but reports expected
+    # failures / unexpected successes in the CPython-style summary and decides
+    # OK/FAILED via wasSuccessful().
+    def _runner_run(self, suite):
+        result = unittest.TestResult()
+        suite.run(result)
+
+        result.printErrors()
+        print("----------------------------------------------------------------------")
+        print("Ran %d tests\n" % result.testsRun)
+        infos = []
+        if result.wasSuccessful():
+            status = "OK"
+        else:
+            status = "FAILED"
+            if result.failuresNum:
+                infos.append("failures=%d" % result.failuresNum)
+            if result.errorsNum:
+                infos.append("errors=%d" % result.errorsNum)
+        if result.skippedNum:
+            infos.append("skipped=%d" % result.skippedNum)
+        if result.expectedFailuresNum:
+            infos.append("expected failures=%d" % result.expectedFailuresNum)
+        if result.unexpectedSuccessesNum:
+            infos.append("unexpected successes=%d" % result.unexpectedSuccessesNum)
+        if infos:
+            print("%s (%s)" % (status, ", ".join(infos)))
+        else:
+            print(status)
+        return result
+
+    unittest.expectedFailure = expectedFailure
+    unittest._handle_test_exception = _handle_test_exception
+    # Class-level defaults keep the counters free per-result: no instance
+    # attribute is allocated until a test is actually recorded (an instance
+    # attribute is created on first increment). They also let results created
+    # before this add-on loaded (e.g. discover's accumulator) be read and
+    # combined with "+".
+    unittest.TestResult.expectedFailuresNum = 0
+    unittest.TestResult.unexpectedSuccessesNum = 0
+    unittest.TestResult.__add__ = _result_add
+    unittest.TestResult.wasSuccessful = _was_successful
+    unittest.TestRunner.run = _runner_run
+    unittest._expectedfailure_patched = True

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -49,6 +49,7 @@ function ci_package_tests_setup_lib {
     $CP python-stdlib/tempfile/tempfile.py "${VIRTUAL_ENV}/lib/"
     $CP -r python-stdlib/unittest/unittest "${VIRTUAL_ENV}/lib/"
     $CP -r python-stdlib/unittest-discover/unittest "${VIRTUAL_ENV}/lib/"
+    $CP -r python-stdlib/unittest-expectedfailure/unittest "${VIRTUAL_ENV}/lib/"
     $CP unix-ffi/ffilib/ffilib.py "${VIRTUAL_ENV}/lib/"
     tree "${VIRTUAL_ENV}"
 }
@@ -104,6 +105,7 @@ function ci_package_tests_run {
         python-stdlib/time \
         python-stdlib/unittest/tests \
         python-stdlib/unittest-discover/tests \
+        python-stdlib/unittest-expectedfailure/tests \
         ; do
         (cd $path && "${MICROPYTHON}" -m unittest)
         if [ $? -ne 0 ]; then false; return; fi


### PR DESCRIPTION
### Summary

I have found that in testing MicroPython it is sometimes hard to keep track of what is correct for Python, and what is correct for MicroPython.
We want the CI to remain green - to detect and avoid regressions, and MicroPython small , and close to CPython.

In MicroPython tests that means that we sometimes need to test for not CPython behaviour.
That can be done with `.exp` files for non-unittest files.

CPython's unittest has a [`@unittest.expectedFailure` decorator](https://docs.python.org/3/library/unittest.html#skipping-tests-and-expected-failures) that can be used to differentiate between: 
- unittests that pass because they are CPython compatible
- unittests that pass because they match MicroPython's minimalism 

> [!NOTE]
> This differentiation is not magically inserted , the test code still needs to be good.

I have used this approach when running matrix tests against the different typing implementations, one example where it was clear that a 100% CPython compatibility was a non-goal.
By decorating some tests with `@unittest.expectedFailure` a much cleared report can be built on the capabilities and correctness for both MicroPython and CPython.

## Implementation details

This is implemented as an optional add-on module in order to keep the `unitlest` module a lean as possible.
The base `unittest` package is intentionally small. Its `@unittest.expectedFailure` decorator swallows a failing test 
and raises `AssertionError` on an unexpected pass, but it does not track those two cases as
separate result categories the way CPython does.

This package layers that behaviour on top of the base package without modifying
it, in the same "overlay" style as `unittest-discover`: installing it adds a
single module, `unittest/expectedfailure.py`, next to the base
`unittest/__init__.py`, and importing that module patches `unittest` at runtime.


```python
import unittest
import unittest.expectedfailure  # activates the add-on (import for its side effect)

class MyTests(unittest.TestCase):
    @unittest.expectedFailure
    def test_known_difference(self):
        self.assertEqual(unsupported(), 42)  # currently fails; that's expected

if __name__ == "__main__":
    unittest.main()
```

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this section empty then your Pull Request may be closed. -->

### Trade-offs and Alternatives

I originally wrote this as a change to `unittest`, but with the recent optimizations refactored to an add-on module , modeled after unittest-discover. 


### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.
