### PR TITLE
requests: Fix protocol-relative redirect Locations.

### DIFF
--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -207,7 +207,9 @@ def request(
             elif l.startswith(b"Location:") and not 200 <= status <= 299:
                 if status in [301, 302, 303, 307, 308]:
                     redirect = str(l[10:-2], "utf-8")
-                    if redirect.startswith("/"):
+                    if redirect.startswith("//"):
+                        redirect = proto + redirect
+                    elif redirect.startswith("/"):
                         redirect = proto + "//" + host + ":" + str(port) + redirect
                 else:
                     raise NotImplementedError("Redirect %d not yet supported" % status)

--- a/python-ecosys/requests/test_requests.py
+++ b/python-ecosys/requests/test_requests.py
@@ -311,6 +311,24 @@ def test_redirect_relative():
     socket.socket = lambda *a, **k: Socket()
 
 
+def test_redirect_protocol_relative():
+    server = iter(
+        [
+            b"HTTP/1.1 301 OK\r\nLocation: //example.com/index\r\n\r\n",
+            SERVER_RESPONSE_200_OK,
+        ]
+    )
+    socket.socket = lambda *a, **k: Socket(next(server))
+
+    response = requests.request("GET", "http://example.com")
+
+    assert response.raw._write_buffer.getvalue() == (
+        b"GET /index HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n"
+    ), format_message(response)
+
+    socket.socket = lambda *a, **k: Socket()
+
+
 test_simple_get()
 test_get_auth()
 test_get_custom_header()
@@ -331,3 +349,4 @@ test_raw_incremental_content_length()
 test_raw_readinto_content_length()
 test_redirect_absolute()
 test_redirect_relative()
+test_redirect_protocol_relative()


### PR DESCRIPTION
### Summary

Follow-up to #931 / commit 8b7a02e, which already rewrites absolute-path
`Location` values such as `/index` onto the current host.

That rewrite used `startswith("/")`, which also matches protocol-relative
URLs (`//host/path`) and incorrectly prepends the original host. Handle
`//` first by prefixing only the current scheme so the redirect host is
preserved.

Path-relative Locations without a leading `/` (for example `index`) are
still not resolved.

Fixes #931.

### Testing

- Unix port: `micropython python-ecosys/requests/test_requests.py` passes,
  including a new `test_redirect_protocol_relative` case.
- `__init__.mpy` size with `mpy-cross` vs `upstream/master`: 2987 -> 3028
  bytes (+41).

### Trade-offs and Alternatives

- Only protocol-relative (`//`) Locations are added here. Absolute-path
  (`/`) support remains as in 8b7a02e.
- Path-relative Locations without `/` stay unsupported to keep the diff
  and bytecode small.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.