### PR TITLE
python-stdlib: Fix invalid backslash escapes in fnmatch and string.

### DIFF
--- a/python-stdlib/fnmatch/fnmatch.py
+++ b/python-stdlib/fnmatch/fnmatch.py
@@ -131,7 +131,7 @@ def translate(pat):
                 # Using ure rather than re-pcre
                 res = res + re_escape(c)
     # Original patterns is undefined, see http://bugs.python.org/issue21464
-    return "(?ms)" + res + "\Z"
+    return "(?ms)" + res + "\\Z"
 
 
 def re_escape(pattern):

--- a/python-stdlib/fnmatch/test_fnmatch.py
+++ b/python-stdlib/fnmatch/test_fnmatch.py
@@ -65,14 +65,14 @@ class FnmatchTestCase(unittest.TestCase):
 
 class TranslateTestCase(unittest.TestCase):
     def test_translate(self):
-        self.assertEqual(translate("*"), "(?ms).*\Z")
-        self.assertEqual(translate("?"), "(?ms).\Z")
-        self.assertEqual(translate("a?b*"), "(?ms)a.b.*\Z")
-        self.assertEqual(translate("[abc]"), "(?ms)[abc]\Z")
-        self.assertEqual(translate("[]]"), "(?ms)[]]\Z")
-        self.assertEqual(translate("[!x]"), "(?ms)[^x]\Z")
-        self.assertEqual(translate("[^x]"), "(?ms)[\\^x]\Z")
-        self.assertEqual(translate("[x"), "(?ms)\\[x\Z")
+        self.assertEqual(translate("*"), "(?ms).*\\Z")
+        self.assertEqual(translate("?"), "(?ms).\\Z")
+        self.assertEqual(translate("a?b*"), "(?ms)a.b.*\\Z")
+        self.assertEqual(translate("[abc]"), "(?ms)[abc]\\Z")
+        self.assertEqual(translate("[]]"), "(?ms)[]]\\Z")
+        self.assertEqual(translate("[!x]"), "(?ms)[^x]\\Z")
+        self.assertEqual(translate("[^x]"), "(?ms)[\\^x]\\Z")
+        self.assertEqual(translate("[x"), "(?ms)\\[x\\Z")
 
 
 class FilterTestCase(unittest.TestCase):

--- a/python-stdlib/string/string/__init__.py
+++ b/python-stdlib/string/string/__init__.py
@@ -6,7 +6,7 @@ ascii_letters = ascii_lowercase + ascii_uppercase
 digits = "0123456789"
 hexdigits = digits + "abcdef" + "ABCDEF"
 octdigits = "01234567"
-punctuation = """!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"""
+punctuation = """!"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"""
 printable = digits + ascii_letters + punctuation + whitespace
 
 


### PR DESCRIPTION
## Summary
- Fixes #1143: `"\Z"` in `fnmatch.translate` and `\]` in `string.punctuation` are unknown string escapes (linters/stubgens reject them).
- Write `"\\Z"` and `[\\]` instead. Runtime values are unchanged.

## Test plan
- `python-stdlib/fnmatch` unittest (`test_translate` included)
- `python-stdlib/string/test_translate.py`