### PR TITLE
ntptime: Reject short NTP replies.

### DIFF
--- a/micropython/net/ntptime/manifest.py
+++ b/micropython/net/ntptime/manifest.py
@@ -1,3 +1,3 @@
-metadata(description="NTP client.", version="0.2.0")
+metadata(description="NTP client.", version="0.2.1")
 
 module("ntptime.py", opt=3)

--- a/micropython/net/ntptime/ntptime.py
+++ b/micropython/net/ntptime/ntptime.py
@@ -19,6 +19,8 @@ def time():
         msg = s.recv(48)
     finally:
         s.close()
+    if len(msg) < 48:
+        raise OSError(-1)
     val = struct.unpack("!I", msg[40:44])[0]
 
     # 2024-01-01 00:00:00 converted to an NTP timestamp

--- a/micropython/net/ntptime/test_ntptime.py
+++ b/micropython/net/ntptime/test_ntptime.py
@@ -1,0 +1,75 @@
+import struct
+import sys
+
+
+class UDPSock:
+    def __init__(self, reply):
+        self._reply = reply
+
+    def settimeout(self, timeout):
+        pass
+
+    def sendto(self, data, addr):
+        pass
+
+    def recv(self, n):
+        return self._reply
+
+    def close(self):
+        pass
+
+
+class FakeSocketMod:
+    AF_INET = 2
+    SOCK_DGRAM = 2
+
+    def __init__(self, reply):
+        self._reply = reply
+
+    def getaddrinfo(self, host, port):
+        return [(None, None, None, None, ("1.2.3.4", port))]
+
+    def socket(self, *a, **k):
+        return UDPSock(self._reply)
+
+
+sys.path.insert(0, "micropython/net/ntptime")
+# ruff: noqa: E402
+import ntptime
+
+
+def ntp_msg(ts=3913056000):
+    msg = bytearray(48)
+    struct.pack_into("!I", msg, 40, ts)
+    return bytes(msg)
+
+
+def _patch(reply):
+    orig = ntptime.socket
+    ntptime.socket = FakeSocketMod(reply)
+    return orig
+
+
+def test_time_ok():
+    orig = _patch(ntp_msg())
+    try:
+        t = ntptime.time()
+        assert isinstance(t, int)
+    finally:
+        ntptime.socket = orig
+
+
+def test_time_short_raises():
+    orig = _patch(b"short")
+    try:
+        try:
+            ntptime.time()
+            assert False, "expected OSError"
+        except OSError as e:
+            assert e.args == (-1,)
+    finally:
+        ntptime.socket = orig
+
+
+test_time_ok()
+test_time_short_raises()

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -58,6 +58,7 @@ function ci_package_tests_run {
     for test in \
         micropython/drivers/storage/sdcard/sdtest.py \
         micropython/umqtt.simple/test_umqtt_simple.py \
+        micropython/net/ntptime/test_ntptime.py \
         micropython/xmltok/test_xmltok.py \
         python-ecosys/requests/test_requests.py \
         python-stdlib/argparse/test_argparse.py \


### PR DESCRIPTION
## Summary
- Fixes #1136: `time()` used `recv(48)` and unpacked `msg[40:44]` with no length check. A short datagram could raise a confusing error or yield a bad timestamp.
- Require `len(msg) >= 48`, otherwise `OSError(-1)` (same family as a socket timeout). Still uses `recv(48)`.
- Do not compare the UDP source address to the send target (can differ in complex network topologies).
- Kiss of Death / zero timestamps are unchanged (see #604).

## Test plan
- `micropython/net/ntptime/test_ntptime.py` (valid 48-byte reply, short payload), wired into package tests CI.