### PR TITLE
usb-device-cdc: optmise CDCInterface constructor

### DIFF
--- a/micropython/usb/examples/device/cdc_repl_example.py
+++ b/micropython/usb/examples/device/cdc_repl_example.py
@@ -25,8 +25,8 @@ import time
 import usb.device
 from usb.device.cdc import CDCInterface
 
-cdc = CDCInterface()
-cdc.init(timeout=0)  # zero timeout makes this non-blocking, suitable for os.dupterm()
+# Zero timeout makes this non-blocking, suitable for os.dupterm().
+cdc = CDCInterface(timeout=0)
 
 # pass builtin_driver=True so that we get the built-in USB-CDC alongside,
 # if it's available.

--- a/micropython/usb/usb-device-cdc/manifest.py
+++ b/micropython/usb/usb-device-cdc/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="0.1.3")
+metadata(version="0.1.4")
 require("usb-device")
 package("usb")

--- a/micropython/usb/usb-device-cdc/usb/device/cdc.py
+++ b/micropython/usb/usb-device-cdc/usb/device/cdc.py
@@ -107,18 +107,14 @@ class CDCInterface(io.IOBase, Interface):
         self.line_coding_cb = None
 
         self._line_state = 0  # DTR & RTS
-        # Set a default line coding of 115200/8N1
-        self._line_coding = bytearray(b"\x00\xc2\x01\x00\x00\x00\x08")
-
-        self._wb = ()  # Optional write Buffer (IN endpoint), set by CDC.init()
-        self._rb = ()  # Optional read Buffer (OUT endpoint), set by CDC.init()
-        self._timeout = 1000  # set from CDC.init() as well
+        self._line_coding = bytearray(7)  # Will be populated by .init()
 
         # one control interface endpoint, two data interface endpoints
         self.ep_c_in = self.ep_d_in = self.ep_d_out = None
 
         self._c_itf = None  # Number of control interface, data interface is one more
 
+        # The _timeout, _wb and _rb attributes will be set by this call to .init().
         self.init(**kwargs)
 
     def init(


### PR DESCRIPTION
### Summary

Don't set `CDCInterface` instance attributes that will just be reset by `self.init()`.

Saves 30 bytes of bytecode.

Also simplify the associated example.

### Testing

Built, and tested the example on RPI_PICO.  It still works.

### Trade-offs and Alternatives

This makes it less clear what exactly are the instance attributes, because their initialisation is done in `.init()`, not the constructor.  The added comment tries to work around that.

### Generative AI

Not used.