### PR TITLE
umqtt.simple: Reject short CONNACK in connect.

### DIFF
--- a/micropython/umqtt.simple/test_umqtt_simple.py
+++ b/micropython/umqtt.simple/test_umqtt_simple.py
@@ -15,6 +15,12 @@ class Socket:
     def read(self, n):
         return self._read_buffer.read(n)
 
+    def settimeout(self, timeout):
+        pass
+
+    def connect(self, addr):
+        pass
+
     def setblocking(self, blocking):
         pass
 
@@ -24,7 +30,8 @@ class Socket:
 
 sys.path.insert(0, "micropython/umqtt.simple")
 # ruff: noqa: E402
-from umqtt.simple import MQTTClient
+from umqtt.simple import MQTTClient, MQTTException
+import umqtt.simple as umqtt_simple
 
 
 def make_client(read_data):
@@ -71,6 +78,69 @@ def test_unsubscribe_long_topic():
     assert out[7:131] == topic, out
 
 
+class FakeSocketMod:
+    def __init__(self, sock):
+        self._sock = sock
+
+    def socket(self, *a, **k):
+        return self._sock
+
+    def getaddrinfo(self, *a, **k):
+        return [(None, None, None, None, ("127.0.0.1", 1883))]
+
+
+def _patch_mqtt_socket(sock):
+    orig = umqtt_simple.socket
+    umqtt_simple.socket = FakeSocketMod(sock)
+    return orig
+
+
+def _restore_mqtt_socket(orig):
+    umqtt_simple.socket = orig
+
+
+def test_connect_ok():
+    sock = Socket(b"\x20\x02\x00\x00")
+    orig = _patch_mqtt_socket(sock)
+    try:
+        c = MQTTClient(b"cid", "127.0.0.1")
+        assert c.connect() == 0
+    finally:
+        _restore_mqtt_socket(orig)
+
+
+def test_connect_short_connack_raises():
+    sock = Socket(b"")
+    orig = _patch_mqtt_socket(sock)
+    try:
+        c = MQTTClient(b"cid", "127.0.0.1")
+        try:
+            c.connect()
+            assert False, "expected MQTTException"
+        except MQTTException as e:
+            assert e.args == (-1,)
+    finally:
+        _restore_mqtt_socket(orig)
+
+
+def test_connect_none_connack_raises():
+    sock = Socket()
+    sock.read = lambda n: None
+    orig = _patch_mqtt_socket(sock)
+    try:
+        c = MQTTClient(b"cid", "127.0.0.1")
+        try:
+            c.connect()
+            assert False, "expected MQTTException"
+        except MQTTException as e:
+            assert e.args == (-1,)
+    finally:
+        _restore_mqtt_socket(orig)
+
+
 test_subscribe_short_topic()
 test_subscribe_long_topic()
 test_unsubscribe_long_topic()
+test_connect_ok()
+test_connect_short_connack_raises()
+test_connect_none_connack_raises()

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -116,11 +116,12 @@ class MQTTClient:
             self._send_str(self.user)
             self._send_str(self.pswd)
         resp = self.sock.read(4)
-        if not resp or len(resp) < 4 or resp[0] != 0x20 or resp[1] != 0x02:
-            raise MQTTException(-1)
-        if resp[3] != 0:
-            raise MQTTException(resp[3])
-        return resp[2] & 1
+        r = -1
+        if resp and len(resp) > 3 and resp[0] == 0x20 and resp[1] == 0x02:
+            r = resp[3]
+            if not r:
+                return resp[2] & 1
+        raise MQTTException(r)
 
     def disconnect(self):
         self.sock.write(b"\xe0\0")

--- a/micropython/umqtt.simple/umqtt/simple.py
+++ b/micropython/umqtt.simple/umqtt/simple.py
@@ -116,7 +116,8 @@ class MQTTClient:
             self._send_str(self.user)
             self._send_str(self.pswd)
         resp = self.sock.read(4)
-        assert resp[0] == 0x20 and resp[1] == 0x02
+        if not resp or len(resp) < 4 or resp[0] != 0x20 or resp[1] != 0x02:
+            raise MQTTException(-1)
         if resp[3] != 0:
             raise MQTTException(resp[3])
         return resp[2] & 1


### PR DESCRIPTION
## Summary
- Fixes #1056: `connect()` used to `assert` on `resp[0]` / `resp[1]` after `sock.read(4)`. A short or missing CONNACK (`b""` or `None` on timeout) raised `IndexError` instead of an MQTT error.
- Raise `MQTTException(-1)` when CONNACK is missing, short, or not a 4-byte CONNACK. Broker return codes 1-5 are unchanged (`MQTTException(resp[3])`).

## Test plan
- Unix `micropython/umqtt.simple/test_umqtt_simple.py`: valid CONNACK, empty read, and `None` read.