### PR TITLE
mip: Better support for natmod installations

### DIFF
--- a/micropython/mip/mip/__init__.py
+++ b/micropython/mip/mip/__init__.py
@@ -24,6 +24,34 @@ _HOSTS = {
 
 _ALLOWED_MIP_URL_PREFIXES = const(("http://", "https://", "codeberg:", "github:", "gitlab:"))
 
+# NB: Must be in the correct order wrt sys.implementation._mpy
+MPY_ARCHITECTURES = [
+    None,
+    "x86",
+    "x64",
+    "armv6",
+    "armv6m",
+    "armv7m",
+    "armv7em",
+    "armv7emsp",
+    "armv7emdp",
+    "xtensa",
+    "xtensawin",
+    "rv32imc",
+    "rv64imc",
+]
+
+
+def _get_mpy_arch_version():
+    sys_mpy = sys.implementation._mpy
+    sys_arch = (sys_mpy >> 10) & 0x0F
+
+    mpy_major = sys_mpy & 0xFF
+    mpy_minor = sys_mpy >> 8 & 3
+    mpy_arch = MPY_ARCHITECTURES[sys_arch]
+
+    return mpy_arch, mpy_major, mpy_minor
+
 
 # This implements os.makedirs(os.dirname(path))
 def _ensure_path_exists(path):
@@ -74,6 +102,12 @@ def _check_exists(path, short_hash):
 
 
 def _rewrite_url(url, branch=None):
+    # substitute markers for native modules (if present)
+    mpy_arch, mpy_major, mpy_minor = _get_mpy_arch_version()
+    mpy_version = f"{mpy_major}.{mpy_minor}"
+    url = url.replace("{MPY_VERSION}", mpy_version)
+    url = url.replace("{MPY_ARCH}", mpy_arch)
+
     for provider, url_format in _HOSTS.items():
         if not url.startswith(provider):
             continue


### PR DESCRIPTION
### Summary

It is possible to install .mpy files using mip, including those that have native code (native modules). But currently one must specify the exact file URL for such files - which for native modules means knowing the correct ABI version and architecture version - something users rarely know offhand. This makes it difficult to document how to install a natmod, and makes it difficult to have scripts that automatically install the correct version.

This change allows using a single URL to specify a native module package - regardless of the ABI/architecture. mip will then lookup the correct hardware architecture and MicroPython ABI version, and substitute this into the URL before doing the download/install.

The use of variables that are substituted allows some flexibility wrt different locations/layouts for .mpy files. This is useful because there is currently no standard (to my knowledge) for how to lay out. So this should be immediately useful to existing distributions of mpy natmods.

Note: for `import foo` to work the .mpy file, the file itself must be named `foo.mpy`. Thus the MPY_ARCH and MPY_VERSION markers can only meaningfully be in directory part of a path.

### Testing

Tested on RP2 port using a Pico W. Example code follows. 

Installs from https://github.com/emlearn/emlearn-micropython project - should work on any hardware supported by emlearn-micropython. By removing the network part, should also work on Unix port.

```python
import network
import mip
import time

# NOTE: must fill this in
WIFI_SSID = None
WIFI_PASSWORD = None

print("Connecting to WiFi", end="")
sta_if = network.WLAN(network.STA_IF)
sta_if.active(True)
sta_if.connect(WIFI_SSID, WIFI_PASSWORD)
while not sta_if.isconnected():
  print(".", end="")
  time.sleep(0.1)
print(" Connected!")

u = 'https://emlearn.github.io/emlearn-micropython/builds/latest/{MPY_ARCH}_{MPY_VERSION}/emlearn_iir.mpy'
mip.install(u)

import emlearn_iir
print(dir(emlearn_iir))
```

### Trade-offs and Alternatives

Small increase in code size of the mip package.
It adds nothing to the core runtime of MicroPython. An alternative implementation that would do versioned/architecture handling at import time would likely increase size of the code.

### Generative AI

I did not use generative AI tools when creating this PR.