### PR TITLE
umqtt.simple: Encode subscribe Remaining Length as VBI.

### DIFF
--- a/micropython/umqtt.simple/manifest.py
+++ b/micropython/umqtt.simple/manifest.py
@@ -1,4 +1,4 @@
-metadata(description="Lightweight MQTT client for MicroPython.", version="1.7.1")
+metadata(description="Lightweight MQTT client for MicroPython.", version="1.8.0")
 
 # Originally written by Paul Sokolovsky.
 

--- a/micropython/umqtt.simple/test_umqtt_simple.py
+++ b/micropython/umqtt.simple/test_umqtt_simple.py
@@ -1,0 +1,76 @@
+import io
+import sys
+
+
+class Socket:
+    def __init__(self, read_data=b""):
+        self._write_buffer = io.BytesIO()
+        self._read_buffer = io.BytesIO(read_data)
+
+    def write(self, buf, length=None):
+        if length is None:
+            length = len(buf)
+        self._write_buffer.write(buf[:length])
+
+    def read(self, n):
+        return self._read_buffer.read(n)
+
+    def setblocking(self, blocking):
+        pass
+
+    def close(self):
+        pass
+
+
+sys.path.insert(0, "micropython/umqtt.simple")
+# ruff: noqa: E402
+from umqtt.simple import MQTTClient
+
+
+def make_client(read_data):
+    c = MQTTClient(b"cid", "127.0.0.1")
+    c.sock = Socket(read_data)
+    c.set_callback(lambda topic, msg: None)
+    return c
+
+
+def test_subscribe_short_topic():
+    # Remaining Length = 5 + 4 = 9 -> single VBI byte 0x09, pid=1
+    c = make_client(b"\x90\x03\x00\x01\x00")
+    c.subscribe(b"abcd", qos=0)
+    out = c.sock._write_buffer.getvalue()
+    assert out[:2] == b"\x82\x09", out
+    assert out[2:4] == b"\x00\x01", out
+    assert out[4:6] == b"\x00\x04", out
+    assert out[6:10] == b"abcd", out
+    assert out[10:11] == b"\x00", out
+
+
+def test_subscribe_long_topic():
+    # Remaining Length = 5 + 123 = 128 -> VBI 0x80 0x01
+    topic = b"a" * 123
+    c = make_client(b"\x90\x03\x00\x01\x00")
+    c.subscribe(topic, qos=0)
+    out = c.sock._write_buffer.getvalue()
+    assert out[:3] == b"\x82\x80\x01", out
+    assert out[3:5] == b"\x00\x01", out
+    assert out[5:7] == b"\x00\x7b", out
+    assert out[7:130] == topic, out
+    assert out[130:131] == b"\x00", out
+
+
+def test_unsubscribe_long_topic():
+    # Remaining Length = 4 + 123 = 127 -> still one VBI byte; use 124 for 128
+    topic = b"a" * 124
+    c = make_client(b"\xb0\x02\x00\x01")
+    c.unsubscribe(topic)
+    out = c.sock._write_buffer.getvalue()
+    assert out[:3] == b"\xa2\x80\x01", out
+    assert out[3:5] == b"\x00\x01", out
+    assert out[5:7] == b"\x00\x7c", out
+    assert out[7:131] == topic, out
+
+
+test_subscribe_short_topic()
+test_subscribe_long_topic()
+test_unsubscribe_long_topic()

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -158,17 +158,17 @@ class MQTTClient:
         elif qos == 2:
             assert 0
 
-    def _send_subunsub(self, topic, typ, ack_op, ack_n, qos=None):
+    def _send_subunsub(self, topic, typ, ack_op, ack_n, qos=0):
         pkt = bytearray(4)
         pkt[0] = typ
         self.pid += 1
         pid = self.pid
-        i = _encode_len(pkt, 4 + len(topic) + (qos != None))
+        i = _encode_len(pkt, 4 + len(topic) + (ack_n > 3))
         self.sock.write(pkt, i + 1)
         struct.pack_into("!H", pkt, 0, pid)
         self.sock.write(pkt, 2)
         self._send_str(topic)
-        if qos != None:
+        if ack_n > 3:
             self.sock.write(bytes((qos,)))
         while 1:
             op = self.wait_msg()

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -7,6 +7,16 @@ class MQTTException(Exception):
     pass
 
 
+def _encode_len(pkt, sz):
+    i = 1
+    while sz > 0x7F:
+        pkt[i] = (sz & 0x7F) | 0x80
+        sz >>= 7
+        i += 1
+    pkt[i] = sz
+    return i
+
+
 class MQTTClient:
     def __init__(
         self,
@@ -93,12 +103,7 @@ class MQTTClient:
             msg[6] |= 0x4 | (self.lw_qos & 0x1) << 3 | (self.lw_qos & 0x2) << 3
             msg[6] |= self.lw_retain << 5
 
-        i = 1
-        while sz > 0x7F:
-            premsg[i] = (sz & 0x7F) | 0x80
-            sz >>= 7
-            i += 1
-        premsg[i] = sz
+        i = _encode_len(premsg, sz)
 
         self.sock.write(premsg, i + 2)
         self.sock.write(msg)
@@ -130,12 +135,7 @@ class MQTTClient:
         if qos > 0:
             sz += 2
         assert sz < 2097152
-        i = 1
-        while sz > 0x7F:
-            pkt[i] = (sz & 0x7F) | 0x80
-            sz >>= 7
-            i += 1
-        pkt[i] = sz
+        i = _encode_len(pkt, sz)
         # print(hex(len(pkt)), hexlify(pkt, ":"))
         self.sock.write(pkt, i + 1)
         self._send_str(topic)
@@ -163,26 +163,19 @@ class MQTTClient:
         pkt[0] = typ
         self.pid += 1
         pid = self.pid
-        sz = 4 + len(topic) + (0 if qos is None else 1)
-        assert sz < 2097152
-        i = 1
-        while sz > 0x7F:
-            pkt[i] = (sz & 0x7F) | 0x80
-            sz >>= 7
-            i += 1
-        pkt[i] = sz
+        i = _encode_len(pkt, 4 + len(topic) + (qos != None))
         self.sock.write(pkt, i + 1)
         struct.pack_into("!H", pkt, 0, pid)
         self.sock.write(pkt, 2)
         self._send_str(topic)
-        if qos is not None:
-            self.sock.write(qos.to_bytes(1, "little"))
+        if qos != None:
+            self.sock.write(bytes((qos,)))
         while 1:
             op = self.wait_msg()
             if op == ack_op:
                 resp = self.sock.read(ack_n)
-                assert resp[1] == pid >> 8 and resp[2] == (pid & 0xFF)
-                if ack_n == 4 and resp[3] == 0x80:
+                assert (resp[1] << 8 | resp[2]) == pid
+                if ack_n > 3 and resp[3] == 0x80:
                     raise MQTTException(resp[3])
                 return
 

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -162,9 +162,19 @@ class MQTTClient:
         assert self.cb is not None, "Subscribe callback is not set"
         pkt = bytearray(b"\x82\0\0\0")
         self.pid += 1
-        struct.pack_into("!BH", pkt, 1, 2 + 2 + len(topic) + 1, self.pid)
+        pid = self.pid
+        sz = 2 + 2 + len(topic) + 1
+        assert sz < 2097152
+        i = 1
+        while sz > 0x7F:
+            pkt[i] = (sz & 0x7F) | 0x80
+            sz >>= 7
+            i += 1
+        pkt[i] = sz
         # print(hex(len(pkt)), hexlify(pkt, ":"))
-        self.sock.write(pkt)
+        self.sock.write(pkt, i + 1)
+        struct.pack_into("!H", pkt, 0, pid)
+        self.sock.write(pkt, 2)
         self._send_str(topic)
         self.sock.write(qos.to_bytes(1, "little"))
         while 1:
@@ -172,7 +182,7 @@ class MQTTClient:
             if op == 0x90:
                 resp = self.sock.read(4)
                 # print(resp)
-                assert resp[1] == pkt[2] and resp[2] == pkt[3]
+                assert resp[1] == pid >> 8 and resp[2] == (pid & 0xFF)
                 if resp[3] == 0x80:
                     raise MQTTException(resp[3])
                 return
@@ -180,14 +190,24 @@ class MQTTClient:
     def unsubscribe(self, topic):
         pkt = bytearray(b"\xa2\0\0\0")
         self.pid += 1
-        struct.pack_into("!BH", pkt, 1, 2 + 2 + len(topic), self.pid)
-        self.sock.write(pkt)
+        pid = self.pid
+        sz = 2 + 2 + len(topic)
+        assert sz < 2097152
+        i = 1
+        while sz > 0x7F:
+            pkt[i] = (sz & 0x7F) | 0x80
+            sz >>= 7
+            i += 1
+        pkt[i] = sz
+        self.sock.write(pkt, i + 1)
+        struct.pack_into("!H", pkt, 0, pid)
+        self.sock.write(pkt, 2)
         self._send_str(topic)
         while 1:
             op = self.wait_msg()
             if op == 0xB0:
                 resp = self.sock.read(3)
-                assert resp[1] == pkt[2] and resp[2] == pkt[3]
+                assert resp[1] == pid >> 8 and resp[2] == (pid & 0xFF)
                 return
 
     # Wait for a single incoming MQTT message and process it.

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -158,12 +158,12 @@ class MQTTClient:
         elif qos == 2:
             assert 0
 
-    def subscribe(self, topic, qos=0):
-        assert self.cb is not None, "Subscribe callback is not set"
-        pkt = bytearray(b"\x82\0\0\0")
+    def _send_subunsub(self, topic, typ, ack_op, ack_n, qos=None):
+        pkt = bytearray(4)
+        pkt[0] = typ
         self.pid += 1
         pid = self.pid
-        sz = 2 + 2 + len(topic) + 1
+        sz = 4 + len(topic) + (0 if qos is None else 1)
         assert sz < 2097152
         i = 1
         while sz > 0x7F:
@@ -171,44 +171,27 @@ class MQTTClient:
             sz >>= 7
             i += 1
         pkt[i] = sz
-        # print(hex(len(pkt)), hexlify(pkt, ":"))
         self.sock.write(pkt, i + 1)
         struct.pack_into("!H", pkt, 0, pid)
         self.sock.write(pkt, 2)
         self._send_str(topic)
-        self.sock.write(qos.to_bytes(1, "little"))
+        if qos is not None:
+            self.sock.write(qos.to_bytes(1, "little"))
         while 1:
             op = self.wait_msg()
-            if op == 0x90:
-                resp = self.sock.read(4)
-                # print(resp)
+            if op == ack_op:
+                resp = self.sock.read(ack_n)
                 assert resp[1] == pid >> 8 and resp[2] == (pid & 0xFF)
-                if resp[3] == 0x80:
+                if ack_n == 4 and resp[3] == 0x80:
                     raise MQTTException(resp[3])
                 return
 
+    def subscribe(self, topic, qos=0):
+        assert self.cb is not None, "Subscribe callback is not set"
+        self._send_subunsub(topic, 0x82, 0x90, 4, qos)
+
     def unsubscribe(self, topic):
-        pkt = bytearray(b"\xa2\0\0\0")
-        self.pid += 1
-        pid = self.pid
-        sz = 2 + 2 + len(topic)
-        assert sz < 2097152
-        i = 1
-        while sz > 0x7F:
-            pkt[i] = (sz & 0x7F) | 0x80
-            sz >>= 7
-            i += 1
-        pkt[i] = sz
-        self.sock.write(pkt, i + 1)
-        struct.pack_into("!H", pkt, 0, pid)
-        self.sock.write(pkt, 2)
-        self._send_str(topic)
-        while 1:
-            op = self.wait_msg()
-            if op == 0xB0:
-                resp = self.sock.read(3)
-                assert resp[1] == pid >> 8 and resp[2] == (pid & 0xFF)
-                return
+        self._send_subunsub(topic, 0xA2, 0xB0, 3)
 
     # Wait for a single incoming MQTT message and process it.
     # Subscribed messages are delivered to a callback previously

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -57,6 +57,7 @@ function ci_package_tests_run {
     export MICROPYPATH
     for test in \
         micropython/drivers/storage/sdcard/sdtest.py \
+        micropython/umqtt.simple/test_umqtt_simple.py \
         micropython/xmltok/test_xmltok.py \
         python-ecosys/requests/test_requests.py \
         python-stdlib/argparse/test_argparse.py \


### PR DESCRIPTION
### Summary

Fixes #969. `subscribe` (and `unsubscribe`) packed Remaining Length with
`struct.pack_into("!BH", ...)`, so values above 127 overflow a single byte
and long topics fail on the wire.

MQTT 3.1.1 section 2.2.3 requires a Variable Byte Integer. This PR encodes
Remaining Length that way for subscribe/unsubscribe, sharing a small
`_encode_len` helper with `connect` and `publish`.

### Testing

- Unix port: `micropython micropython/umqtt.simple/test_umqtt_simple.py`
  (mock socket, no broker):
  - short topic (single-byte Remaining Length)
  - subscribe with topic length 123 (Remaining Length 128 -> `82 80 01`)
  - unsubscribe with topic length 124 (Remaining Length 128 -> `a2 80 01`)
- `simple.mpy` via `mpy-cross` vs `upstream/master`: 2512 -> 2515 bytes (+3).

### Trade-offs and Alternatives

- Subscribe and unsubscribe share `_send_subunsub`; Remaining Length encoding
  is factored into `_encode_len` and reused by connect/publish to keep `.mpy`
  size close to master.
- `unsubscribe` is included because it had the same one-byte Remaining Length
  bug.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.