### PR TITLE
CONTRIBUTING: Clarify some constraints for PR submission.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,13 @@ Similar to the main repository, a configuration is provided for the
 rules and apply linting checks. See the documentation for using pre-commit
 in [the code conventions document](https://github.com/micropython/micropython/blob/master/CODECONVENTIONS.md#automatic-pre-commit-hooks)
 
+While it is possible to create simple PRs from within GitHub itself, doing so
+is not really recommended. Doing so would bypass the pre-commit checks and
+you will end up with a PR that will potentially fail one or more CI jobs due
+to a commit subject/message that does not follow the format conventions, code
+that was not formatted using `ruff` beforehand, or for simpler things like a
+typo or a spelling error.
+
 In addition to the conventions from the main repository, there are some
 specific conventions and guidelines for micropython-lib:
 


### PR DESCRIPTION
### Summary

This PR updates the contribution guidelines to clarify some points related to submitting PRs in a way that wouldn't fail basic CI checks.

The contribution guidelines assumed that all PRs would come from a properly set-up environment, which it may not always be the case for small changes being done from within GitHub itself.  However these PRs would not undergo the checks provided by the pre-commit hooks that are set up in a properly set-up environment.

These changes aim to dissuade users who read the guidelines first to submit PRs from GitHub directly but to do so from a configured environment, and if that is not the case to at least make explicit the commit message validation criteria.  There isn't much to do for code formatting rules besides saying to use "ruff" first, unfortunately.

This PR was inspired by the brief discussion in #1077 - not to single the PR out - as the guidelines weren't clear on certain points and we end up with a PR that, whilst it fixed an existing issue, cannot be merged for reasons that may not be explicit enough.

### Generative AI

I did not use generative AI tools when creating this PR.