### PR TITLE
requests: Match response header names case-insensitively.

### DIFF
--- a/python-ecosys/requests/manifest.py
+++ b/python-ecosys/requests/manifest.py
@@ -1,3 +1,3 @@
-metadata(version="1.1.0", pypi="requests")
+metadata(version="1.1.1", pypi="requests")
 
 package("requests")

--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -223,10 +223,11 @@ def request(
             if not l or l == b"\r\n":
                 break
             # print(l)
-            if l.startswith(b"Transfer-Encoding:"):
+            lowerl = l.lower()
+            if lowerl.startswith(b"transfer-encoding:"):
                 if b"chunked" in l:
                     chunked = True
-            elif l.startswith(b"Location:") and not 200 <= status <= 299:
+            elif lowerl.startswith(b"location:") and not 200 <= status <= 299:
                 if status in [301, 302, 303, 307, 308]:
                     redirect = str(l[10:-2], "utf-8")
                     if redirect.startswith("/"):

--- a/python-ecosys/requests/requests/__init__.py
+++ b/python-ecosys/requests/requests/__init__.py
@@ -241,7 +241,7 @@ def request(
                 k, v = l.split(":", 1)
                 v = v.strip()
                 resp_d[k] = v
-                if k.lower() == "content-length":
+                if lowerl.startswith(b"content-length:"):
                     remaining = int(v)
             else:
                 parse_headers(l, resp_d)

--- a/python-ecosys/requests/test_requests.py
+++ b/python-ecosys/requests/test_requests.py
@@ -359,6 +359,16 @@ def test_redirect_lowercase_location():
     socket.socket = lambda *a, **k: Socket()
 
 
+def test_content_length_lowercase_header():
+    socket.socket = lambda *a, **k: Socket(
+        read_data=b"HTTP/1.1 200 OK\r\ncontent-length: 5\r\n\r\nhello"
+    )
+    response = requests.request("GET", "http://example.com")
+    assert response.content == b"hello"
+    assert response.headers["content-length"] == "5"
+    socket.socket = lambda *a, **k: Socket()
+
+
 test_simple_get()
 test_get_query_anchor()
 test_get_auth()
@@ -383,3 +393,4 @@ test_redirect_absolute()
 test_redirect_relative()
 test_chunked_response_lowercase_header()
 test_redirect_lowercase_location()
+test_content_length_lowercase_header()

--- a/python-ecosys/requests/test_requests.py
+++ b/python-ecosys/requests/test_requests.py
@@ -332,6 +332,33 @@ def test_redirect_relative():
     socket.socket = lambda *a, **k: Socket()
 
 
+def test_chunked_response_lowercase_header():
+    socket.socket = lambda *a, **k: Socket(
+        read_data=b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
+    )
+    response = requests.request("GET", "http://example.com")
+    assert response.content == b"hello world"
+    socket.socket = lambda *a, **k: Socket()
+
+
+def test_redirect_lowercase_location():
+    server = iter(
+        [
+            b"HTTP/1.1 301 OK\r\nlocation: /index\r\n\r\n",
+            SERVER_RESPONSE_200_OK,
+        ]
+    )
+    socket.socket = lambda *a, **k: Socket(next(server))
+
+    response = requests.request("GET", "http://example.com")
+
+    assert response.raw._write_buffer.getvalue() == (
+        b"GET /index HTTP/1.1\r\nConnection: close\r\nHost: example.com\r\n\r\n"
+    ), format_message(response)
+
+    socket.socket = lambda *a, **k: Socket()
+
+
 test_simple_get()
 test_get_query_anchor()
 test_get_auth()
@@ -354,3 +381,5 @@ test_raw_incremental_content_length()
 test_raw_readinto_content_length()
 test_redirect_absolute()
 test_redirect_relative()
+test_chunked_response_lowercase_header()
+test_redirect_lowercase_location()


### PR DESCRIPTION
## Summary
- Fixes #523 (supersedes the 2022 `urequests` PR; the module is now `requests`).
- Match `Transfer-Encoding` and `Location` on the wire case-insensitively (RFC 9110 Sec. 5.1), same `lowerl = l.lower()` once-per-line pattern as #523 and #1146.
- Covers the `requests` half of #1126. #1146 stays aiohttp-only.

## Test plan
- Unix `test_requests.py`, including lowercase `transfer-encoding` chunked and `location` redirect cases.
- `__init__.mpy` (`mpy-cross`, compiled as `__init__.py`): master 3160, this PR 3169 (+9).