### PR TITLE
Add simple UUID module with uuid4()

### DIFF
--- a/python-stdlib/uuid/manifest.py
+++ b/python-stdlib/uuid/manifest.py
@@ -1,0 +1,3 @@
+metadata(version="0.1.0")
+
+module("uuid.py")

--- a/python-stdlib/uuid/test_uuid.py
+++ b/python-stdlib/uuid/test_uuid.py
@@ -1,0 +1,15 @@
+import uuid
+
+u1 = uuid.uuid4()
+u2 = uuid.uuid4()
+
+assert str(u1) != str(u2), "Two uuid4 should not match"
+
+assert len(str(u1)) == len(str(u1)) == 36
+
+assert str(repr(u1)).startswith("<UUID")
+assert str(repr(u1)).endswith(">")
+
+assert len(u1.hex) == 32
+
+print("OK")

--- a/python-stdlib/uuid/test_uuid.py
+++ b/python-stdlib/uuid/test_uuid.py
@@ -15,9 +15,10 @@ class TestUUID(unittest.TestCase):
         self.assertEqual(len(str(u)), 36)
 
     def test_repr(self):
-        u = str(repr(uuid.uuid4()))
-        self.assertTrue(u.startswith("<UUID"))
-        self.assertTrue(u.endswith(">"))
+        u = repr(uuid.uuid4())
+        self.assertEqual(len(u), 44)
+        self.assertTrue(u.startswith("UUID('"))
+        self.assertTrue(u.endswith("')"))
 
     def test_constructor(self):
         u1 = uuid.uuid4()

--- a/python-stdlib/uuid/test_uuid.py
+++ b/python-stdlib/uuid/test_uuid.py
@@ -10,8 +10,9 @@ class TestUUID(unittest.TestCase):
 
     def test_len(self):
         u = uuid.uuid4()
-        self.assertEqual(len(str(u)), 36)
+        self.assertEqual(len(u.bytes), 16)
         self.assertEqual(len(u.hex), 32)
+        self.assertEqual(len(str(u)), 36)
 
     def test_repr(self):
         u = str(repr(uuid.uuid4()))

--- a/python-stdlib/uuid/test_uuid.py
+++ b/python-stdlib/uuid/test_uuid.py
@@ -1,15 +1,28 @@
+import unittest
 import uuid
 
-u1 = uuid.uuid4()
-u2 = uuid.uuid4()
 
-assert str(u1) != str(u2), "Two uuid4 should not match"
+class TestUUID(unittest.TestCase):
+    def test_unique(self):
+        n = 10
+        us = set(uuid.uuid4().bytes for _ in range(n))
+        self.assertEqual(len(us), n)
 
-assert len(str(u1)) == len(str(u1)) == 36
+    def test_len(self):
+        u = uuid.uuid4()
+        self.assertEqual(len(str(u)), 36)
+        self.assertEqual(len(u.hex), 32)
 
-assert str(repr(u1)).startswith("<UUID")
-assert str(repr(u1)).endswith(">")
+    def test_repr(self):
+        u = str(repr(uuid.uuid4()))
+        self.assertTrue(u.startswith("<UUID"))
+        self.assertTrue(u.endswith(">"))
 
-assert len(u1.hex) == 32
+    def test_constructor(self):
+        u1 = uuid.uuid4()
+        u2 = uuid.UUID(bytes.fromhex(u1.hex))
+        self.assertEqual(u1.hex, u2.hex)
 
-print("OK")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python-stdlib/uuid/uuid.py
+++ b/python-stdlib/uuid/uuid.py
@@ -1,0 +1,28 @@
+import os
+import ubinascii
+
+
+class UUID:
+    def __init__(self, bytes):
+        if len(bytes) != 16:
+            raise ValueError('bytes arg must be 16 bytes long')
+        self._bytes = bytes
+
+    @property
+    def hex(self):
+        return ubinascii.hexlify(self._bytes).decode()
+
+    def __str__(self):
+        h = self.hex
+        return '-'.join((h[0:8], h[8:12], h[12:16], h[16:20], h[20:32]))
+
+    def __repr__(self):
+        return "<UUID: %s>" % str(self)
+
+
+def uuid4():
+    """Generates a random UUID compliant to RFC 4122 pg.14"""
+    random = bytearray(os.urandom(16))
+    random[6] = (random[6] & 0x0F) | 0x40
+    random[8] = (random[8] & 0x3F) | 0x80
+    return UUID(bytes=random)

--- a/python-stdlib/uuid/uuid.py
+++ b/python-stdlib/uuid/uuid.py
@@ -16,7 +16,7 @@ class UUID:
         return "-".join((h[0:8], h[8:12], h[12:16], h[16:20], h[20:32]))
 
     def __repr__(self):
-        return "<UUID: %s>" % str(self)
+        return "UUID('{}')".format(self)
 
 
 def uuid4():

--- a/python-stdlib/uuid/uuid.py
+++ b/python-stdlib/uuid/uuid.py
@@ -1,20 +1,19 @@
 import os
-import ubinascii
 
 
 class UUID:
     def __init__(self, bytes):
         if len(bytes) != 16:
-            raise ValueError('bytes arg must be 16 bytes long')
+            raise ValueError("bytes arg must be 16 bytes long")
         self._bytes = bytes
 
     @property
     def hex(self):
-        return ubinascii.hexlify(self._bytes).decode()
+        return self._bytes.hex()
 
     def __str__(self):
         h = self.hex
-        return '-'.join((h[0:8], h[8:12], h[12:16], h[16:20], h[20:32]))
+        return "-".join((h[0:8], h[8:12], h[12:16], h[16:20], h[20:32]))
 
     def __repr__(self):
         return "<UUID: %s>" % str(self)

--- a/python-stdlib/uuid/uuid.py
+++ b/python-stdlib/uuid/uuid.py
@@ -5,11 +5,11 @@ class UUID:
     def __init__(self, bytes):
         if len(bytes) != 16:
             raise ValueError("bytes arg must be 16 bytes long")
-        self._bytes = bytes
+        self.bytes = bytes
 
     @property
     def hex(self):
-        return self._bytes.hex()
+        return self.bytes.hex()
 
     def __str__(self):
         h = self.hex
@@ -24,4 +24,4 @@ def uuid4():
     random = bytearray(os.urandom(16))
     random[6] = (random[6] & 0x0F) | 0x40
     random[8] = (random[8] & 0x3F) | 0x80
-    return UUID(bytes=random)
+    return UUID(bytes(random))

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -106,6 +106,7 @@ function ci_package_tests_run {
         python-stdlib/time \
         python-stdlib/unittest/tests \
         python-stdlib/unittest-discover/tests \
+        python-stdlib/uuid \
         ; do
         (cd $path && "${MICROPYTHON}" -m unittest)
         if [ $? -ne 0 ]; then false; return; fi


### PR DESCRIPTION
### Summary

This PR pulls in @andrewleech 's minimal UUID implementation from https://github.com/pfalcon/pycopy-lib (originally submitted here as #312, #313 long ago).

Then I made a few updates to it:
- add `manifest.py`
- convert test to use `unittest` and run it under CI
- use `bytes.hex()` instead of `binascii.hexlify().decode()`
- run `ruff format`

### Testing

Test added that runs under CI.

### Trade-offs and Alternatives

This adds a minimal implementation of `uuid.uuid4()` which is arguably the more important of the uuidX functions.

Alternatives:
- #282 is similarly small, but didn't mask the correct bits for the UUID value
- #504 brings in the full CPython module which is large and probably we don't need all that functionality

### Generative AI

Not used.