### PR TITLE
aiohttp: Match response header names case-insensitively.

### DIFF
--- a/python-ecosys/aiohttp/aiohttp/__init__.py
+++ b/python-ecosys/aiohttp/aiohttp/__init__.py
@@ -125,10 +125,11 @@ class ClientSession:
                 if not line or line == b"\r\n":
                     break
                 _headers.append(line)
-                if line.startswith(b"Transfer-Encoding:"):
+                lowerl = line.lower()
+                if lowerl.startswith(b"transfer-encoding:"):
                     if b"chunked" in line:
                         chunked = True
-                elif line.startswith(b"Location:"):
+                elif lowerl.startswith(b"location:"):
                     url = line.rstrip().split(None, 1)[1].decode()
 
             if 301 <= status <= 303:

--- a/python-ecosys/aiohttp/manifest.py
+++ b/python-ecosys/aiohttp/manifest.py
@@ -1,6 +1,6 @@
 metadata(
     description="HTTP client module for MicroPython asyncio module",
-    version="0.0.7",
+    version="0.0.8",
     pypi="aiohttp",
 )
 


### PR DESCRIPTION
### Summary

Fixes #1126. Response header field names are case-insensitive (RFC 9110
Sec. 5.1), but `ClientSession._request` matched `Transfer-Encoding` and
`Location` with fixed capitalization via `startswith`. Servers that send
`transfer-encoding:` or `location:` would skip chunked detection or
redirects.

Match those names with `line.lower().startswith(...)`, same idea as the
sketch on the issue and prior art in #523 (for old `urequests`, superseded
after the rename to `requests`). The `Location` value is still taken from
the original line so URL case is preserved.

### Testing

- `mpy-cross` on `aiohttp/__init__.py` (compiled as `__init__.py`):
  - master: 3787 bytes
  - this PR: 3796 bytes (+9)
- No automated aiohttp package test in CI yet; change is two comparisons in
  the header parse loop.

### Trade-offs and Alternatives

- aiohttp-only. The same wire-parse pattern exists in `requests` and can be
  a small follow-up; left out here to keep the diff minimal and avoid
  overlapping the open chunked-response work.
- Outgoing request header dict case-insensitivity (e.g. a `_Headers`
  helper) is a larger change and out of scope for this issue.

### Generative AI

I used generative AI tools when creating this PR, but a human has checked the
code and is responsible for the code and the description above.